### PR TITLE
fix MCP server crash: parallel preflight + ClosedResourceError resilience

### DIFF
--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -20,6 +20,8 @@ import platform
 import sys
 import traceback
 from datetime import datetime, timezone
+
+import anyio
 from pathlib import Path
 
 # ── Crash log setup ───────────────────────────────────────────────────────────
@@ -207,20 +209,31 @@ except BaseException:
 # Verify all tool images exist locally before the server starts.
 # Missing images get a warning — they'll be pulled on first use, but the
 # user sees upfront which tools are ready vs. need a pull.
+#
+# IMPORTANT: This must complete fast. Claude Code kills MCP servers that take
+# too long to start. Checks run in parallel with a 10-second hard timeout.
+
+_PREFLIGHT_TIMEOUT = 10  # seconds — must be well under Claude Code's startup timeout
 
 _phase("DOCKER IMAGE PREFLIGHT CHECK")
 try:
     from tools import REGISTRY
     from tools.docker_runner import image_exists
 
+    async def _check_one(img: str) -> tuple[str, bool]:
+        try:
+            return (img, await asyncio.wait_for(image_exists(img), timeout=5))
+        except (asyncio.TimeoutError, Exception):
+            return (img, False)
+
     async def _preflight():
-        ready, missing = [], []
-        for tool in REGISTRY.values():
-            img = tool.image
-            if await image_exists(img):
-                ready.append(img)
-            else:
-                missing.append(img)
+        images = [tool.image for tool in REGISTRY.values()]
+        results = await asyncio.wait_for(
+            asyncio.gather(*[_check_one(img) for img in images]),
+            timeout=_PREFLIGHT_TIMEOUT,
+        )
+        ready = [img for img, ok in results if ok]
+        missing = [img for img, ok in results if not ok]
         return ready, missing
 
     _ready, _missing = asyncio.run(_preflight())
@@ -239,18 +252,54 @@ try:
         )
     else:
         _phase(f"PREFLIGHT: all {len(_ready)} tool images ready")
-except BaseException:
-    _phase("PREFLIGHT CHECK FAILED (non-fatal)")
+except (asyncio.TimeoutError, BaseException):
+    _phase("PREFLIGHT CHECK FAILED (non-fatal — Docker may be slow)")
     traceback.print_exc(file=sys.stderr)
     # Non-fatal — server can still start, images will pull on demand.
+
+
+# ── Monkey-patch: suppress ClosedResourceError in MCP message handling ────────
+# MCP SDK v1.26.0 bug: _handle_request (server.py:781) calls message.respond()
+# OUTSIDE its try/except, so if the client disconnects while a response is
+# being sent, ClosedResourceError propagates through TaskGroups and crashes
+# mcp.run().  This patch wraps _handle_message to catch the exception cleanly.
+
+_phase("PATCHING MCP SDK for ClosedResourceError resilience")
+try:
+    _orig_handle_message = mcp._mcp_server._handle_message  # bound method
+
+    async def _safe_handle_message(message, session, lifespan_context, raise_exceptions=False):
+        try:
+            return await _orig_handle_message(message, session, lifespan_context, raise_exceptions)
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+            sys.stderr.write(
+                f"\n[WARN {_ts()}] Client disconnected mid-response — "
+                f"ClosedResourceError suppressed (not a bug)\n"
+            )
+            sys.stderr.flush()
+
+    mcp._mcp_server._handle_message = _safe_handle_message
+    _phase("MCP SDK patched OK")
+except BaseException:
+    _phase("MCP SDK PATCH FAILED (non-fatal)")
+    traceback.print_exc(file=sys.stderr)
 
 
 # ── Start MCP server ──────────────────────────────────────────────────────────
 
 _phase("CALLING mcp.run()  — server handshake begins now")
 try:
-    mcp.run()
-    _phase("mcp.run() returned normally")
+    try:
+        mcp.run()
+        _phase("mcp.run() returned normally")
+    except* (anyio.ClosedResourceError, anyio.BrokenResourceError):
+        # Safety net: if ClosedResourceError escapes despite the monkey-patch
+        # (e.g. from the stdio transport layer itself), treat it as a normal
+        # client disconnect rather than a crash.
+        _phase("mcp.run() exited — client disconnected (ClosedResourceError suppressed)")
+except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+    # Bare (non-grouped) ClosedResourceError — same treatment.
+    _phase("mcp.run() exited — client disconnected (ClosedResourceError suppressed)")
 except BaseException:
     _phase("CRASHED inside mcp.run()")
     traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
## Summary

- **Preflight check** (added in 85ec3a2) ran `docker image inspect` on 7 images **sequentially with no timeout**, blocking server startup for minutes when Docker was slow. Claude Code killed the server before `mcp.run()` was reached, triggering a crash.
- **MCP SDK bug** (all versions 1.0.0–1.26.0): `message.respond()` in `_handle_request` (server.py:781) is outside the try/except block. When the client disconnects mid-response, `anyio.ClosedResourceError` propagates through TaskGroups and crashes the server. Never hit before because startup was fast enough that the client never disconnected during request handling.

### Fixes

1. **Parallel preflight with hard timeout** — all image checks run via `asyncio.gather` with 5s per-check and 10s overall timeout. Can never block startup.
2. **Monkey-patch `_handle_message`** — catches `ClosedResourceError`/`BrokenResourceError` at the message handler level so client disconnects are logged, not fatal.
3. **`except*` safety net** around `mcp.run()` — catches any escaping ExceptionGroups containing transport errors.

## Test plan

- [x] All 323 existing tests pass
- [ ] Start MCP server with Docker stopped — preflight should fail fast (<10s), server should still start
- [ ] Start MCP server with Docker running — preflight should complete in <1s
- [ ] Run a scan, kill Claude Code mid-scan — server should log a warning, not crash with ExceptionGroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)