### PR TITLE
fix docker pull hang and add startup preflight check

### DIFF
--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -203,6 +203,48 @@ except BaseException:
     # Non-fatal — don't exit, the server may still function.
 
 
+# ── Docker image preflight check ─────────────────────────────────────────────
+# Verify all tool images exist locally before the server starts.
+# Missing images get a warning — they'll be pulled on first use, but the
+# user sees upfront which tools are ready vs. need a pull.
+
+_phase("DOCKER IMAGE PREFLIGHT CHECK")
+try:
+    from tools import REGISTRY
+    from tools.docker_runner import image_exists
+
+    async def _preflight():
+        ready, missing = [], []
+        for tool in REGISTRY.values():
+            img = tool.image
+            if await image_exists(img):
+                ready.append(img)
+            else:
+                missing.append(img)
+        return ready, missing
+
+    _ready, _missing = asyncio.run(_preflight())
+
+    for _img in _ready:
+        sys.stderr.write(f"  [OK]      {_img}\n")
+    for _img in _missing:
+        sys.stderr.write(f"  [MISSING] {_img}  — will pull on first use\n")
+    sys.stderr.flush()
+
+    if _missing:
+        _phase(
+            f"PREFLIGHT: {len(_ready)}/{len(_ready) + len(_missing)} images ready. "
+            f"Run 'docker pull' or session(action='pull_images') for: "
+            f"{', '.join(_missing)}"
+        )
+    else:
+        _phase(f"PREFLIGHT: all {len(_ready)} tool images ready")
+except BaseException:
+    _phase("PREFLIGHT CHECK FAILED (non-fatal)")
+    traceback.print_exc(file=sys.stderr)
+    # Non-fatal — server can still start, images will pull on demand.
+
+
 # ── Start MCP server ──────────────────────────────────────────────────────────
 
 _phase("CALLING mcp.run()  — server handshake begins now")

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -7,7 +7,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tools.docker_runner import _ensure_image, run_container
+from tools.docker_runner import _ensure_image, image_exists, run_container
 import tools.docker_runner as _dr
 
 
@@ -118,6 +118,48 @@ async def test_ensure_image_pull_failure_falls_back_to_stdout(_skip_image_pull):
     with patch("tools.docker_runner.asyncio.create_subprocess_exec", side_effect=_side_effect):
         with pytest.raises(RuntimeError, match="not found"):
             await _ensure_image("missing:latest")
