### PR TITLE
feat: add searchsploit (Exploit-DB) to Kali image and skill workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ You have 30 skills at your disposal. Use the right one based on the task:
 |-------|---------|--------------|
 | `/container-k8s-security` | User asks to assess containers or Kubernetes | Container escape, K8s RBAC, pod security, exposed API servers, etcd access, image vulnerabilities |
 | `/metasploit` | CVE confirmed exploitable — validate with Metasploit | Exploit validation, payload generation, post-exploitation (separate Docker container) |
+| `/reverse-shell` | Exploit needs a callback — generate payload and listener | Platform-specific reverse shells (bash, python, php, powershell, msfvenom) + Kali listener setup |
 
 ### Analysis & Reporting Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ You have 30 skills at your disposal. Use the right one based on the task:
 | `/container-k8s-security` | User asks to assess containers or Kubernetes | Container escape, K8s RBAC, pod security, exposed API servers, etcd access, image vulnerabilities |
 | `/metasploit` | CVE confirmed exploitable — validate with Metasploit | Exploit validation, payload generation, post-exploitation (separate Docker container) |
 | `/reverse-shell` | Exploit needs a callback — generate payload and listener | Platform-specific reverse shells (bash, python, php, powershell, msfvenom) + Kali listener setup |
+| `/web-exploit` | Injection point or logic flaw found — deep exploitation | SQLi (blind/OOB), XSS, SSRF, parameter tampering, file upload bypass, deserialization, command injection |
 
 ### Analysis & Reporting Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Run any security scanner. `tool` selects the scanner, `target` is the URL/host/p
 | metasploit | host/IP | module=, payload=, rport=, lhost=, lport=4444 |
 
 ### `kali(command, timeout)`
-Run any command in the Kali container (auto-starts if needed). Hundreds of tools: nikto, sqlmap, gobuster, hydra, testssl, enum4linux-ng, wapiti, etc.
+Run any command in the Kali container (auto-starts if needed). Hundreds of tools: nikto, sqlmap, gobuster, hydra, testssl, enum4linux-ng, wapiti, searchsploit, etc.
 
 ### `http(action, url, method, headers, body, options)`
 Raw HTTP requests and PoC saving.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -390,6 +390,28 @@ docker build -t pentest-agent/metasploit ./tools/metasploit/
 
 ---
 
+## `/reverse-shell`
+
+Reverse shell payload generation and listener management. Generates platform-specific payloads and sets up listeners in the Kali container.
+
+```
+/reverse-shell 10.0.0.5 lhost=10.0.0.1 lport=4444 type=bash
+/reverse-shell 10.0.0.10 type=powershell encode=base64
+/reverse-shell 10.0.0.5 type=msfvenom
+```
+
+**What it does:**
+
+1. **Payload generation** — bash, python, php, perl, ruby, netcat, socat, powershell, awk, msfvenom (ELF, EXE, WAR, JSP, PHP, ASP)
+2. **Encoding** — base64, URL-encode, hex for WAF/filter bypass
+3. **Listener setup** — ncat, socat, Meterpreter multi/handler, encrypted (OpenSSL)
+4. **Shell stabilization** — python pty.spawn, script, socat TTY upgrade
+5. **Decision tree** — selects payload based on target OS and available interpreters
+
+No new tools needed — uses ncat, socat, msfvenom, openssl already in Kali.
+
+---
+
 ## Chaining skills
 
 Skills are designed to be chained automatically during an engagement:
@@ -402,6 +424,7 @@ Before a pentest
 During a pentest (/pentester)
   ├── /analyze-cve            if nuclei or semgrep finds a CVE dependency
   ├── /metasploit             if exploitable CVE confirmed — validate with Metasploit modules
+  ├── /reverse-shell          exploit needs a callback — payload generation + listener setup
   ├── /ssl-tls-audit          if TLS services are found — PCI DSS/NIST compliance audit
   ├── /network-assess         if internal network scope — segmentation, SNMP, broadcast protocols
   ├── /credential-audit       weak auth found — brute-force, spraying, default credentials

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -423,6 +423,7 @@ Before a pentest
 
 During a pentest (/pentester)
   ├── /analyze-cve            if nuclei or semgrep finds a CVE dependency
+  ├── /web-exploit            injection point or logic flaw found — deep SQLi, XSS, SSRF, parameter tampering
   ├── /metasploit             if exploitable CVE confirmed — validate with Metasploit modules
   ├── /reverse-shell          exploit needs a callback — payload generation + listener setup
   ├── /ssl-tls-audit          if TLS services are found — PCI DSS/NIST compliance audit

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -83,6 +83,10 @@ mkdir -p "$HOME/.claude/skills/metasploit"
 cp "$REPO_DIR/skills/metasploit/SKILL.md" "$HOME/.claude/skills/metasploit/SKILL.md"
 ok "/metasploit skill installed"
 
+mkdir -p "$HOME/.claude/skills/reverse-shell"
+cp "$REPO_DIR/skills/reverse-shell/SKILL.md" "$HOME/.claude/skills/reverse-shell/SKILL.md"
+ok "/reverse-shell skill installed"
+
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""
 echo "AI testing tools (FuzzyAI + PyRIT) use LLM APIs for attacks and scoring."

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -87,6 +87,10 @@ mkdir -p "$HOME/.claude/skills/reverse-shell"
 cp "$REPO_DIR/skills/reverse-shell/SKILL.md" "$HOME/.claude/skills/reverse-shell/SKILL.md"
 ok "/reverse-shell skill installed"
 
