### PR TITLE
feat: add /codebase skill — ASVS 5.0 white-box source code review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ You have 30 skills at your disposal. Use the right one based on the task:
 | `/metasploit` | CVE confirmed exploitable — validate with Metasploit | Exploit validation, payload generation, post-exploitation (separate Docker container) |
 | `/reverse-shell` | Exploit needs a callback — generate payload and listener | Platform-specific reverse shells (bash, python, php, powershell, msfvenom) + Kali listener setup |
 | `/web-exploit` | Injection point or logic flaw found — deep exploitation | SQLi (blind/OOB), XSS, SSRF, parameter tampering, file upload bypass, deserialization, command injection |
+| `/codebase` | Source code available — white-box review before testing | ASVS 5.0 code review: endpoint mapping, auth architecture, dangerous patterns, IaC, source-to-sink tracing |
 
 ### Analysis & Reporting Skills
 
@@ -43,6 +44,7 @@ You have 30 skills at your disposal. Use the right one based on the task:
 ### When to chain skills during an engagement
 
 - **During a pentest** (`/pentester`): if you discover a CVE-affected dependency (e.g. via nuclei or semgrep), consider running `/analyze-cve` to trace whether it's actually exploitable in context.
+- **Before a pentest — source code available**: run `/codebase` first for ASVS 5.0 white-box review. Maps endpoints, auth, dangerous patterns from source. Makes all subsequent testing targeted.
 - **Before a pentest**: if the user provides architecture details, run `/threat-model` first to identify high-risk areas, then focus the pentest on those areas.
 - **Before a pentest**: run `/osint` for passive recon to inform the active testing scope.
 - **During a pentest — API target**: chain into `/api-security` for OWASP API Top 10 coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ You have 30 skills at your disposal. Use the right one based on the task:
 | `/reverse-shell` | Exploit needs a callback — generate payload and listener | Platform-specific reverse shells (bash, python, php, powershell, msfvenom) + Kali listener setup |
 | `/web-exploit` | Injection point or logic flaw found — deep exploitation | SQLi (blind/OOB), XSS, SSRF, parameter tampering, file upload bypass, deserialization, command injection |
 | `/codebase` | Source code available — white-box review before testing | ASVS 5.0 code review: endpoint mapping, auth architecture, dangerous patterns, IaC, source-to-sink tracing |
+| `/remediate` | After any scan — generate fixes for findings | Code patches (diff), config changes, dependency updates, IaC fixes with verification steps |
 
 ### Analysis & Reporting Skills
 
@@ -71,7 +72,8 @@ You have 30 skills at your disposal. Use the right one based on the task:
 - **For incident response**: run `/forensics` for log analysis, timeline reconstruction, and IOC extraction.
 - **For authorized social engineering**: run `/phishing-sim` with written authorization.
 - **For egress testing**: run `/c2-simulation` to identify viable C2 channels (simulated traffic only).
-- **At the end of any pentest or triage**: run `/gh-export` to format all confirmed findings as copy-pasteable GitHub issue blocks.
+- **After any scan with findings**: run `/remediate` to generate specific fixes (code patches, config changes) for every finding. Stores remediation in findings.json for dashboard and exports.
+- **At the end of any pentest or triage**: run `/gh-export` to format all confirmed findings as copy-pasteable GitHub issue blocks (now includes ## Remediation section if fixes were generated).
 
 ## Available MCP Tools
 

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -176,6 +176,18 @@ async def api_patch_finding(finding_id: str, request: Request) -> JSONResponse:
         return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
 
 
+@app.delete("/api/clear")
+async def api_clear() -> JSONResponse:
+    """Reset findings.json to empty state — clears all findings, diagrams, and session data."""
+    from core.findings import FINDINGS_FILE, _save
+    _save({
+        "meta": {"created": "", "target": ""},
+        "findings": [],
+        "diagrams": [],
+    })
+    return JSONResponse({"ok": True})
+
+
 @app.get("/api/logs")
 async def api_logs(file: str = "") -> JSONResponse:
     from core.logger import log_path, _LOG_DIR

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -165,8 +165,12 @@ async def api_patch_finding(finding_id: str, request: Request) -> JSONResponse:
     from core.findings import update_finding
     try:
         body = await request.json()
-        gh_issue = body.get("gh_issue", "")
-        updated = await update_finding(finding_id, gh_issue)
+        updated = await update_finding(
+            finding_id,
+            gh_issue=body.get("gh_issue"),
+            remediation=body.get("remediation"),
+            reproduction=body.get("reproduction"),
+        )
         return JSONResponse({"ok": updated})
     except Exception as exc:
         return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)

