### PR TITLE
fix: dashboard fix-panel, ffuf rate limiting, Dockerfile ARM builds

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -441,6 +441,11 @@
     wrap.innerHTML = `<table><thead><tr>
       <th>Severity</th><th>Finding</th><th>Target</th><th>Tool</th><th>Time</th>
     </tr></thead><tbody>${filtered.map(f => rowHTML(f, openIds)).join('')}</tbody></table>`;
+    // Restore open fix panels after DOM rebuild
+    _openFixPanels.forEach(id => {
+      const el = document.getElementById('fix-' + id);
+      if (el) el.style.display = 'block';
+    });
   }
 
   function rowHTML(f, openIds) {
@@ -508,9 +513,17 @@
   }
 
   // ── Fix button — toggle remediation detail ─────────────────────────────────
+  const _openFixPanels = new Set();
   function toggleFix(findingId) {
     const el = document.getElementById('fix-' + findingId);
-    if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
+    if (!el) return;
+    if (_openFixPanels.has(findingId)) {
+      _openFixPanels.delete(findingId);
+      el.style.display = 'none';
+    } else {
+      _openFixPanels.add(findingId);
+      el.style.display = 'block';
+    }
   }
 
   function buildFixDetail(f) {

--- a/tools/ffuf.py
+++ b/tools/ffuf.py
@@ -12,7 +12,8 @@ def _build_args(
     extensions: str = "",
     flags:      str = "",
 ) -> list[str]:
-    args = ["-u", f"{url}/FUZZ", "-w", wordlist, "-of", "json", "-o", "/dev/stdout", "-s"]
+    args = ["-u", f"{url}/FUZZ", "-w", wordlist, "-of", "json", "-o", "/dev/stdout", "-s",
+            "-rate", "50"]  # 50 req/s — avoid DoS on target
     if extensions:
         args += ["-e", extensions]
     if flags:
@@ -24,7 +25,7 @@ TOOL = Tool(
     name            = "ffuf",
     image           = "ghcr.io/ffuf/ffuf",
     build_args      = _build_args,
-    default_timeout = 900,
+    default_timeout = 14400,  # 4 hours — rate-limited at 50 req/s
     risk_level      = "intrusive",
     max_output      = 8_000,   # matched paths only (JSON); tail-biased clip keeps last results
     description     = (

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -59,13 +59,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     theharvester nfs-common lbd \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 10: network utilities + wordlists + document tools + RDP + cross-compilation
+# Layer 10: network utilities + wordlists + document tools + cross-compilation
 # gcc-mingw-w64 — cross-compile C exploits to Windows EXE/DLL from Kali
 RUN apt-get update && apt-get install -y --no-install-recommends \
     socat proxychains4 curl wget \
     seclists wordlists \
-    gcc gcc-multilib gcc-mingw-w64 unrar p7zip-full \
-    poppler-utils freerdp3-x11 \
+    gcc gcc-mingw-w64 unrar p7zip-full \
+    poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional: gcc-multilib (amd64 only) + freerdp (xfreerdp for RDP)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc-multilib 2>/dev/null || true \
+    && apt-get install -y --no-install-recommends freerdp2-x11 2>/dev/null \
+    || apt-get install -y --no-install-recommends xfreerdp 2>/dev/null || true \
     && rm -rf /var/lib/apt/lists/*
 
 # ProjectDiscovery tools via apt (katana not in arm64 repo — installed via pre-built binary)

--- a/tools/metasploit/Dockerfile
+++ b/tools/metasploit/Dockerfile
@@ -1,8 +1,7 @@
 FROM metasploitframework/metasploit-framework:latest
 
-USER root  # NOSONAR — root required for apk install and msfconsole DB access; container is isolated + disposable
-
-# Metasploit image is Alpine-based — use apk
+# Install Python + Flask for the command API server
+# The msf image runs as uid 1000 — use --user flag instead of USER directive
 RUN apk add --no-cache python3 py3-pip \
     && pip3 install --no-cache-dir flask --break-system-packages
 


### PR DESCRIPTION
## Summary
- **Dashboard fix panel**: clicking Fix button now stays open across auto-refresh cycles. The 1-second DOM rebuild was resetting panel state — now tracked in a `Set` and restored after each render
- **ffuf rate limiting**: added `-rate 50` (50 req/s) default to prevent DoS on targets. Increased timeout from 15 min to 4 hours to accommodate large wordlists with extensions
- **Kali Dockerfile**: split `gcc-multilib` and `freerdp` into optional layer with `|| true` — these packages don't exist on arm64 (Apple Silicon)
- **Metasploit Dockerfile**: removed `USER root` — the Alpine-based msf image has no root entry in `/etc/passwd`, causing build failure
- **pentester.md**: removed `/gh-export` from auto-chain — it's a manual user-invoked step

## Test plan
- [ ] Open dashboard with findings that have remediation — click Fix button, wait 5+ seconds, verify panel stays open
- [ ] Run ffuf scan — verify `-rate 50` appears in Docker command, verify no timeout on moderate wordlists
- [ ] Build Kali image on arm64: `docker build -t pentest-agent/kali-mcp ./tools/kali/`
- [ ] Build Metasploit image: `docker build -t pentest-agent/metasploit ./tools/metasploit/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)