### PR TITLE
add /cloud-security skill with Kali cloud tools and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ You have 30 skills at your disposal. Use the right one based on the task:
 | Skill | Trigger | What it does |
 |-------|---------|--------------|
 | `/container-k8s-security` | User asks to assess containers or Kubernetes | Container escape, K8s RBAC, pod security, exposed API servers, etcd access, image vulnerabilities |
+| `/cloud-security` | User asks to assess cloud infrastructure (AWS/Azure/GCP) | IAM privilege escalation, public storage, serverless attack surface, database exposure, logging gaps, compliance mapping |
 
 ### Analysis & Reporting Skills
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -262,6 +262,41 @@ Comprehensive container and Kubernetes security assessment covering OWASP Kubern
 
 ---
 
+## `/cloud-security`
+
+Cloud security posture assessment for AWS, Azure, and GCP — IAM privilege escalation, public storage, serverless attack surface, database exposure, logging gaps, and compliance mapping.
+
+```
+/cloud-security my-aws-account provider=aws mode=authenticated depth=standard
+/cloud-security 10.0.0.5 provider=aws mode=external depth=quick
+/cloud-security my-project provider=gcp mode=authenticated depth=thorough
+```
+
+**What it does:**
+
+1. **External recon** — public bucket/blob scanning, IMDS probing (AWS/Azure/GCP metadata endpoints), nuclei cloud templates
+2. **IAM privilege escalation** — systematic testing of iam:PassRole+Lambda, iam:CreatePolicyVersion, iam:AttachUserPolicy, sts:AssumeRole chains, cross-account trust abuse (10 escalation vectors with severity matrix)
+3. **Storage deep-dive** — bucket policies, ACLs, versioning, encryption, cross-account access, pre-signed URL abuse, object-level ACL enumeration
+4. **Network security** — security groups/NSGs open to 0.0.0.0/0, critical port exposure
+5. **Serverless attack surface** — Lambda/Functions env var secrets, layer inspection, API Gateway auth bypass, Step Functions state injection
+6. **Database exposure** — RDS/DynamoDB/ElastiCache/DocumentDB/OpenSearch public access, encryption, snapshot sharing
+7. **Logging validation** — CloudTrail, VPC Flow Logs, GuardDuty, Security Hub, Config
+8. **Container registry security** — ECR/ACR/Artifact Registry scanning, cross-account pull, immutability
+9. **Cloud-specific attacks** — resource policy confusion, SSM/Secrets Manager enumeration, managed identity abuse, service account key audit
+10. **Automated scanning** — Prowler + ScoutSuite
+11. **Attack path mapping** — chains from public exposure to sensitive data access
+12. **Compliance mapping** — SOC 2, PCI DSS 4.0, HIPAA, CIS benchmarks
+
+**Depth presets:**
+
+| Depth | Tools | Cost | Time | Calls |
+|---|---|---|---|---|
+| `quick` | Public bucket scan + IMDS probe + nuclei cloud templates | $0.10 | 15 min | 10 |
+| `standard` | quick + IAM escalation + storage deep-dive + security groups | $0.50 | 45 min | 25 |
+| `thorough` | standard + Prowler/ScoutSuite + serverless + databases + logging + container registry + attack paths + compliance | $2.00 | 120 min | 60 |
+
+---
+
 ## `/ssl-tls-audit`
 
 Deep TLS/SSL configuration audit with compliance mapping to PCI DSS 4.0, NIST SP 800-52r2, and FedRAMP.
@@ -373,6 +408,7 @@ During a pentest (/pentester)
   ├── /credential-audit       weak auth found — brute-force, spraying, default credentials
   ├── /post-exploit           initial access obtained — privesc, credential harvesting, pivot
   ├── /container-k8s-security if Docker/K8s infrastructure is discovered
+  ├── /cloud-security         if AWS/Azure/GCP infrastructure is discovered
   └── /ai-redteam             if an LLM endpoint is discovered
 
 After initial access (/post-exploit)

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -79,6 +79,10 @@ mkdir -p "$HOME/.claude/skills/container-k8s-security"
 cp "$REPO_DIR/skills/container-k8s-security/SKILL.md" "$HOME/.claude/skills/container-k8s-security/SKILL.md"
 ok "/container-k8s-security skill installed"
 
+mkdir -p "$HOME/.claude/skills/cloud-security"
+cp "$REPO_DIR/skills/cloud-security/SKILL.md" "$HOME/.claude/skills/cloud-security/SKILL.md"
+ok "/cloud-security skill installed"
+
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""
 echo "AI testing tools (FuzzyAI + PyRIT) use LLM APIs for attacks and scoring."
@@ -177,5 +181,6 @@ echo "    /analyze-cve lodash 4.17.20 CVE-...      — CVE exploitability analys
 echo "    /threat-model                             — PASTA threat model"
 echo "    /aikido-triage findings.csv /path/to/app — triage Aikido CSV + HTML report"
 echo "    /ai-redteam https://ai-app.com/api/chat   — OWASP LLM Top 10 red-team assessment"
+echo "    /cloud-security my-aws-account provider=aws — cloud security posture assessment"
 echo "    /gh-export                               — export findings as GitHub issue blocks"
 echo ""

--- a/installers/uninstall.sh
+++ b/installers/uninstall.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # ── Remove security analysis skills ──────────────────────────────────────────
-for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security"; do
+for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/cloud-security"; do
     if [ -d "$skill_dir" ]; then
         rm -rf "$skill_dir"
         ok "Removed $(basename "$skill_dir") skill"

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -131,6 +131,27 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
     && chmod +x /usr/local/bin/dive \
     && rm /tmp/dive.tar.gz
 
+# Layer 12: cloud security — AWS CLI, Azure CLI, GCP CLI, Prowler, ScoutSuite
+# AWS CLI (via pip — kali apt awscli is often outdated)
+RUN pip3 install --no-cache-dir awscli --break-system-packages || true
+
+# Azure CLI
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl apt-transport-https lsb-release gnupg \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends azure-cli \
+    && rm -rf /var/lib/apt/lists/* || true
+
+# GCP CLI
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && apt-get update && apt-get install -y --no-install-recommends google-cloud-cli \
+    && rm -rf /var/lib/apt/lists/* || true
+
+# Prowler (AWS/Azure/GCP security auditor) + ScoutSuite (multi-cloud auditor)
+RUN pip3 install --no-cache-dir prowler scoutsuite --break-system-packages || true
+
 # Decompress rockyou wordlist (needed by hydra, john, etc.)
 RUN gzip -d /usr/share/wordlists/rockyou.txt.gz 2>/dev/null || true
 


### PR DESCRIPTION
- New skill: cloud security posture assessment for AWS, Azure, GCP covering IAM escalation, public storage, serverless, databases, logging gaps, and compliance mapping (SOC 2, PCI DSS, HIPAA, CIS)
- Kali Dockerfile: add AWS CLI, Azure CLI, GCP CLI, Prowler, ScoutSuite
- CLAUDE.md: add to Domain-Specific Skills table
- docs/skills.md: add documentation entry and chaining diagram
- install.sh/uninstall.sh: add cloud-security skill lifecycle
- pentester.md: add chaining rule for cloud infrastructure discovery