### PR TITLE
Programmatic gate enforcement and finding lifecycle management

### DIFF
--- a/core/api_server.py
+++ b/core/api_server.py
@@ -194,11 +194,27 @@ async def api_patch_finding(finding_id: str, request: Request) -> JSONResponse:
         body = await request.json()
         updated = await update_finding(
             finding_id,
+            severity=body.get("severity"),
+            title=body.get("title"),
+            description=body.get("description"),
+            evidence=body.get("evidence"),
+            status=body.get("status"),
             gh_issue=body.get("gh_issue"),
             remediation=body.get("remediation"),
             reproduction=body.get("reproduction"),
+            escalation_leads=body.get("escalation_leads"),
         )
         return JSONResponse({"ok": updated})
+    except Exception as exc:
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+
+
+@app.delete("/api/findings/{finding_id}")
+async def api_delete_finding(finding_id: str) -> JSONResponse:
+    from core.findings import delete_finding
+    try:
+        archived = await delete_finding(finding_id)
+        return JSONResponse({"ok": archived})
     except Exception as exc:
         return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
 

--- a/core/findings.py
+++ b/core/findings.py
@@ -9,11 +9,17 @@ Schema
   "meta":     { "created": "<ISO>", "target": "" },
   "findings": [ { id, timestamp, title, severity, target,
                    description, evidence, tool_used, cve,
-                   reproduction?, gh_issue?, remediation? } ],
-  "diagrams": [ { id, timestamp, title, mermaid } ]
+                   status?, reproduction?, gh_issue?, remediation? } ],
+  "diagrams": [ { id, timestamp, title, mermaid } ],
+  "archived": [ ... same shape as findings, moved here on delete ... ]
 }
 
 Optional fields set via update_finding():
