### PR TITLE
feat: add /ad-assessment skill for Active Directory security audits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ You have 30 skills at your disposal. Use the right one based on the task:
 |-------|---------|--------------|
 | `/container-k8s-security` | User asks to assess containers or Kubernetes | Container escape, K8s RBAC, pod security, exposed API servers, etcd access, image vulnerabilities |
 | `/cloud-security` | User asks to assess cloud infrastructure (AWS/Azure/GCP) | IAM privilege escalation, public storage, serverless attack surface, database exposure, logging gaps, compliance mapping |
+| `/ad-assessment` | User asks to audit Active Directory | Domain enumeration, ADCS (ESC1-ESC8), delegation abuse, ACL analysis, GPO security, BloodHound attack paths, trust exploitation |
 
 ### Analysis & Reporting Skills
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -364,6 +364,41 @@ Internal network assessment — assumes attacker has physical or VPN access to t
 | `standard` | quick + top-1000 ports + SMB/SNMP/NFS enum + broadcast protocols | $0.50 | 45 min | 25 |
 | `thorough` | standard + full port scan + segmentation testing + router/switch audit | $2.00 | 120 min | 60 |
 
+## `/ad-assessment`
+
+Active Directory security audit using the MITRE ATT&CK framework — full domain enumeration, ADCS attacks (ESC1-ESC8), delegation abuse, ACL analysis, GPO security, BloodHound attack paths, and forest trust exploitation.
+
+```
+/ad-assessment 10.0.0.1 domain=CORP.LOCAL user=auditor pass=P@ssw0rd depth=standard
+/ad-assessment dc01.corp.local domain=CORP.LOCAL depth=thorough
+/ad-assessment 192.168.1.10 depth=quick
+```
+
+**What it does:**
+
+1. **Domain enumeration** — functional level, password policy, privileged groups, Machine Account Quota, Protected Users
+2. **Kerberos attacks** — Kerberoasting (SPN enumeration + hash cracking), AS-REP Roasting
+3. **Service account security** — SPN accounts with old passwords, gMSA detection, DONT_EXPIRE_PASSWORD
+4. **ADCS assessment** — ESC1 through ESC8 (SAN abuse, enrollment agent, template ACL, CA flags, NTLM relay to HTTP enrollment)
+5. **Delegation analysis** — unconstrained, constrained (S4U2Proxy), RBCD
+6. **Fine-grained password policies** — FGPP precedence, weak policies on service accounts
+7. **LAPS deployment** — coverage gaps, v1 vs v2, unauthorized read access
+8. **GPO security** — GPP passwords, writable GPOs, security-critical settings (logon scripts, scheduled tasks, restricted groups)
+9. **ACL analysis** — dangerous permissions (DCSync, WriteDACL, GenericAll on AdminSDHolder), GUID-decoded rights
+10. **BloodHound collection** — shortest path to DA, Kerberoastable with DA path, unconstrained delegation
+11. **Forest trust analysis** — SID filtering, selective authentication, trust key extraction
+12. **Attack path prioritization** — P0 (immediate DA) through P3 (defense gaps)
+
+**Depth presets:**
+
+| Depth | Tools | Cost | Time | Calls |
+|---|---|---|---|---|
+| `quick` | Domain enum + password policy + privileged groups + Kerberoasting + AS-REP | $0.10 | 15 min | 10 |
+| `standard` | quick + ADCS (ESC1-ESC8) + delegation + GPO + ACL + FGPP + LAPS + service accounts | $0.50 | 45 min | 25 |
+| `thorough` | standard + BloodHound + forest trust analysis + attack path prioritization | $2.00 | 120 min | 60 |
+
+---
+
 ## `/post-exploit`
 
 Post-exploitation workflow — privilege escalation, credential harvesting, persistence assessment, and pivot preparation. Uses LinPEAS/WinPEAS as primary enumeration with dynamic GTFOBins cross-referencing.
@@ -409,10 +444,12 @@ During a pentest (/pentester)
   ├── /post-exploit           initial access obtained — privesc, credential harvesting, pivot
   ├── /container-k8s-security if Docker/K8s infrastructure is discovered
   ├── /cloud-security         if AWS/Azure/GCP infrastructure is discovered
+  ├── /ad-assessment          if Active Directory domain is discovered
   └── /ai-redteam             if an LLM endpoint is discovered
 
 After initial access (/post-exploit)
   ├── /lateral-movement       credentials + pivot opportunities — pass-the-hash, Kerberoasting
