### PR TITLE
Enforce mandatory credential-audit chaining and fix threat model sort

### DIFF
--- a/core/api_server.py
+++ b/core/api_server.py
@@ -136,7 +136,11 @@ async def _get_svgs(candidate: Path, content: str) -> dict[str, str]:
 async def api_get_threat_model(file: str = "") -> JSONResponse:
     files: list[str] = []
     if _THREAT_MODEL_DIR.exists():
-        files = sorted([p.name for p in _THREAT_MODEL_DIR.glob("*.md")], reverse=True)
+        # Sort by modification time (most recent first) so the active scan's
+        # threat model appears as the default selection.
+        md_paths = list(_THREAT_MODEL_DIR.glob("*.md"))
+        md_paths.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        files = [p.name for p in md_paths]
 
     if not file and files:
         file = files[0]


### PR DESCRIPTION
## Summary

- Update skills submodule to include mandatory credential-audit chaining and platform-aware username expansion ([skills#6](https://github.com/0x0pointer/skills/pull/6))
- Fix threat model dropdown to sort by modification time instead of alphabetically

## Context

During a thorough pentest of 136.111.37.122 (SSH-only on port 2222), ad-hoc hydra brute-force missed the valid credential `anne:princess` because:

1. The pentester workflow skipped the `/credential-audit` checkpoint and ran hydra directly
2. The username list had only ~17 generic names — common first names like `anne` weren't included
3. The password list (`top-20`) was too small — `princess` (a top-25 password) wasn't in it

The skills submodule update ([details in skills#6](https://github.com/0x0pointer/skills/pull/6)) makes the credential-audit checkpoint mandatory and adds platform-aware username expansion with ~200 common first names and the top-1000 password list.

## Changes

### Skills submodule update (0ea7bb4 → 8cb5006)
- **pentester.md**: Auth service checkpoint is now a hard gate (MANDATORY). Three new rules ban ad-hoc brute-force. Username source checklist added.
- **credential-audit/SKILL.md**: Platform-aware username expansion (~200 first names + OS/cloud accounts), top-1000 password list, empty password checks, username-derived mutations, mandatory cross-service spray.

### `core/api_server.py`
- Threat model file dropdown now sorted by `st_mtime` (most recent first) instead of alphabetically, so the active scan's threat model is the default selection.

## Test plan

- [ ] Verify skills submodule points to correct commit with credential-audit changes
- [ ] Open dashboard, create two threat models — confirm the most recent appears first in dropdown
- [ ] Run `/pentester` against SSH target — verify it chains into `/credential-audit` at step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)