### PR TITLE
Fine-tune and improve skills: wpscan + pattern library

### DIFF
--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -15,9 +15,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 3: web scanning + exploit-db + php (for running PHP exploits)
+# wpscan — WordPress plugin/theme/core CVE scanner (the authoritative source
+#   for WordPress plugin vulnerabilities — nuclei templates are incomplete)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nikto sqlmap whatweb wafw00f wapiti commix xsser davtest skipfish \
-    zaproxy exploitdb php-cli \
+    zaproxy exploitdb php-cli wpscan \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 4: web fuzzing / discovery


### PR DESCRIPTION
## Summary

Fine-tunes and improves the pentest skill library, pairing with the skills-repo PR [0x0pointer/skills#16](https://github.com/0x0pointer/skills/pull/16). The work came out of a gap analysis on unsolved XBOW CTF benchmarks — several challenges were failing not because of missing tools but because of missing pattern teachings or one absent CLI tool.

## Changes

### Kali Dockerfile — \`wpscan\` added to layer 3

\`wpscan\` is the authoritative WordPress plugin / theme / core CVE scanner. 90%+ of CMS compromises in the wild come from plugin CVEs, which nuclei templates and generic web fuzzers miss. Adding \`wpscan\` to the Kali container gives the agent an instant plugin/theme enumeration capability on any WordPress target.

Install size: ~30 MB. No other changes.

### Skills submodule bump

Bumps the skills submodule to [0x0pointer/skills#16](https://github.com/0x0pointer/skills/pull/16) which brings in:

- **4 new pattern refs**: \`oob-exfil.md\`, \`nginx-alias-traversal.md\`, \`idor-advanced.md\`, \`cms-cves.md\`
- **12 restructured existing refs** — every web-exploit ref now follows the same Root pattern + How to recognize the surface + numbered Attack N structure (matches \`jwt.md\`)
- **Updated Jinja2 SSTI gadgets** (the current cycler/lipsum/namespace/joiner chain — the old config.__class__ gadget doesn't work on Jinja2 2.9+)
- **LFI filter-bypass decision tree** — probe first, match bypass to filter type
- **Apache \`<Limit>\` / J2EE \`<security-constraint>\` HTTP verb authentication bypass** (the BOGUS trick)
- **Mass assignment on login / register / password-reset endpoints** (not just CRUD)
- **Cross-endpoint credential pivot** for SQLi-to-login chains
- **SSTI via include sink** — two-step stored-SSTI chain
- **New pentester orchestrator rules**: source-first escalation on 401/403, hidden-link discovery, cookie content inspection (decode + magic bytes), HTTP verb sweep, out-of-band exfiltration, structure-aware IDOR, CMS detection → mandatory plugin scan
- **API security updates**: GraphQL \"query every field\" pattern, kwargs-splat NoSQLi injection, login mass assignment

## Why

These are not new tools — they're pattern teachings that help the LLM recognize a situation and reach for the right technique. The gap analysis against the XBEN benchmark showed that agent-smith was failing challenges where the vulnerability was clear but the agent was either (a) fuzzing when it should have read source, (b) fuzzing when it should have tried a non-standard HTTP verb, (c) giving up on blind vulns instead of switching to OOB exfil, or (d) enumerating opaque IDs sequentially instead of decoding their structure.

All the pattern teachings are written in the agent-smith house style — the \"why\" first, then the recognition signals, then the tactical commands. The goal is for the agent to adapt to unseen targets, not to memorize payloads.

## Test plan

- [ ] Rebuild Kali image with \`wpscan\` and verify it's available inside the container
- [ ] Run \`/pentester\` against a WordPress target — confirm wpscan auto-triggers
- [ ] Re-run the previously-unsolved XBEN challenges (022, 023, 034, 054, 057, 063, 079, 091, 093, 094, 095, 097, 099, 100) against the patched skills — expected to solve ~14 of these
- [ ] Verify no regression on previously-solved challenges

## Related

- Skill changes: [0x0pointer/skills#16](https://github.com/0x0pointer/skills/pull/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)