+
+
+@pytest.mark.asyncio
+async def test_ensure_image_pull_timeout_raises(_skip_image_pull):
+    """docker pull exceeds PULL_TIMEOUT → RuntimeError with actionable message."""
+    inspect_proc = _make_inspect_proc(returncode=1)
+    pull_proc = MagicMock()
+    pull_proc.kill = MagicMock()
+    pull_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+    call_count = 0
+
+    async def _side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return inspect_proc if call_count == 1 else pull_proc
+
+    async def _fake_wait_for(coro, timeout):
+        raise asyncio.TimeoutError
+
+    with patch("tools.docker_runner.asyncio.create_subprocess_exec", side_effect=_side_effect), \
+         patch("tools.docker_runner.asyncio.wait_for", side_effect=_fake_wait_for):
+        with pytest.raises(RuntimeError, match="Timed out pulling"):
+            await _ensure_image("slow:latest")
+    pull_proc.kill.assert_called_once()
+    assert "slow:latest" not in _dr._pulled_images
+
+
+@pytest.mark.asyncio
+async def test_image_exists_returns_true():
+    """image_exists returns True when docker image inspect succeeds."""
+    proc = _make_inspect_proc(returncode=0)
+    with patch("tools.docker_runner.asyncio.create_subprocess_exec", return_value=proc):
+        assert await image_exists("present:latest") is True
+
+
+@pytest.mark.asyncio
+async def test_image_exists_returns_false():
+    """image_exists returns False when docker image inspect fails."""
+    proc = _make_inspect_proc(returncode=1)
+    with patch("tools.docker_runner.asyncio.create_subprocess_exec", return_value=proc):
+        assert await image_exists("absent:latest") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -10,8 +10,6 @@ To add a new tool:
 """
 from __future__ import annotations
 
-from tools.ffuf       import TOOL as _ffuf
-from tools.fuzzyai    import TOOL as _fuzzyai
 from tools.httpx      import TOOL as _httpx
 from tools.naabu      import TOOL as _naabu
 from tools.nmap       import TOOL as _nmap
@@ -21,16 +19,18 @@ from tools.subfinder  import TOOL as _subfinder
 from tools.trufflehog import TOOL as _trufflehog
 
 # fmt: off
+# REGISTRY contains only tools that run as standalone Docker containers
+# via _run() / docker_runner.run_container(). Tools that run inside the
+# Kali container (ffuf, spider, fuzzyai, pyrit, garak, promptfoo) are
+# NOT registered here — they use kali_runner.exec_command() directly.
 REGISTRY = {
     _nmap.name:       _nmap,        # nmap       — port scanner
     _naabu.name:      _naabu,       # naabu      — fast port scanner
     _httpx.name:      _httpx,       # httpx      — HTTP probe
     _nuclei.name:     _nuclei,      # nuclei     — template vuln scanner
-    _ffuf.name:       _ffuf,        # ffuf       — web fuzzer
     _subfinder.name:  _subfinder,   # subfinder  — subdomain discovery
     _semgrep.name:    _semgrep,     # semgrep    — static code analysis
     _trufflehog.name: _trufflehog,  # trufflehog — secret scanner
-    _fuzzyai.name:    _fuzzyai,     # fuzzyai    — AI/LLM security fuzzer
 }
 # fmt: on
 

--- a/tools/docker_runner.py
+++ b/tools/docker_runner.py
@@ -4,21 +4,27 @@ import asyncio
 import os
 
 DEFAULT_TIMEOUT = 600
+PULL_TIMEOUT = 300  # 5 min max for pulling a single image
 
 _pulled_images: set[str] = set()
 
 
-async def _ensure_image(image: str) -> None:
-    """Pull an image if it hasn't been pulled this session."""
-    if image in _pulled_images:
-        return
+async def image_exists(image: str) -> bool:
+    """Check if a Docker image exists locally (no pull)."""
     proc = await asyncio.create_subprocess_exec(
         "docker", "image", "inspect", image,
         stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.DEVNULL,
     )
     await proc.wait()
-    if proc.returncode == 0:
+    return proc.returncode == 0
+
+
+async def _ensure_image(image: str) -> None:
+    """Pull an image if it hasn't been pulled this session."""
+    if image in _pulled_images:
+        return
+    if await image_exists(image):
         _pulled_images.add(image)
         return
     pull = await asyncio.create_subprocess_exec(
@@ -26,7 +32,17 @@ async def _ensure_image(image: str) -> None:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await pull.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            pull.communicate(), timeout=PULL_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        pull.kill()
+        await pull.communicate()
+        raise RuntimeError(
+            f"Timed out pulling Docker image '{image}' after {PULL_TIMEOUT}s. "
+            f"Check your network or pre-pull with: docker pull {image}"
+        )
     if pull.returncode != 0:
         msg = stderr.decode(errors="replace").strip() or stdout.decode(errors="replace").strip()
         raise RuntimeError(


### PR DESCRIPTION
## Summary

- **Fixed hang**: `docker_runner._ensure_image()` had no timeout on `docker pull` — if the registry was slow or required auth (ghcr.io), the MCP server hung indefinitely mid-scan with no error. Now times out after 300s, kills the process, and raises `RuntimeError` with an actionable message.
- **Startup preflight**: New phase in `__main__.py` prints `[OK]`/`[MISSING]` for each tool image before `mcp.run()`. Non-fatal — server starts either way, but you see upfront which tools need a pull.
- **Registry cleanup**: Removed `ffuf` and `fuzzyai` from REGISTRY — they run inside the Kali container via `kali_runner.exec_command()`, never used `docker_runner.run_container()`. Their REGISTRY entries caused false `[MISSING]` warnings.

## Test plan

- [x] All 323 tests pass
- [x] New tests: pull timeout raises RuntimeError and kills process, `image_exists()` returns true/false correctly
- [ ] Manual: restart MCP server, verify preflight output in `logs/mcp_crash.log`
- [ ] Manual: remove a cached image (`docker rmi projectdiscovery/naabu`), run a scan, verify it pulls with timeout instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)