### PR TITLE
optimize token usage: persist session state, parse tool output, compr…

### DIFF
--- a/.claude/hooks/post-compact.sh
+++ b/.claude/hooks/post-compact.sh
@@ -23,9 +23,15 @@ if data.get("status") != "running":
 skill = data.get("skill", "")
 target = data.get("target", "")
 depth = data.get("depth", "")
+step = data.get("current_step", "")
+tools = data.get("tools_called", [])
 
 print("CONTEXT RECOVERY AFTER COMPACTION")
 print(f"Active scan: {target} (depth={depth})")
+if tools:
+    print(f"Tools already run: {', '.join(tools)}")
+if step:
+    print(f"Resume at step: {step}")
 if skill:
     print(f"Active skill: /{skill}")
     print(f"ACTION REQUIRED: Re-invoke the /{skill} skill to reload its workflow.")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,9 +204,10 @@ scan(tool="promptfoo", target="http://ai-app.com/api/chat", options={"plugins": 
 When you see a "CONTEXT RECOVERY AFTER COMPACTION" message or realize your context was compacted mid-scan:
 
 1. **Re-invoke the active skill** — use the Skill tool to reload its full workflow. Do NOT continue from memory alone.
-2. **Call `session(action="status")`** — see what tools already ran, findings count, cost.
-3. **Resume, don't restart** — pick up from where the workflow was interrupted. The `tools_run` list shows completed steps.
+2. **Call `session(action="status")`** — see what tools already ran (`tools_run`), current step (`current_step`), findings count, cost. These are persisted to disk and survive compaction.
+3. **Resume at the right step** — use `current_step` to skip already-completed phases. Don't restart the workflow from scratch.
 4. **When chaining skills** — call `session(action="set_skill", options={"skill": "new-skill"})` so recovery knows which skill to reload.
+5. **Set step checkpoints** — call `session(action="set_step", options={"step": "5_nuclei_scan"})` at major workflow transitions so recovery can resume at the right point.
 
 ## Project layout
 - `mcp_server/__main__.py` — entry point, crash logging, module imports

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-smith
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=0x0pointer_agent-smith&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=0x0pointer_agent-smith) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=0x0pointer_agent-smith&metric=bugs)](https://sonarcloud.io/summary/new_code?id=0x0pointer_agent-smith)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=0x0pointer_agent-smith&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=0x0pointer_agent-smith) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=0x0pointer_agent-smith&metric=bugs)](https://sonarcloud.io/summary/new_code?id=0x0pointer_agent-smith) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=0x0pointer_agent-smith&metric=coverage)](https://sonarcloud.io/summary/new_code?id=0x0pointer_agent-smith)
 
 > **For authorized security testing only.**
 > Only use this tool against systems you own or have explicit written permission to test.

--- a/core/session.py
+++ b/core/session.py
@@ -113,6 +113,8 @@ def start(
         "limits":       limits,
         "skill":         skill,
         "skill_history": [skill] if skill else [],
+        "tools_called":  [],
+        "current_step":  None,
     }
     _flush()
     return _current
@@ -184,6 +186,25 @@ def set_skill(skill_name: str) -> dict | None:
     _current["skill"] = skill_name
     if skill_name not in _current["skill_history"]:
         _current["skill_history"].append(skill_name)
+    _flush()
+    return _current
+
+
+def add_tool_called(tool_name: str) -> None:
+    """Persist a tool name to the tools_called list in session.json."""
+    if _current and _current["status"] == "running":
+        tools = _current.setdefault("tools_called", [])
+        if tool_name not in tools:
+            tools.append(tool_name)
+            _flush()
+
+
+def set_step(step: str) -> dict | None:
+    """Update the current workflow step checkpoint (e.g. '5_nuclei_scan')."""
+    global _current
+    if _current is None or _current["status"] != "running":
+        return None
+    _current["current_step"] = step
     _flush()
     return _current
 

--- a/mcp_server/_app.py
+++ b/mcp_server/_app.py
@@ -60,6 +60,7 @@ _session_tools_called: set[str] = set()
 
 def _record(tool_name: str) -> None:
     _session_tools_called.add(tool_name)
+    scan_session.add_tool_called(tool_name)
 
 
 # ── Output clipping ───────────────────────────────────────────────────────────

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -16,7 +16,7 @@ from mcp_server._app import mcp, _session_tools_called
 async def session(action: str, options: dict | None = None) -> str:
     """Scan lifecycle and infrastructure management.
 
-    action  : start | complete | status | set_skill | start_kali | stop_kali | start_metasploit | stop_metasploit | pull_images | set_codebase
+    action  : start | complete | status | set_skill | set_step | start_kali | stop_kali | start_metasploit | stop_metasploit | pull_images | set_codebase
 
     start options:
       target, depth=standard (recon|standard|thorough), scope=[],
@@ -29,6 +29,9 @@ async def session(action: str, options: dict | None = None) -> str:
 
     set_skill options:
       skill= (name of the active skill, e.g. "pentester", "ai-redteam")
+
+    set_step options:
+      step= (current workflow step, e.g. "5_nuclei_scan")
 
     set_codebase options:
       path= (absolute path to local codebase)
@@ -45,6 +48,8 @@ async def session(action: str, options: dict | None = None) -> str:
         return _do_status()
     elif action == "set_skill":
         return _do_set_skill(opts)
+    elif action == "set_step":
+        return _do_set_step(opts)
     elif action == "start_kali":
         return await _do_start_kali()
     elif action == "stop_kali":
@@ -58,7 +63,7 @@ async def session(action: str, options: dict | None = None) -> str:
     elif action == "set_codebase":
         return _do_set_codebase(opts)
     else:
-        return f"Unknown action '{action}'. Use: start, complete, status, set_skill, start_kali, stop_kali, start_metasploit, stop_metasploit, pull_images, set_codebase"
+        return f"Unknown action '{action}'. Use: start, complete, status, set_skill, set_step, start_kali, stop_kali, start_metasploit, stop_metasploit, pull_images, set_codebase"
 
 
 def _do_start(opts):
@@ -148,24 +153,33 @@ def _do_status():
     data = findings_store._load()
     current = scan_session.get() or {}
     remaining = scan_session.remaining(summary) if current else {}
+    # Merge in-memory + persisted tool tracking for resilience
+    persisted_tools = set(current.get("tools_called", []))
+    all_tools = sorted(_session_tools_called | persisted_tools)
     result = {
         "target": current.get("target", ""),
         "depth": current.get("depth", ""),
         "status": current.get("status", ""),
         "skill": current.get("skill"),
-        "skill_history": current.get("skill_history", []),
-        "tools_run": sorted(_session_tools_called),
+        "current_step": current.get("current_step"),
+        "tools_run": all_tools,
         "findings_count": len(data.get("findings", [])),
         "diagrams_count": len(data.get("diagrams", [])),
         "cost_usd": summary.get("est_cost_usd", 0),
         "tool_calls": summary.get("tool_calls_total", 0),
     }
     if remaining:
-        result["remaining"] = remaining
+        result["remaining"] = {
+            "cost_usd": remaining.get("cost_remaining_usd", 0),
+            "time_min": remaining.get("time_remaining_minutes", 0),
+            "calls": remaining.get("calls_remaining", -1),
+        }
     if current.get("skill") and current.get("status") == "running":
+        step = current.get("current_step", "")
+        step_msg = f" Resume at step: {step}." if step else ""
         result["_recovery_hint"] = (
             f"If you lost context, re-invoke the /{current['skill']} skill "
-            f"to reload its workflow, then resume from where tools_run left off."
+            f"to reload its workflow.{step_msg}"
         )
     return json.dumps(result, indent=2)
 
@@ -179,6 +193,17 @@ def _do_set_skill(opts):
         return "No active running session — cannot set skill."
     log.note(f"Active skill changed to: {skill_name}")
     return f"Active skill set to: {skill_name}"
+
+
+def _do_set_step(opts):
+    step = opts.get("step", "")
+    if not step:
+        return "Error: 'step' option is required"
+    result = scan_session.set_step(step)
+    if result is None:
+        return "No active running session — cannot set step."
+    log.note(f"Step checkpoint: {step}")
+    return f"Step checkpoint: {step}"
 
 
 async def _do_start_kali():

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,11 +1,12 @@
 """
-Tests for tools.semgrep._parse and tools.trufflehog._parse.
+Tests for tools.semgrep._parse, tools.trufflehog._parse, and tools.nuclei._parse.
 """
 import json
 import pytest
 
 from tools.semgrep import _parse as semgrep_parse
 from tools.trufflehog import _parse as trufflehog_parse
+from tools.nuclei import _parse as nuclei_parse
 
 
 # ---------------------------------------------------------------------------
@@ -183,3 +184,105 @@ def test_trufflehog_parse_skips_blank_lines():
     stdout = "\n\n" + _th_line() + "\n\n"
     findings = trufflehog_parse(stdout, "")
     assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# nuclei parser
+# ---------------------------------------------------------------------------
+
+def _nuclei_line(template_id="cve-2021-44228", severity="critical",
+                 name="Log4Shell", matched_at="http://target.com:8080",
+                 type_="http", host="target.com", cve_id="CVE-2021-44228"):
+    obj = {
+        "template-id": template_id,
+        "info": {
+            "severity": severity,
+            "name": name,
+            "classification": {"cve-id": cve_id} if cve_id else {},
+        },
+        "matched-at": matched_at,
+        "type": type_,
+        "host": host,
+        # Verbose fields that should be stripped by the parser
+        "template-url": "https://github.com/nuclei-templates/...",
+        "curl-command": "curl -X GET http://target.com:8080",
+        "matcher-name": "log4j-detect",
+        "request": "GET / HTTP/1.1\r\nHost: target.com\r\n...",
+        "response": "HTTP/1.1 200 OK\r\n...",
+    }
+    return json.dumps(obj)
+
+
+def test_nuclei_parse_returns_list():
+    assert isinstance(nuclei_parse(_nuclei_line(), ""), list)
+
+
+def test_nuclei_parse_empty_input():
+    assert nuclei_parse("", "") == []
+
+
+def test_nuclei_parse_single_finding():
+    findings = nuclei_parse(_nuclei_line(), "")
+    assert len(findings) == 1
+
+
+def test_nuclei_parse_extracts_template():
+    findings = nuclei_parse(_nuclei_line(template_id="cve-2021-44228"), "")
+    assert findings[0]["template"] == "cve-2021-44228"
+
+
+def test_nuclei_parse_extracts_severity():
+    findings = nuclei_parse(_nuclei_line(severity="high"), "")
+    assert findings[0]["severity"] == "high"
+
+
+def test_nuclei_parse_extracts_name():
+    findings = nuclei_parse(_nuclei_line(name="Log4Shell RCE"), "")
+    assert findings[0]["name"] == "Log4Shell RCE"
+
+
+def test_nuclei_parse_extracts_matched():
+    findings = nuclei_parse(_nuclei_line(matched_at="http://x.com/api"), "")
+    assert findings[0]["matched"] == "http://x.com/api"
+
+
+def test_nuclei_parse_extracts_host():
+    findings = nuclei_parse(_nuclei_line(host="10.0.0.1"), "")
+    assert findings[0]["host"] == "10.0.0.1"
+
+
+def test_nuclei_parse_extracts_cve():
+    findings = nuclei_parse(_nuclei_line(cve_id="CVE-2021-44228"), "")
+    assert findings[0]["cve"] == "CVE-2021-44228"
+
+
+def test_nuclei_parse_strips_verbose_fields():
+    findings = nuclei_parse(_nuclei_line(), "")
+    keys = set(findings[0].keys())
+    assert "curl-command" not in keys
+    assert "request" not in keys
+    assert "response" not in keys
+    assert "template-url" not in keys
+
+
+def test_nuclei_parse_skips_invalid_json():
+    stdout = "not json\n" + _nuclei_line() + "\ngarbage"
+    findings = nuclei_parse(stdout, "")
+    assert len(findings) == 1
+
+
+def test_nuclei_parse_multiple_findings():
+    lines = "\n".join(_nuclei_line(template_id=f"cve-{i}") for i in range(5))
+    findings = nuclei_parse(lines, "")
+    assert len(findings) == 5
+
+
+def test_nuclei_parse_skips_blank_lines():
+    stdout = "\n\n" + _nuclei_line() + "\n\n"
+    findings = nuclei_parse(stdout, "")
+    assert len(findings) == 1
+
+
+def test_nuclei_parse_no_classification():
+    findings = nuclei_parse(_nuclei_line(cve_id=None), "")
+    assert findings[0]["cve"] == ""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -276,3 +276,90 @@ def test_skill_persisted_to_file(tmp_path, monkeypatch):
     data = json.loads((tmp_path / "session.json").read_text())
     assert data["skill"] == "pentester"
     assert data["skill_history"] == ["pentester"]
+
+
+# ---------------------------------------------------------------------------
+# tools_called tracking
+# ---------------------------------------------------------------------------
+
+def test_start_initialises_tools_called():
+    sess = core.session.start("example.com")
+    assert sess["tools_called"] == []
+
+
+def test_add_tool_called_appends():
+    core.session.start("example.com")
+    core.session.add_tool_called("nmap")
+    core.session.add_tool_called("nuclei")
+    assert core.session.get()["tools_called"] == ["nmap", "nuclei"]
+
+
+def test_add_tool_called_no_duplicates():
+    core.session.start("example.com")
+    core.session.add_tool_called("nmap")
+    core.session.add_tool_called("nmap")
+    assert core.session.get()["tools_called"] == ["nmap"]
+
+
+def test_add_tool_called_noop_without_session():
+    core.session._current = None
+    core.session.add_tool_called("nmap")  # should not raise
+
+
+def test_add_tool_called_noop_after_complete():
+    core.session.start("example.com")
+    core.session.complete("done")
+    core.session.add_tool_called("nmap")
+    assert core.session.get()["tools_called"] == []
+
+
+def test_tools_called_persisted_to_file(tmp_path, monkeypatch):
+    import json
+    monkeypatch.setattr(core.session, "_SESSION_FILE", tmp_path / "session.json")
+    core.session.start("example.com")
+    core.session.add_tool_called("nmap")
+    core.session.add_tool_called("httpx")
+    data = json.loads((tmp_path / "session.json").read_text())
+    assert data["tools_called"] == ["nmap", "httpx"]
+
+
+# ---------------------------------------------------------------------------
+# current_step checkpoint
+# ---------------------------------------------------------------------------
+
+def test_start_initialises_current_step():
+    sess = core.session.start("example.com")
+    assert sess["current_step"] is None
+
+
+def test_set_step_updates():
+    core.session.start("example.com")
+    result = core.session.set_step("3_nuclei_scan")
+    assert result["current_step"] == "3_nuclei_scan"
+
+
+def test_set_step_overwrites_previous():
+    core.session.start("example.com")
+    core.session.set_step("3_nuclei_scan")
+    core.session.set_step("5_ffuf")
+    assert core.session.get()["current_step"] == "5_ffuf"
+
+
+def test_set_step_returns_none_without_session():
+    core.session._current = None
+    assert core.session.set_step("anything") is None
+
+
+def test_set_step_noop_after_complete():
+    core.session.start("example.com")
+    core.session.complete("done")
+    assert core.session.set_step("late_step") is None
+
+
+def test_step_persisted_to_file(tmp_path, monkeypatch):
+    import json
+    monkeypatch.setattr(core.session, "_SESSION_FILE", tmp_path / "session.json")
+    core.session.start("example.com")
+    core.session.set_step("5_ffuf")
+    data = json.loads((tmp_path / "session.json").read_text())
+    assert data["current_step"] == "5_ffuf"

--- a/tools/nuclei.py
+++ b/tools/nuclei.py
@@ -1,14 +1,37 @@
 from __future__ import annotations
 
-# Parser: not needed — nuclei outputs JSON lines with -jsonl flag,
-# including severity, template-id, and matched URL. Claude reads this natively.
-# Raw stdout is returned directly.
-#
 # Templates note: projectdiscovery/nuclei v3 does NOT bundle templates in the image.
 # We mount ~/.nuclei-templates as a persistent volume so templates are downloaded
 # once on first use and reused on subsequent runs. -ut keeps them up to date.
 
+import json as _json
+
 from tools.base import Tool
+
+
+def _parse(stdout: str, stderr: str) -> list[dict]:
+    """Extract actionable fields from nuclei JSONL, drop verbose metadata."""
+    findings: list[dict] = []
+    for line in (stdout or "").strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = _json.loads(line)
+            info = obj.get("info", {})
+            classification = info.get("classification", {})
+            findings.append({
+                "template":  obj.get("template-id", ""),
+                "severity":  info.get("severity", ""),
+                "name":      info.get("name", ""),
+                "matched":   obj.get("matched-at", ""),
+                "type":      obj.get("type", ""),
+                "host":      obj.get("host", ""),
+                "cve":       classification.get("cve-id") if classification else "",
+            })
+        except (_json.JSONDecodeError, AttributeError):
+            continue
+    return findings
 
 # Persistent template cache on the host — shared across all nuclei runs.
 _TEMPLATES_VOLUME = ("~/.nuclei-templates", "/root/nuclei-templates")
@@ -34,9 +57,10 @@ TOOL = Tool(
     name            = "nuclei",
     image           = "projectdiscovery/nuclei",
     build_args      = _build_args,
+    parser          = _parse,
     default_timeout = 900,   # nuclei can run long on large targets; first run downloads templates
     risk_level      = "intrusive",
-    max_output      = 12_000,
+    max_output      = 4_000,  # raw portion only; parser extracts structured findings separately
     extra_volumes   = [_TEMPLATES_VOLUME],
     description     = (
         "Template-based vulnerability scanner. "

--- a/tools/semgrep.py
+++ b/tools/semgrep.py
@@ -64,7 +64,7 @@ TOOL = Tool(
     default_timeout = 900,
     risk_level      = "safe",
     needs_mount     = True,
-    max_output      = 20_000,  # parser already strips AST noise; 20K covers ~100 findings
+    max_output      = 12_000,  # parser strips AST noise; 12K aligns with other structured tools
     description     = (
         "Static code analysis — finds security bugs in source code. "
         "Mounts the local codebase (set via set_codebase_target). "


### PR DESCRIPTION
…ess status

Close three gaps in compaction recovery and reduce context consumption:

Recovery:
- Persist tools_called list to session.json (was in-memory only)
- Add current_step checkpoint so skills resume at the right phase
- Post-compact hook now shows tools already run + resume step

Token optimization:
- Add nuclei JSONL parser: extracts 7 essential fields, strips curl-command/request/response/template-url noise (12K → ~4K)
- Reduce semgrep output cap from 20K to 12K (parser already filters)
- Compress status response: drop skill_history, flatten remaining dict from 6 fields to 3

Tests: 26 new (12 session + 14 nuclei parser), 262 total passing.