--- a/core/findings.py
+++ b/core/findings.py
@@ -8,9 +8,16 @@ Schema
 {
   "meta":     { "created": "<ISO>", "target": "" },
   "findings": [ { id, timestamp, title, severity, target,
-                   description, evidence, tool_used, cve } ],
+                   description, evidence, tool_used, cve,
+                   reproduction?, gh_issue?, remediation? } ],
   "diagrams": [ { id, timestamp, title, mermaid } ]
 }
+
+Optional fields set via update_finding():
+  reproduction: { type, command, expected, verified }
+  gh_issue:     "<markdown block>"
+  remediation:  { summary, fix_type, diff, before, after, file, line,
+                  language, effort, breaking_change, references, verification }
 
 Used exclusively by mcp_server.py; not a Tool registry entry.
 """
@@ -60,6 +67,7 @@ async def add_finding(
     evidence:    str,
     tool_used:   str = "",
     cve:         str = "",
+    reproduction: dict | None = None,
 ) -> dict:
     """Append a vulnerability finding. Returns the stored entry."""
     entry = {
@@ -73,6 +81,8 @@ async def add_finding(
         "tool_used":   tool_used,
         "cve":         cve,
     }
+    if reproduction:
+        entry["reproduction"] = reproduction
     async with _lock:
         data = _load()
         data["findings"].append(entry)
@@ -80,14 +90,23 @@ async def add_finding(
     return entry
 
 
-async def update_finding(finding_id: str, gh_issue: str) -> bool:
-    """Attach a GitHub issue markdown block to an existing finding by id.
-    Returns True if the finding was found and updated, False otherwise."""
+_UPDATABLE_FIELDS = {"gh_issue", "remediation", "reproduction"}
+
+
+async def update_finding(finding_id: str, **fields) -> bool:
+    """Update fields on an existing finding by id.
+
+    Accepted fields: gh_issue, remediation, reproduction.
+    Returns True if the finding was found and updated, False otherwise.
+    """
+    updates = {k: v for k, v in fields.items() if k in _UPDATABLE_FIELDS and v is not None}
+    if not updates:
+        return False
     async with _lock:
         data = _load()
         for entry in data["findings"]:
             if entry.get("id") == finding_id:
-                entry["gh_issue"] = gh_issue
+                entry.update(updates)
                 _save(data)
                 return True
     return False

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -143,9 +143,38 @@ Triage every finding in an Aikido SAST/SCA CSV export against the actual codebas
 
 ---
 
+## `/remediate`
+
+Generates specific, implementable fixes for every finding in `findings.json`. Produces code patches (unified diff), configuration changes, dependency updates, and IaC fixes — not generic advice but actual before/after code.
+
+```
+/remediate depth=thorough
+/remediate finding-id-here
+```
+
+**What it does:**
+
+1. Reads all findings from the dashboard API
+2. For each finding (critical/high first), generates a specific fix based on the vulnerability type and framework
+3. PATCHes each finding with a `remediation` object containing: summary, diff, before/after code, effort level, breaking change flag, OWASP references, and verification step
+4. Uses the finding's `reproduction` command as the regression test: "run this after the fix — it should now fail"
+
+**Dashboard integration:** Each finding with remediation shows a "Fix" button that expands to show the diff, effort level, and verification steps.
+
+**Export integration:** `/gh-export` includes a `## Remediation` section in each GitHub issue when remediation data is present.
+
+**Depth presets:**
+
+| Depth | What runs | Cost | Time | Calls |
+|---|---|---|---|---|
+| `quick` | Summary fix + effort level per finding | $0.10 | 10 min | 10 |
+| `thorough` | Full diff + before/after + references + verification per finding | $0.50 | 30 min | 30 |
+
+---
+
 ## `/gh-export`
 
-Formats all confirmed findings from `findings.json` as copy-pasteable GitHub issue blocks, following the AppSec reporting guide template. After generating each block, patches the finding in `findings.json` with the formatted text so the dashboard can surface it.
+Formats all confirmed findings from `findings.json` as copy-pasteable GitHub issue blocks, following the AppSec reporting guide template. Now includes a `## Remediation` section with code diffs and verification steps when `/remediate` has run. After generating each block, patches the finding in `findings.json` with the formatted text so the dashboard can surface it.
 
 ```
 /gh-export
@@ -582,8 +611,9 @@ For AI/LLM targets (instead of /pentester)
 
 After a pentest
   ├── /threat-model           STRIDE analysis based on discovered architecture
+  ├── /remediate              generate specific fixes for every finding
   ├── /aikido-triage          if an Aikido CSV export is available
-  └── /gh-export              format all findings as GitHub issues
+  └── /gh-export              format findings as GitHub issues (includes remediation)
 ```
 
 Claude chains these automatically based on context — you can also invoke them manually at any point.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,6 +4,38 @@ Skills are slash commands that expand into detailed instructions for Claude. The
 
 ---
 
+## `/codebase`
+
+White-box source code security review structured around OWASP ASVS 5.0 (427 verification requirements). Reads and understands application source code to build a security knowledge base that enriches all downstream skills.
+
+```
+/codebase /path/to/project depth=standard
+/codebase /path/to/project depth=thorough focus=auth
+/codebase /path/to/project depth=quick
+```
+
+**What it does:**
+
+1. **Orientation** — identify tech stack, framework, dependencies, project structure, configuration
+2. **Attack surface mapping** — extract ALL route/endpoint definitions from source code with auth/middleware annotations
+3. **Auth architecture** — map authentication mechanism, session config, authorization model, token handling (ASVS V6-V10)
+4. **Automated scanning** — semgrep SAST + trufflehog secret scanning in parallel
+5. **Dangerous pattern analysis** — injection, output encoding, deserialization, input validation, file handling, business logic (ASVS V1-V5)
+6. **Infrastructure review** — cryptography, TLS config, secret management, data protection, error handling, IaC (ASVS V11-V16)
+7. **Security profile output** — structured summary for downstream skills + ASVS coverage map
+
+**Depth presets:**
+
+| Depth | What runs | Cost | Time | Calls |
+|---|---|---|---|---|
+| `quick` | Orientation + automated scanning (semgrep + trufflehog) | $0.10 | 15 min | 10 |
+| `standard` | quick + route mapping + auth review + dangerous patterns | $0.50 | 45 min | 30 |
+| `thorough` | full ASVS-mapped review + IaC + crypto + source-to-sink tracing | $2.00 | 120 min | 60 |
+
+**Chains into:** `/threat-model` (real architecture from code), `/pentester` (targeted scanning of discovered endpoints), `/web-exploit` (source-to-sink context), `/cloud-security` (IaC verification), `/analyze-cve` (full code context for CVE tracing).
+
+---
+
 ## `/pentester`
 
 Full penetration test — recon through exploitation through reporting.
@@ -518,6 +550,7 @@ Skills are designed to be chained automatically during an engagement:
 
 ```
 Before a pentest
+  ├── /codebase               if source code available — ASVS 5.0 white-box review
   ├── /osint                  passive recon — subdomains, emails, tech stack, cloud storage
   └── /threat-model           identify high-risk areas to focus the scan
 

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -103,6 +103,10 @@ mkdir -p "$HOME/.claude/skills/web-exploit"
 cp "$REPO_DIR/skills/web-exploit/SKILL.md" "$HOME/.claude/skills/web-exploit/SKILL.md"
 ok "/web-exploit skill installed"
 
+mkdir -p "$HOME/.claude/skills/codebase"
+cp "$REPO_DIR/skills/codebase/SKILL.md" "$HOME/.claude/skills/codebase/SKILL.md"
+ok "/codebase skill installed"
+
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""
 echo "AI testing tools (FuzzyAI + PyRIT) use LLM APIs for attacks and scoring."

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -107,6 +107,10 @@ mkdir -p "$HOME/.claude/skills/codebase"
 cp "$REPO_DIR/skills/codebase/SKILL.md" "$HOME/.claude/skills/codebase/SKILL.md"
 ok "/codebase skill installed"
 
+mkdir -p "$HOME/.claude/skills/remediate"
+cp "$REPO_DIR/skills/remediate/SKILL.md" "$HOME/.claude/skills/remediate/SKILL.md"
+ok "/remediate skill installed"
+
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""
 echo "AI testing tools (FuzzyAI + PyRIT) use LLM APIs for attacks and scoring."

--- a/installers/uninstall.sh
+++ b/installers/uninstall.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # ── Remove security analysis skills ──────────────────────────────────────────
-for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/cloud-security" "$HOME/.claude/skills/ad-assessment" "$HOME/.claude/skills/email-security" "$HOME/.claude/skills/metasploit" "$HOME/.claude/skills/reverse-shell" "$HOME/.claude/skills/web-exploit" "$HOME/.claude/skills/codebase"; do
+for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/cloud-security" "$HOME/.claude/skills/ad-assessment" "$HOME/.claude/skills/email-security" "$HOME/.claude/skills/metasploit" "$HOME/.claude/skills/reverse-shell" "$HOME/.claude/skills/web-exploit" "$HOME/.claude/skills/codebase" "$HOME/.claude/skills/remediate"; do
     if [ -d "$skill_dir" ]; then
         rm -rf "$skill_dir"
         ok "Removed $(basename "$skill_dir") skill"

--- a/installers/uninstall.sh
+++ b/installers/uninstall.sh
@@ -30,7 +30,7 @@ else
 fi
 
 # ── Remove security analysis skills ──────────────────────────────────────────
-for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/cloud-security" "$HOME/.claude/skills/ad-assessment" "$HOME/.claude/skills/email-security" "$HOME/.claude/skills/metasploit" "$HOME/.claude/skills/reverse-shell" "$HOME/.claude/skills/web-exploit"; do
+for skill_dir in "$HOME/.claude/skills/analyze-cve" "$HOME/.claude/skills/threat-modeling" "$HOME/.claude/skills/aikido-triage" "$HOME/.claude/skills/gh-export" "$HOME/.claude/skills/ai-redteam" "$HOME/.claude/skills/container-k8s-security" "$HOME/.claude/skills/cloud-security" "$HOME/.claude/skills/ad-assessment" "$HOME/.claude/skills/email-security" "$HOME/.claude/skills/metasploit" "$HOME/.claude/skills/reverse-shell" "$HOME/.claude/skills/web-exploit" "$HOME/.claude/skills/codebase"; do
     if [ -d "$skill_dir" ]; then
         rm -rf "$skill_dir"
         ok "Removed $(basename "$skill_dir") skill"

--- a/mcp_server/report_tools.py
+++ b/mcp_server/report_tools.py
@@ -14,7 +14,8 @@ async def report(action: str, data: dict) -> str:
 
     finding data:
       title, severity (critical|high|medium|low|info), target,
-      description, evidence, tool_used=, cve=
+      description, evidence, tool_used=, cve=,
+      reproduction= {type: http|command|script|manual, command: "...", expected: "..."}
 
     diagram data:
       title, mermaid (valid Mermaid source)
@@ -49,6 +50,7 @@ async def _do_finding(data):
         evidence=data.get("evidence", ""),
         tool_used=data.get("tool_used", ""),
         cve=data.get("cve", ""),
+        reproduction=data.get("reproduction"),
     )
     log.finding(severity, title, target)
     return f"Finding logged: [{severity.upper()}] {title}"

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -120,6 +120,37 @@
     .copy-gh-btn:hover { color: #58a6ff; border-color: #58a6ff; }
     .copy-gh-btn.copied { color: #3fb950; border-color: #3fb950; }
 
+    .replay-btn {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      background: none; border: 1px solid #30363d; border-radius: 4px;
+      color: #d29922; padding: 0.15rem 0.45rem; font-size: 0.72rem;
+      cursor: pointer; transition: color .15s, border-color .15s; vertical-align: middle;
+      margin-left: 0.3rem; white-space: nowrap;
+    }
+    .replay-btn:hover { color: #e3b341; border-color: #e3b341; }
+    .replay-btn.copied { color: #3fb950; border-color: #3fb950; }
+
+    .fix-btn {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      background: none; border: 1px solid #30363d; border-radius: 4px;
+      color: #a371f7; padding: 0.15rem 0.45rem; font-size: 0.72rem;
+      cursor: pointer; transition: color .15s, border-color .15s; vertical-align: middle;
+      margin-left: 0.3rem; white-space: nowrap;
+    }
+    .fix-btn:hover { color: #c49bff; border-color: #c49bff; }
+
+    .remediation-detail {
+      background: #161b22; border: 1px solid #30363d; border-radius: 6px;
+      padding: 1rem; margin-top: 0.5rem; font-size: 0.82rem;
+    }
+    .remediation-detail pre { background: #0d1117; padding: 0.75rem; border-radius: 4px; overflow-x: auto; }
+    .remediation-detail .effort-badge {
+      display: inline-block; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.7rem; font-weight: 600;
+    }
+    .effort-low { background: #238636; color: #fff; }
+    .effort-medium { background: #d29922; color: #000; }
+    .effort-high { background: #da3633; color: #fff; }
+
     .empty-placeholder {
       padding: 3rem; text-align: center; color: #6e7681;
       border: 1px dashed #30363d; border-radius: 6px;
@@ -416,12 +447,20 @@
            GH Issue
          </button>`
       : '';
+    const replayBtn = f.reproduction?.command
+      ? `<button class="replay-btn" onclick="copyReplay(this,'${f.id}')" title="Copy reproduction command">&#9654; Replay</button>`
+      : '';
+    const fixBtn = f.remediation
+      ? `<button class="fix-btn" onclick="toggleFix('${f.id}')" title="Show remediation">&#128295; Fix</button>`
+      : '';
+    const fixDetail = f.remediation ? buildFixDetail(f) : '';
     return `<tr>
       <td><span class="badge badge-${f.severity}">${f.severity}</span></td>
       <td>
-        <div class="desc"><strong>${esc(f.title)}</strong>${newBadge}${ghBtn}</div>
+        <div class="desc"><strong>${esc(f.title)}</strong>${newBadge}${replayBtn}${fixBtn}${ghBtn}</div>
         <div style="margin-top:.3rem;color:#8b949e;font-size:.82rem">${esc(f.description)}</div>
         ${cve}
+        ${fixDetail}
         ${f.evidence ? `<details ${isOpen?'open':''} data-id="${f.id}">
           <summary></summary>
           <pre class="evidence">${esc(f.evidence)}</pre>
@@ -445,6 +484,42 @@
         btn.innerHTML = btn.innerHTML.replace('Copied!', 'GH Issue');
       }, 2000);
     });
+  }
+
+  // ── Replay button — copy reproduction command ──────────────────────────────
+  function copyReplay(btn, findingId) {
+    const f = (allData.findings || []).find(x => x.id === findingId);
+    if (!f?.reproduction?.command) return;
+    navigator.clipboard.writeText(f.reproduction.command).then(() => {
+      btn.classList.add('copied');
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.classList.remove('copied'); btn.innerHTML = '&#9654; Replay'; }, 2000);
+    });
+  }
+
+  // ── Fix button — toggle remediation detail ─────────────────────────────────
+  function toggleFix(findingId) {
+    const el = document.getElementById('fix-' + findingId);
+    if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
+  }
+
+  function buildFixDetail(f) {
+    const r = f.remediation;
+    if (!r) return '';
+    const effortClass = r.effort === 'low' ? 'effort-low' : r.effort === 'high' ? 'effort-high' : 'effort-medium';
+    const breaking = r.breaking_change ? '<span style="color:#da3633;margin-left:.5rem">&#9888; Breaking change</span>' : '';
+    const diffBlock = r.diff ? `<div style="margin-top:.5rem"><strong>Diff:</strong><pre>${esc(r.diff)}</pre></div>` : '';
+    const beforeAfter = (r.before && r.after) ? `
+      <div style="margin-top:.5rem"><strong>Before:</strong><pre style="color:#da3633">${esc(r.before)}</pre></div>
+      <div><strong>After:</strong><pre style="color:#3fb950">${esc(r.after)}</pre></div>` : '';
+    const refs = r.references?.length ? `<div style="margin-top:.5rem"><strong>References:</strong><ul>${r.references.map(u => '<li><a href="'+esc(u)+'" target="_blank" style="color:#58a6ff">'+esc(u)+'</a></li>').join('')}</ul></div>` : '';
+    const verify = r.verification ? `<div style="margin-top:.5rem"><strong>Verification:</strong> ${esc(r.verification)}</div>` : '';
+    const file = r.file ? `<div style="margin-top:.3rem;color:#8b949e">${esc(r.file)}${r.line ? ':'+r.line : ''} (${esc(r.language||'')})</div>` : '';
+    return `<div id="fix-${f.id}" class="remediation-detail" style="display:none">
+      <div><strong>${esc(r.summary)}</strong></div>
+      <div style="margin-top:.3rem"><span class="effort-badge ${effortClass}">${esc(r.effort||'unknown')} effort</span>${breaking}</div>
+      ${file}${diffBlock}${beforeAfter}${verify}${refs}
+    </div>`;
   }
 
   function setFilter(sev) {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -16,7 +16,14 @@
     }
 
     /* ── Header ── */
+    .header-row { display: flex; justify-content: space-between; align-items: center; }
     h1 { font-size: 1.2rem; color: #f0f6fc; margin-bottom: 0.25rem; }
+    .clear-btn {
+      background: none; border: 1px solid #30363d; border-radius: 4px;
+      color: #6e7681; padding: 0.25rem 0.7rem; font-size: 0.75rem;
+      cursor: pointer; transition: color .15s, border-color .15s;
+    }
+    .clear-btn:hover { color: #da3633; border-color: #da3633; }
 
     #status { font-size: 0.8rem; color: #6e7681; margin-bottom: 0.75rem; }
     #status .dot {
@@ -252,7 +259,10 @@
 <body>
 
 <!-- ── Header ────────────────────────────────────────────────────────────── -->
-<h1>Pentest Dashboard</h1>
+<div class="header-row">
+  <h1>Pentest Dashboard</h1>
+  <button class="clear-btn" onclick="clearFindings()" title="Clear all findings, diagrams, and session data">Clear All</button>
+</div>
 <div id="status"><span class="dot"></span>Connecting…</div>
 
 <!-- ── Session strip ─────────────────────────────────────────────────────── -->
@@ -526,6 +536,21 @@
     filter = sev;
     renderStats(allData.findings || []);
     renderFindingsTable(allData.findings || []);
+  }
+
+  // ── Clear all findings ──────────────────────────────────────────────────
+  function clearFindings() {
+    if (!confirm('Clear all findings, diagrams, and session data? This cannot be undone.')) return;
+    fetch('/api/clear', { method: 'DELETE' })
+      .then(r => r.json())
+      .then(d => {
+        if (d.ok) {
+          allData = { findings: [], diagrams: [] };
+          renderStats([]);
+          renderFindingsTable([]);
+        }
+      })
+      .catch(() => alert('Failed to clear — is the dashboard API running?'));
   }
 
   // ── Topology tab ──────────────────────────────────────────────────────────

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -184,6 +184,19 @@ def test_api_patch_finding_invalid_json():
     assert response.status_code == 400
 
 
+def test_api_clear_resets_findings(tmp_path, monkeypatch):
+    from core import findings as findings_mod
+    findings_file = tmp_path / "findings.json"
+    findings_file.write_text(json.dumps({"meta": {}, "findings": [{"id": "1"}], "diagrams": [{"id": "2"}]}))
+    monkeypatch.setattr(findings_mod, "FINDINGS_FILE", findings_file)
+    response = client.delete("/api/clear")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    data = json.loads(findings_file.read_text())
+    assert data["findings"] == []
+    assert data["diagrams"] == []
+
+
 # ── lifecycle helpers ─────────────────────────────────────────────────────────
 
 def test_read_pid_returns_none_for_missing_file(tmp_path, monkeypatch):

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -82,7 +82,7 @@ async def test_update_finding_attaches_gh_issue(findings_file):
     entry = await core.findings.add_finding(
         title="SQLi", severity="high", target="t", description="d", evidence="e"
     )
-    result = await core.findings.update_finding(entry["id"], "## GitHub Issue\nFix this.")
+    result = await core.findings.update_finding(entry["id"], gh_issue="## GitHub Issue\nFix this.")
     assert result is True
     data = json.loads(findings_file.read_text())
     assert data["findings"][0]["gh_issue"] == "## GitHub Issue\nFix this."
@@ -90,7 +90,7 @@ async def test_update_finding_attaches_gh_issue(findings_file):
 
 @pytest.mark.asyncio
 async def test_update_finding_returns_false_for_missing_id(findings_file):
-    result = await core.findings.update_finding("nonexistent-uuid", "issue")
+    result = await core.findings.update_finding("nonexistent-uuid", gh_issue="issue")
     assert result is False
 
 

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -95,6 +95,39 @@ async def test_update_finding_returns_false_for_missing_id(findings_file):
 
 
 @pytest.mark.asyncio
+async def test_add_finding_with_reproduction(findings_file):
+    repro = {"type": "http", "command": "curl http://target/?q=1' OR 1=1--", "expected": "returns all rows"}
+    entry = await core.findings.add_finding(
+        title="SQLi", severity="critical", target="t", description="d", evidence="e",
+        reproduction=repro,
+    )
+    assert entry["reproduction"] == repro
+    data = json.loads(findings_file.read_text())
+    assert data["findings"][0]["reproduction"]["command"] == repro["command"]
+
+
+@pytest.mark.asyncio
+async def test_update_finding_remediation(findings_file):
+    entry = await core.findings.add_finding(
+        title="XSS", severity="high", target="t", description="d", evidence="e"
+    )
+    remediation = {"summary": "Add output encoding", "effort": "low", "fix_type": "code_patch"}
+    result = await core.findings.update_finding(entry["id"], remediation=remediation)
+    assert result is True
+    data = json.loads(findings_file.read_text())
+    assert data["findings"][0]["remediation"]["summary"] == "Add output encoding"
+
+
+@pytest.mark.asyncio
+async def test_update_finding_no_valid_fields(findings_file):
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    result = await core.findings.update_finding(entry["id"], invalid_field="nope")
+    assert result is False
+
+
+@pytest.mark.asyncio
 async def test_load_creates_empty_structure_when_file_missing(findings_file):
     """File doesn't exist yet — _load() should return an empty valid structure."""
     assert not findings_file.exists()


