### PR TITLE
fix: surface skill catalog to opencode and fix kali timeout chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,35 @@ Scan lifecycle and infrastructure.
 - `action="pull_images"` — pre-pull all Docker images
 - `action="set_codebase"` — options: `{path}` — set local codebase for semgrep/trufflehog
 
+## Available Skills
+
+Skills are slash commands that contain full structured workflows. In Claude Code they appear via `/skill-name`; in opencode they appear as `/command-name`. Always prefer invoking a skill over improvising a workflow from scratch — the skill files contain all chaining rules, tool sequences, and completion gates.
+
+| Command | Purpose | Invoke when |
+|---------|---------|-------------|
+| `/pentester` | Full pentest orchestrator — recon → exploitation → report | General web/network pentest request |
+| `/web-exploit` | Deep injection, auth, logic, and business-logic exploitation | Web app confirmed; systematic endpoint testing needed |
+| `/codebase` | OWASP ASVS 5.0 white-box source code review | Local codebase path provided |
+| `/ai-redteam` | OWASP LLM Top 10 red-team — prompt injection, jailbreaks, data extraction | AI/chatbot/LLM target |
+| `/cloud-security` | AWS/Azure/GCP IAM, storage, serverless posture assessment | Cloud account target |
+| `/ad-assessment` | Active Directory — trusts, GPO, ACL, ADCS (ESC1-8), delegation | Domain controller / Windows AD environment |
+| `/network-assess` | VLAN hopping, ARP, LLMNR/NBT-NS, SNMP, NFS, segmentation | Internal LAN/network target |
+| `/lateral-movement` | Pass-the-hash, Kerberoasting, NTLM relay, WMI/WinRM, pivoting | Post-initial-access; need to move laterally |
+| `/credential-audit` | Brute-force, spraying, MFA bypass, OAuth/OIDC, session entropy | Authentication surface testing |
+| `/post-exploit` | Privesc (Linux/Windows), persistence, credential harvesting, pivoting | Shell access obtained |
+| `/container-k8s-security` | Container escape, Docker socket, K8s RBAC, pod security, etcd | Docker / Kubernetes target |
+| `/osint` | Subdomain enumeration, email harvest, Shodan, CT logs, Wayback | External recon phase; passive information gathering |
+| `/ssl-tls-audit` | TLS protocol versions, cipher suites, cert chain, POODLE/BEAST/Heartbleed | Any HTTPS/TLS endpoint |
+| `/email-security` | SPF/DKIM/DMARC, open relay, spoofing, SMTP security, MTA-STS | Domain email infrastructure |
+| `/metasploit` | Exploit validation and exploitation via Metasploit Framework | CVE to exploit; need controlled exploitation |
+| `/reverse-shell` | Reverse shell payload generation and listener management | Need shell on target system |
+| `/analyze-cve` | CVE exploitability analysis, code path tracing, Burp PoC generation | Known CVE in a dependency |
+| `/threat-model` | PASTA framework + 4-question threat model | Architecture or design review |
+| `/aikido-triage` | Triage Aikido security CSV against local codebase; verdict each finding | Aikido CSV scan results provided |
+| `/gh-export` | Format all confirmed findings as GitHub issue markdown blocks | End of pentest; ready to file issues |
+| `/remediate` | Fix vulnerabilities in source code | Post-finding code remediation needed |
+| `/request-cves` | Generate MITRE CVE request packages and GitHub Security Advisory drafts | Novel vulnerability discovered; need CVE disclosure |
+
 ## Project layout
 - `mcp_server/__main__.py` — entry point, crash logging, module imports
 - `mcp_server/_app.py` — FastMCP singleton, `_run()` dispatcher, `_clip()` helper

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -138,6 +138,10 @@ mkdir -p "$HOME/.claude/skills/ssl-tls-audit"
 cp "$REPO_DIR/skills/ssl-tls-audit/SKILL.md" "$HOME/.claude/skills/ssl-tls-audit/SKILL.md"
 ok "/ssl-tls-audit skill installed"
 
+mkdir -p "$HOME/.claude/skills/request-cves"
+cp "$REPO_DIR/skills/request-cves/SKILL.md" "$HOME/.claude/skills/request-cves/SKILL.md"
+ok "/request-cves skill installed"
+
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""
 echo "AI testing tools (FuzzyAI + PyRIT) use LLM APIs for attacks and scoring."

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -62,7 +62,7 @@ mcp["pentest-agent"] = {
     "type":    "local",
     "command": ["poetry", "-C", str(repo_dir), "run", "python", "-m", "mcp_server"],
     "enabled": True,
-    "timeout": 30000,
+    "timeout": 660000,   # 11 minutes — 10% above the kali() tool's default 600 s command timeout
 }
 
 # Add CLAUDE.md to global instructions (avoid duplicates)