+mkdir -p "$HOME/.claude/skills/web-exploit"
+cp "$REPO_DIR/skills/web-exploit/SKILL.md" "$HOME/.claude/skills/web-exploit/SKILL.md"
+ok "/web-exploit skill installed"
+
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""
 echo "AI testing tools (FuzzyAI + PyRIT) use LLM APIs for attacks and scoring."

--- a/installers/uninstall.sh
+++ b/installers/uninstall.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # ── Remove security analysis skills ──────────────────────────────────────────
-for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/metasploit"; do
+for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/metasploit" "$HOME/.claude/skills/reverse-shell"; do
     if [ -d "$skill_dir" ]; then
         rm -rf "$skill_dir"
         ok "Removed $(basename "$skill_dir") skill"

--- a/installers/uninstall.sh
+++ b/installers/uninstall.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # ── Remove security analysis skills ──────────────────────────────────────────
-for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/metasploit" "$HOME/.claude/skills/reverse-shell"; do
+for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/metasploit" "$HOME/.claude/skills/reverse-shell" "$HOME/.claude/skills/web-exploit"; do
     if [ -d "$skill_dir" ]; then
         rm -rf "$skill_dir"
         ok "Removed $(basename "$skill_dir") skill"

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -55,10 +55,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     theharvester nfs-common lbd \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 10: network utilities + wordlists
+# Layer 10: network utilities + wordlists + document tools + RDP
 RUN apt-get update && apt-get install -y --no-install-recommends \
     socat proxychains4 curl wget \
     seclists wordlists \
+    poppler-utils freerdp3-x11 \
     && rm -rf /var/lib/apt/lists/*
 
 # ProjectDiscovery tools via apt (katana not in arm64 repo — installed via pre-built binary)

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsrecon dnsenum fierce dmitry dnstwist dnsmap whois bind9-dnsutils \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 3: web scanning + exploit-db
+# Layer 3: web scanning + exploit-db + php (for running PHP exploits)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nikto sqlmap whatweb wafw00f wapiti commix xsser davtest skipfish \
-    zaproxy exploitdb \
+    zaproxy exploitdb php-cli \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 4: web fuzzing / discovery
@@ -45,9 +45,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Layer 8: service enumeration
 # snmpwalk is bundled in the snmp package; snmp-check not available on arm64
+# default-mysql-client — MySQL/MariaDB CLI for database enumeration and credential extraction
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ssh-audit redis-tools snmp onesixtyone swaks \
     smtp-user-enum ike-scan finger rpcbind \
+    default-mysql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 9: OSINT / recon

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     socat proxychains4 curl wget \
     seclists wordlists \
-    gcc-mingw-w64 \
+    gcc-mingw-w64 unrar p7zip-full \
     poppler-utils freerdp3-x11 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsrecon dnsenum fierce dmitry dnstwist dnsmap whois bind9-dnsutils \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 3: web scanning
+# Layer 3: web scanning + exploit-db
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nikto sqlmap whatweb wafw00f wapiti commix xsser davtest skipfish \
-    zaproxy \
+    zaproxy exploitdb \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 4: web fuzzing / discovery

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     socat proxychains4 curl wget \
     seclists wordlists \
-    gcc-mingw-w64 unrar p7zip-full \
+    gcc gcc-multilib gcc-mingw-w64 unrar p7zip-full \
     poppler-utils freerdp3-x11 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -57,10 +57,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     theharvester nfs-common lbd \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 10: network utilities + wordlists + document tools + RDP
+# Layer 10: network utilities + wordlists + document tools + RDP + cross-compilation
+# gcc-mingw-w64 — cross-compile C exploits to Windows EXE/DLL from Kali
 RUN apt-get update && apt-get install -y --no-install-recommends \
     socat proxychains4 curl wget \
     seclists wordlists \
+    gcc-mingw-w64 \
     poppler-utils freerdp3-x11 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
Gap analysis of the [Pebbles proving ground lab](https://pentesting.zeyu2001.com/proving-grounds/warm-up/pebbles) revealed that `searchsploit` (Exploit-DB offline search) was missing from the Kali image, preventing quick exploit lookups by application name and version.

### Changes
- **Kali Dockerfile**: added `exploitdb` package to Layer 3
- **CLAUDE.md**: added `searchsploit` to kali tool list
- **pentester.md**: new step 8 — after version identification (httpx/whatweb/nuclei/nmap), run `searchsploit <app> <version>` to find known exploits before deep dives
- **analyze-cve/SKILL.md**: added searchsploit to Phase 1 context gathering
- **metasploit/SKILL.md**: added searchsploit as first step in module discovery (faster than MSF search, covers non-MSF exploits)

### Gap analysis context
The Pebbles lab required: nmap → gobuster → identify ZoneMinder v1.29.0 → find Exploit-DB #41239 → sqlmap SQLi → root. Without `searchsploit`, the agent couldn't look up "zoneminder 1.29" against Exploit-DB. All other steps were already covered.

## Test plan
- [ ] Rebuild Kali image: `docker build -t pentest-agent/kali-mcp ./tools/kali/`
- [ ] Verify: `kali("searchsploit zoneminder 1.29")` returns Exploit-DB results
- [ ] Verify: `kali("searchsploit --cve CVE-2021-44228")` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)