### PR TITLE
fix: await _do_complete() in session dispatcher

### DIFF
--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -46,7 +46,7 @@ async def session(action: str, options: dict | None = None) -> str:
     if action == "start":
         return _do_start(opts)
     elif action == "complete":
-        return _do_complete(opts)
+        return await _do_complete(opts)
     elif action == "status":
         return _do_status()
     elif action == "set_skill":


### PR DESCRIPTION
## Summary
- Missing `await` on `_do_complete()` at line 49 of `session_tools.py`
- `_do_complete` is `async def` but was called without `await`, returning the coroutine object instead of its string result
- Causes pydantic validation error: `Input should be a valid string, input_type=coroutine`

One-line fix: `return _do_complete(opts)` → `return await _do_complete(opts)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)