+  ├── /ad-assessment          domain environment — ADCS, delegation, ACLs, trust analysis
   └── /credential-audit       harvested hashes — crack and test credentials
 
 During a codebase scan

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -83,6 +83,10 @@ mkdir -p "$HOME/.claude/skills/cloud-security"
 cp "$REPO_DIR/skills/cloud-security/SKILL.md" "$HOME/.claude/skills/cloud-security/SKILL.md"
 ok "/cloud-security skill installed"
 
+mkdir -p "$HOME/.claude/skills/ad-assessment"
+cp "$REPO_DIR/skills/ad-assessment/SKILL.md" "$HOME/.claude/skills/ad-assessment/SKILL.md"
+ok "/ad-assessment skill installed"
+
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""
 echo "AI testing tools (FuzzyAI + PyRIT) use LLM APIs for attacks and scoring."
@@ -182,5 +186,6 @@ echo "    /threat-model                             — PASTA threat model"
 echo "    /aikido-triage findings.csv /path/to/app — triage Aikido CSV + HTML report"
 echo "    /ai-redteam https://ai-app.com/api/chat   — OWASP LLM Top 10 red-team assessment"
 echo "    /cloud-security my-aws-account provider=aws — cloud security posture assessment"
+echo "    /ad-assessment 10.0.0.1 domain=CORP.LOCAL  — Active Directory security audit"
 echo "    /gh-export                               — export findings as GitHub issue blocks"
 echo ""

--- a/installers/uninstall.sh
+++ b/installers/uninstall.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # ── Remove security analysis skills ──────────────────────────────────────────
-for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/cloud-security"; do
+for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/cloud-security" "$HOME/.claude/skills/ad-assessment"; do
     if [ -d "$skill_dir" ]; then
         rm -rf "$skill_dir"
         ok "Removed $(basename "$skill_dir") skill"

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -37,11 +37,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Layer 7: SMB / Windows / AD
 # rpcclient is bundled inside smbclient; ldapdomaindump is pip-only
+# certipy-ad — ADCS enumeration and exploitation (ESC1-ESC8)
+# bloodhound — BloodHound ingestor for AD attack path mapping
 RUN apt-get update && apt-get install -y --no-install-recommends \
     smbmap smbclient samba-common-bin impacket-scripts \
     enum4linux-ng netexec ldap-utils python3-pip \
     && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --no-cache-dir ldapdomaindump --break-system-packages
+    && pip3 install --no-cache-dir ldapdomaindump certipy-ad bloodhound --break-system-packages
 
 # Layer 8: service enumeration
 # snmpwalk is bundled in the snmp package; snmp-check not available on arm64


### PR DESCRIPTION
## Summary
- New `/ad-assessment` skill — comprehensive AD security audit using MITRE ATT&CK framework
- **Kali Dockerfile**: adds `certipy-ad` and `bloodhound` (python ingestor) to Layer 7
- **CLAUDE.md**: added to Domain-Specific Skills table
- **docs/skills.md**: full documentation entry + chaining diagram update
- **install.sh / uninstall.sh**: skill lifecycle management
- **pentester.md**: chaining rule — auto-invoked when AD domain is discovered
- **lateral-movement**: chaining rule — invoke for full AD audit after lateral movement

### Skill coverage (13 phases)
- Domain enumeration + functional level analysis
- Kerberoasting + AS-REP Roasting
- Service account security (gMSA detection, SPN analysis)
- ADCS ESC1-ESC8 (certipy-ad)
- Delegation analysis (unconstrained, constrained, RBCD)
- Fine-grained password policies
- LAPS deployment + bypass
- GPO security (GPP passwords, writable GPOs, logon scripts)
- ACL analysis with GUID decoding (DCSync, WriteDACL, GenericAll)
- BloodHound collection + attack path analysis
- Forest trust deep analysis (SID filtering, selective auth)
- Attack path prioritization (P0-P3)

## Test plan
- [ ] Run `./installers/install.sh` — verify `/ad-assessment` skill gets installed
- [ ] Run `./installers/uninstall.sh` — verify cleanup
- [ ] Rebuild Kali image: `docker build -t pentest-agent/kali-mcp ./tools/kali/`
- [ ] Verify `certipy --help` and `bloodhound-python --help` work inside Kali container
- [ ] Invoke `/ad-assessment` skill in Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)