### PR DESCRIPTION
## Summary
Two new skills + infrastructure changes for white-box security review and vulnerability remediation.

### `/codebase` — ASVS 5.0 White-Box Source Code Review
Reads and understands application source code to build a security knowledge base that enriches all downstream skills.

**7 phases:** orientation, attack surface mapping, auth architecture, automated scanning (semgrep + trufflehog), dangerous pattern analysis with source-to-sink tracing, IaC/crypto/config review, and security profile output.

### `/remediate` — Vulnerability Fix Generation
Generates specific, implementable fixes for every finding: code patches (unified diff), configuration changes, dependency updates, IaC fixes — with verification steps using the reproduction command as a regression test.

### Schema + Dashboard Changes
- **findings.json**: new `reproduction` and `remediation` fields on findings
- **report_finding**: accepts `reproduction` parameter
- **PATCH endpoint**: accepts `remediation` and `reproduction`
- **Dashboard**: Replay button (copy PoC command), Fix button (show diff + effort), Clear All button

### How it chains
| Direction | Skill | Value added |
|-----------|-------|-------------|
| \`/codebase\` -> \`/pentester\` | Endpoint inventory drives targeted scanning |
| \`/codebase\` -> \`/threat-model\` | Real architecture from code, not guessed |
| \`/codebase\` -> \`/web-exploit\` | Source-to-sink context for injection points |
| \`/codebase\` -> \`/cloud-security\` | IaC review before runtime testing |
| \`/codebase\` -> \`/container-k8s-security\` | K8s manifests + Dockerfiles from code review |
| \`/codebase\` -> \`/analyze-cve\` | Full code context for dependency tracing |
| \`/codebase\` -> \`/credential-audit\` | Auth mechanism + password policy from code |
| \`/codebase\` -> \`/remediate\` | Source context for generating accurate code fixes |
| \`/pentester\` -> \`/codebase\` | Auto-chains when local codebase target |
| \`/remediate\` -> \`/gh-export\` | Fixes included in GitHub issue ## Remediation section |

### Post-scan workflow
\`/pentester\` -> \`/threat-model\` -> \`/remediate\` -> \`/gh-export\`

## Test plan
- [ ] Run \`./installers/install.sh\` — verify \`/codebase\` and \`/remediate\` skills installed
- [ ] Invoke \`/codebase /path/to/project depth=quick\` — verify orientation + scanning
- [ ] Invoke \`/remediate\` after a scan — verify fixes generated and PATCHed to findings
- [ ] Dashboard: verify Replay, Fix, and Clear All buttons work
- [ ] \`/gh-export\` includes ## Remediation section when remediation data present
- [ ] Existing tests pass (update_finding keyword args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)