+  severity:         "critical" | "high" | "medium" | "low" | "info"
+  title:            updated title string
+  description:      updated description string
+  evidence:         updated evidence string
+  status:           "confirmed" | "false_positive" | "draft"
   reproduction:     { type, command, expected, verified }
   gh_issue:         "<markdown block>"
   remediation:      { summary, fix_type, diff, before, after, file, line,
@@ -94,13 +100,17 @@ async def add_finding(
     return entry
 
 
-_UPDATABLE_FIELDS = {"gh_issue", "remediation", "reproduction", "escalation_leads"}
+_UPDATABLE_FIELDS = {
+    "severity", "title", "description", "evidence", "status",
+    "gh_issue", "remediation", "reproduction", "escalation_leads",
+}
 
 
 async def update_finding(finding_id: str, **fields) -> bool:
     """Update fields on an existing finding by id.
 
-    Accepted fields: gh_issue, remediation, reproduction.
+    Accepted fields: severity, title, description, evidence, status,
+    gh_issue, remediation, reproduction, escalation_leads.
     Returns True if the finding was found and updated, False otherwise.
     """
     updates = {k: v for k, v in fields.items() if k in _UPDATABLE_FIELDS and v is not None}
@@ -111,6 +121,25 @@ async def update_finding(finding_id: str, **fields) -> bool:
         for entry in data["findings"]:
             if entry.get("id") == finding_id:
                 entry.update(updates)
+                _save(data)
+                return True
+    return False
+
+
+async def delete_finding(finding_id: str) -> bool:
+    """Move a finding from findings[] to archived[].
+
+    Returns True if the finding was found and archived, False otherwise.
+    """
+    async with _lock:
+        data = _load()
+        if "archived" not in data:
+            data["archived"] = []
+        for i, entry in enumerate(data["findings"]):
+            if entry.get("id") == finding_id:
+                entry["archived_at"] = datetime.now(timezone.utc).isoformat()
+                data["archived"].append(entry)
+                data["findings"].pop(i)
                 _save(data)
                 return True
     return False

--- a/mcp_server/report_tools.py
+++ b/mcp_server/report_tools.py
@@ -51,12 +51,20 @@ _AUTH_KEYWORDS = (
 async def report(action: str, data: Any) -> str:
     """Log findings, diagrams, notes, or coverage matrix updates.
 
-    action : finding | diagram | note | dashboard | coverage
+    action : finding | update_finding | delete_finding | diagram | note | dashboard | coverage
 
     finding data:
       title, severity (critical|high|medium|low|info), target,
       description, evidence, tool_used=, cve=,
       reproduction= {type: http|command|script|manual, command: "...", expected: "..."}
+
+    update_finding data:
+      id (required), plus any fields to update:
+      severity, title, description, evidence, status (confirmed|false_positive|draft),
+      gh_issue, remediation, reproduction, escalation_leads
+
+    delete_finding data:
+      id — moves the finding to the archived[] array (not permanently deleted)
 
     diagram data:
       title, mermaid (valid Mermaid source)
@@ -85,6 +93,10 @@ async def report(action: str, data: Any) -> str:
         data = json.loads(data)
     if action == "finding":
         return await _do_finding(data)
+    elif action == "update_finding":
+        return await _do_update_finding(data)
+    elif action == "delete_finding":
+        return await _do_delete_finding(data)
     elif action == "diagram":
         return await _do_diagram(data)
     elif action == "note":
@@ -94,7 +106,7 @@ async def report(action: str, data: Any) -> str:
     elif action == "coverage":
         return await _do_coverage(data)
     else:
-        return f"Unknown action '{action}'. Use: finding, diagram, note, dashboard, coverage"
+        return f"Unknown action '{action}'. Use: finding, update_finding, delete_finding, diagram, note, dashboard, coverage"
 
 
 async def _do_finding(data):
@@ -149,6 +161,29 @@ def _auto_trigger_finding_gates(title: str, severity: str, description: str) -> 
             triggered.append("credential_audit")
 
     return triggered
+
+
+async def _do_update_finding(data):
+    finding_id = data.get("id", "")
+    if not finding_id:
+        return "Missing required field: id"
+    fields = {k: v for k, v in data.items() if k != "id"}
+    if not fields:
+        return "No fields to update. Provide severity, title, description, evidence, status, etc."
+    updated = await findings_store.update_finding(finding_id, **fields)
+    if updated:
+        return f"Finding updated: {finding_id} — fields: {', '.join(fields.keys())}"
+    return f"Finding not found: {finding_id}"
+
+
+async def _do_delete_finding(data):
+    finding_id = data.get("id", "")
+    if not finding_id:
+        return "Missing required field: id"
+    archived = await findings_store.delete_finding(finding_id)
+    if archived:
+        return f"Finding archived: {finding_id} — moved to archived[] in findings.json"
+    return f"Finding not found: {finding_id}"
 
 
 async def _do_diagram(data):

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -291,6 +291,58 @@ def test_api_patch_finding_invalid_json():
     response = client.patch("/api/findings/abc123", content=b"not json", headers={"content-type": "application/json"})
     assert response.status_code == 400
 
+def test_api_patch_finding_severity(monkeypatch):
+    from core import findings as findings_mod
+    monkeypatch.setattr(findings_mod, "update_finding", AsyncMock(return_value=True))
+    response = client.patch("/api/findings/abc123", json={"severity": "critical"})
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+def test_api_patch_finding_status(monkeypatch):
+    from core import findings as findings_mod
+    monkeypatch.setattr(findings_mod, "update_finding", AsyncMock(return_value=True))
+    response = client.patch("/api/findings/abc123", json={"status": "false_positive"})
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+def test_api_patch_finding_multiple_fields(monkeypatch):
+    from core import findings as findings_mod
+    mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(findings_mod, "update_finding", mock)
+    response = client.patch("/api/findings/abc123", json={
+        "severity": "high", "title": "Updated", "status": "confirmed"
+    })
+    assert response.status_code == 200
+    mock.assert_awaited_once()
+    _, kwargs = mock.call_args
+    assert kwargs["severity"] == "high"
+    assert kwargs["title"] == "Updated"
+    assert kwargs["status"] == "confirmed"
+
+
+# ── DELETE /api/findings/{id} ────────────────────────────────────────────────
+
+def test_api_delete_finding_success(monkeypatch):
+    from core import findings as findings_mod
+    monkeypatch.setattr(findings_mod, "delete_finding", AsyncMock(return_value=True))
+    response = client.delete("/api/findings/abc123")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+def test_api_delete_finding_not_found(monkeypatch):
+    from core import findings as findings_mod
+    monkeypatch.setattr(findings_mod, "delete_finding", AsyncMock(return_value=False))
+    response = client.delete("/api/findings/nonexistent")
+    assert response.status_code == 200
+    assert response.json()["ok"] is False
+
+def test_api_delete_finding_error(monkeypatch):
+    from core import findings as findings_mod
+    monkeypatch.setattr(findings_mod, "delete_finding", AsyncMock(side_effect=Exception("db error")))
+    response = client.delete("/api/findings/abc123")
+    assert response.status_code == 400
+    assert "db error" in response.json()["error"]
+
 
 def test_api_clear_resets_findings(tmp_path, monkeypatch):
     from core import findings as findings_mod

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -201,3 +201,132 @@ async def test_add_finding_without_escalation_leads(findings_file):
         description="d", evidence="e",
     )
     assert "escalation_leads" not in entry
+
+
+# ---------------------------------------------------------------------------
+# update_finding — new fields (severity, title, description, evidence, status)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_update_finding_severity(findings_file):
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    ok = await core.findings.update_finding(entry["id"], severity="critical")
+    assert ok
+    data = json.loads(findings_file.read_text())
+    assert data["findings"][0]["severity"] == "critical"
+
+
+@pytest.mark.asyncio
+async def test_update_finding_title(findings_file):
+    entry = await core.findings.add_finding(
+        title="Old", severity="low", target="t", description="d", evidence="e"
+    )
+    ok = await core.findings.update_finding(entry["id"], title="New Title")
+    assert ok
+    data = json.loads(findings_file.read_text())
+    assert data["findings"][0]["title"] == "New Title"
+
+
+@pytest.mark.asyncio
+async def test_update_finding_description(findings_file):
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="old", evidence="e"
+    )
+    ok = await core.findings.update_finding(entry["id"], description="new desc")
+    assert ok
+    data = json.loads(findings_file.read_text())
+    assert data["findings"][0]["description"] == "new desc"
+
+
+@pytest.mark.asyncio
+async def test_update_finding_evidence(findings_file):
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="old"
+    )
+    ok = await core.findings.update_finding(entry["id"], evidence="new evidence")
+    assert ok
+    data = json.loads(findings_file.read_text())
+    assert data["findings"][0]["evidence"] == "new evidence"
+
+
+@pytest.mark.asyncio
+async def test_update_finding_status(findings_file):
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    ok = await core.findings.update_finding(entry["id"], status="false_positive")
+    assert ok
+    data = json.loads(findings_file.read_text())
+    assert data["findings"][0]["status"] == "false_positive"
+
+
+@pytest.mark.asyncio
+async def test_update_finding_multiple_fields(findings_file):
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    ok = await core.findings.update_finding(
+        entry["id"], severity="high", status="confirmed", title="Updated"
+    )
+    assert ok
+    data = json.loads(findings_file.read_text())
+    f = data["findings"][0]
+    assert f["severity"] == "high"
+    assert f["status"] == "confirmed"
+    assert f["title"] == "Updated"
+
+
+# ---------------------------------------------------------------------------
+# delete_finding — archive
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_finding_moves_to_archived(findings_file):
+    entry = await core.findings.add_finding(
+        title="FP", severity="low", target="t", description="d", evidence="e"
+    )
+    ok = await core.findings.delete_finding(entry["id"])
+    assert ok
+    data = json.loads(findings_file.read_text())
+    assert len(data["findings"]) == 0
+    assert len(data["archived"]) == 1
+    assert data["archived"][0]["id"] == entry["id"]
+    assert "archived_at" in data["archived"][0]
+
+
+@pytest.mark.asyncio
+async def test_delete_finding_returns_false_for_missing_id(findings_file):
+    ok = await core.findings.delete_finding("nonexistent-uuid")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_delete_finding_preserves_other_findings(findings_file):
+    e1 = await core.findings.add_finding(
+        title="Keep", severity="high", target="t", description="d", evidence="e"
+    )
+    e2 = await core.findings.add_finding(
+        title="Remove", severity="low", target="t", description="d", evidence="e"
+    )
+    await core.findings.delete_finding(e2["id"])
+    data = json.loads(findings_file.read_text())
+    assert len(data["findings"]) == 1
+    assert data["findings"][0]["id"] == e1["id"]
+
+
+@pytest.mark.asyncio
+async def test_delete_finding_creates_archived_key_if_missing(findings_file):
+    """archived[] key should be created on first delete even if not in file."""
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    # Verify no archived key yet
+    data = json.loads(findings_file.read_text())
+    assert "archived" not in data
+    # Delete should create it
+    await core.findings.delete_finding(entry["id"])
+    data = json.loads(findings_file.read_text())
+    assert "archived" in data
+    assert len(data["archived"]) == 1

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -1,0 +1,99 @@
+"""
+Tests for mcp_server.report_tools — update_finding and delete_finding actions.
+"""
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from mcp_server.report_tools import _do_update_finding, _do_delete_finding, report
+
+
+# ── _do_update_finding ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_update_finding_missing_id():
+    result = await _do_update_finding({})
+    assert "Missing required field: id" in result
+
+
+@pytest.mark.asyncio
+async def test_update_finding_no_fields():
+    result = await _do_update_finding({"id": "abc123"})
+    assert "No fields to update" in result
+
+
+@pytest.mark.asyncio
+async def test_update_finding_success(findings_file):
+    import core.findings
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    result = await _do_update_finding({
+        "id": entry["id"], "severity": "critical", "status": "confirmed"
+    })
+    assert "Finding updated" in result
+    assert "severity" in result
+    assert "status" in result
+
+
+@pytest.mark.asyncio
+async def test_update_finding_not_found(findings_file):
+    result = await _do_update_finding({"id": "nonexistent", "severity": "high"})
+    assert "Finding not found" in result
+
+
+# ── _do_delete_finding ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_delete_finding_missing_id():
+    result = await _do_delete_finding({})
+    assert "Missing required field: id" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_finding_success(findings_file):
+    import core.findings
+    entry = await core.findings.add_finding(
+        title="FP", severity="low", target="t", description="d", evidence="e"
+    )
+    result = await _do_delete_finding({"id": entry["id"]})
+    assert "Finding archived" in result
+    data = json.loads(findings_file.read_text())
+    assert len(data["findings"]) == 0
+    assert len(data["archived"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_finding_not_found(findings_file):
+    result = await _do_delete_finding({"id": "nonexistent"})
+    assert "Finding not found" in result
+
+
+# ── report() dispatcher ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_report_update_finding_action(findings_file):
+    import core.findings
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    result = await report("update_finding", {"id": entry["id"], "status": "confirmed"})
+    assert "Finding updated" in result
+
+
+@pytest.mark.asyncio
+async def test_report_delete_finding_action(findings_file):
+    import core.findings
+    entry = await core.findings.add_finding(
+        title="T", severity="low", target="t", description="d", evidence="e"
+    )
+    result = await report("delete_finding", {"id": entry["id"]})
+    assert "Finding archived" in result
+
+
+@pytest.mark.asyncio
+async def test_report_unknown_action():
+    result = await report("bogus_action", {})
+    assert "Unknown action" in result
+    assert "update_finding" in result
+    assert "delete_finding" in result


### PR DESCRIPTION
## Summary
- **Programmatic gate enforcement**: mandatory skill chains (post-exploit, credential-audit, container-k8s-security) are now enforced in code via `report_tools.py` — when a finding matches gate triggers (RCE keywords, auth keywords, container indicators), the response includes `⚠️ MANDATORY GATE TRIGGERED` with the required skill invocation
- **Finding lifecycle**: add `update_finding` and `delete_finding` actions to the `report()` tool — findings can be updated (severity, status, title, etc.) or archived (moved to `archived[]`, not permanently deleted)
- **CVE candidate pipeline**: pentester skill now generates `cve-candidates.json` after remediation, feeding the `/request-cves` skill
- **False positive filtering**: `analyze-cve` archives false positives via `delete_finding`, `gh-export` skips `false_positive`/`info` findings

## Changes
- `core/session.py` — gate enforcement logic with keyword matching
- `mcp_server/report_tools.py` — `update_finding`, `delete_finding` actions + auto-trigger gates on new findings
- `mcp_server/session_tools.py` — gate status tracking via session
- `core/findings.py` — expand updatable fields, add `delete_finding` (archive)
- `core/api_server.py` — `DELETE /api/findings/{id}` endpoint, expanded PATCH fields
- `skills/` — analyze-cve, gh-export, pentester updates

## Test plan
- [ ] 125 new tests in `test_session.py` for gate enforcement logic
- [ ] Verify gate triggers on RCE finding keywords
- [ ] Verify `delete_finding` moves to `archived[]` not permanent delete
- [ ] Verify `update_finding` accepts new fields (severity, status, title)
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)