@@ -120,7 +120,8 @@ _install_skill "network-assess"         "$REPO_DIR/skills/network-assess/SKILL.m
 _install_skill "osint"                  "$REPO_DIR/skills/osint/SKILL.md"
 _install_skill "post-exploit"           "$REPO_DIR/skills/post-exploit/SKILL.md"
 _install_skill "ssl-tls-audit"          "$REPO_DIR/skills/ssl-tls-audit/SKILL.md"
-ok "20 skill commands installed"
+_install_skill "request-cves"           "$REPO_DIR/skills/request-cves/SKILL.md"
+ok "21 skill commands installed"
 
 # ── Install web-exploit reference files (lazy-loaded per injection type) ─────
 echo ""

--- a/installers/opencode-pentest-recovery.mjs
+++ b/installers/opencode-pentest-recovery.mjs
@@ -79,6 +79,25 @@ export const PentestRecovery = async ({ directory }) => {
         );
       }
 
+      lines.push("");
+      lines.push(
+        "Available skills (use these — do not improvise workflows from scratch):"
+      );
+      lines.push(
+        "  /pentester /web-exploit /codebase /ai-redteam /cloud-security /ad-assessment"
+      );
+      lines.push(
+        "  /network-assess /lateral-movement /credential-audit /post-exploit"
+      );
+      lines.push(
+        "  /container-k8s-security /osint /ssl-tls-audit /email-security /metasploit"
+      );
+      lines.push(
+        "  /reverse-shell /analyze-cve /threat-model /aikido-triage /gh-export"
+      );
+      lines.push("  /remediate /request-cves");
+      lines.push("  Full descriptions in CLAUDE.md.");
+
       output.context.push(lines.join("\n"));
     },
 

--- a/mcp_server/kali_tools.py
+++ b/mcp_server/kali_tools.py
@@ -12,6 +12,10 @@ async def kali(command: str, timeout: int = 600) -> str:
     """Run any command in the Kali container (auto-starts if needed).
     Hundreds of tools available: nikto, sqlmap, gobuster, hydra, testssl,
     enum4linux-ng, wapiti, sslscan, ssh-audit, theHarvester, dnsrecon, etc.
+
+    timeout: seconds to wait for the command (default 600 = 10 min).
+    Increase for long-running tools — e.g. timeout=1200 for deep sqlmap/hydra runs.
+    The command is killed and partial output returned if the timeout is exceeded.
     """
     from tools import kali_runner
 

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -151,6 +151,14 @@ def _do_start(opts):
         "",
         f"Proceed with the {depth} scan workflow.",
         "Stop and call session(action='complete') when finished or when a limit is hit.",
+        "",
+        "Skills available (invoke these instead of improvising workflows):",
+        "  /pentester /web-exploit /codebase /ai-redteam /cloud-security /ad-assessment",
+        "  /network-assess /lateral-movement /credential-audit /post-exploit",
+        "  /container-k8s-security /osint /ssl-tls-audit /email-security /metasploit",
+        "  /reverse-shell /analyze-cve /threat-model /aikido-triage /gh-export",
+        "  /remediate /request-cves",
+        "  See CLAUDE.md for full skill descriptions and trigger conditions.",
     ]
     return "\n".join(lines)
 

--- a/tools/kali_runner.py
+++ b/tools/kali_runner.py
@@ -156,8 +156,8 @@ async def exec_command(command: str, timeout: int = 600) -> str:
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"{KALI_API}/api/command",
-                json={"command": command},
-                timeout=aiohttp.ClientTimeout(total=timeout + 5),
+                json={"command": command, "timeout": timeout},
+                timeout=aiohttp.ClientTimeout(total=timeout + 30),
             ) as resp:
                 data      = await resp.json()
                 stdout    = data.get("stdout", "")


### PR DESCRIPTION
Skill visibility (opencode sees no system-reminder injection unlike Claude Code):
- CLAUDE.md: add full 22-skill catalog table with command, purpose, and trigger conditions so opencode agents know available skills from session zero
- session_tools.py: echo skill list in session(action="start") response as a belt-and-suspenders reminder when a scan begins
- opencode-pentest-recovery.mjs: append skill list to post-compaction context injection so the agent re-anchors after losing context
- install.sh + install_opencode.sh: add missing /request-cves skill install (added in commit 3f7005c but never wired into either installer)

Kali timeouts (three-layer fix):
- install_opencode.sh: raise opencode.json MCP timeout 30 000 → 660 000 ms (11 min, 10% above the kali() default 600 s command timeout)
- kali_runner.py: pass {"timeout": timeout} in the kali-server-mcp POST body so the container subprocess uses the agent-requested deadline, not the server's own default; raise aiohttp headroom from +5 s → +30 s
- kali_tools.py: document the timeout param so agents know to increase it for deep sqlmap/hydra/nikto runs