### PR TITLE
kali: add phpggc + wrap commands in bash -c

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ testpaths = ["tests"]
 
 [tool.coverage.run]
 source = ["core", "tools", "mcp_server"]
-omit = ["tools/kali/*", "*/kali_runner.py", "tools/metasploit/*"]
+omit = ["tools/kali/*", "tools/metasploit/*"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/test_kali_runner.py
+++ b/tests/test_kali_runner.py
@@ -42,6 +42,86 @@ def test_host_rewrite_empty_string():
 
 
 # ---------------------------------------------------------------------------
+# _force_bash (pure function — no mocking needed)
+# ---------------------------------------------------------------------------
+
+def test_force_bash_wraps_simple_command():
+    result = kr._force_bash("id")
+    assert result.startswith("bash -c ")
+    # shlex.quote wraps single-word args in single quotes only if necessary
+    assert "id" in result
+
+
+def test_force_bash_preserves_bashisms():
+    # `[[ ]]` is the canonical bashism dash does not support
+    cmd = '[[ "a" == "a" ]] && echo ok'
+    result = kr._force_bash(cmd)
+    assert result.startswith("bash -c ")
+    # The inner command survives intact once shell-unquoted
+    import shlex
+    tokens = shlex.split(result)
+    assert tokens[:2] == ["bash", "-c"]
+    assert tokens[2] == cmd
+
+
+def test_force_bash_preserves_single_quotes():
+    cmd = "echo 'hello world'"
+    result = kr._force_bash(cmd)
+    import shlex
+    tokens = shlex.split(result)
+    assert tokens[:2] == ["bash", "-c"]
+    assert tokens[2] == cmd
+
+
+def test_force_bash_preserves_double_quotes_and_vars():
+    cmd = 'echo "$HOME"'
+    result = kr._force_bash(cmd)
+    import shlex
+    tokens = shlex.split(result)
+    assert tokens[:2] == ["bash", "-c"]
+    assert tokens[2] == cmd
+
+
+def test_force_bash_preserves_pipes_and_redirects():
+    cmd = "ls -la | grep foo > /tmp/out.txt 2>&1"
+    result = kr._force_bash(cmd)
+    import shlex
+    tokens = shlex.split(result)
+    assert tokens[:2] == ["bash", "-c"]
+    assert tokens[2] == cmd
+
+
+def test_force_bash_preserves_backslashes():
+    cmd = r"grep -E 'foo\s+bar' /etc/passwd"
+    result = kr._force_bash(cmd)
+    import shlex
+    tokens = shlex.split(result)
+    assert tokens[:2] == ["bash", "-c"]
+    assert tokens[2] == cmd
+
+
+def test_force_bash_double_wrapping_is_idempotent_in_effect():
+    # Already-wrapped commands get double-wrapped, which is harmless —
+    # the outer bash invokes the inner bash with the same argument list.
+    cmd = "bash -c 'echo inner'"
+    result = kr._force_bash(cmd)
+    assert result.startswith("bash -c ")
+    import shlex
+    tokens = shlex.split(result)
+    assert tokens[:2] == ["bash", "-c"]
+    assert tokens[2] == cmd
+
+
+def test_force_bash_empty_string_unchanged():
+    # No point wrapping an empty command.
+    assert kr._force_bash("") == ""
+
+
+def test_force_bash_whitespace_only_unchanged():
+    assert kr._force_bash("   ") == "   "
+
+
+# ---------------------------------------------------------------------------
 # exec_command — mocked ensure_running + aiohttp
 # ---------------------------------------------------------------------------
 
@@ -142,3 +222,39 @@ async def test_exec_command_handles_aiohttp_exception():
          patch.object(aiohttp, "ClientSession", side_effect=Exception("conn refused")):
         result = await kr.exec_command("id")
     assert "Error" in result or "conn refused" in result
+
+
+@pytest.mark.asyncio
+async def test_exec_command_wraps_in_bash_c_before_sending():
+    """The posted command must start with `bash -c ` so bashisms survive
+    dash (/bin/sh on Kali) when kali-server-mcp executes it."""
+    resp = _mock_resp(stdout="ok")
+    session = _mock_session(resp)
+    import aiohttp
+    with patch.object(kr, "ensure_running", AsyncMock(return_value=(True, "running"))), \
+         patch.object(aiohttp, "ClientSession", return_value=session):
+        await kr.exec_command('[[ "a" == "a" ]] && echo ok')
+    posted_json = session.post.call_args[1]["json"]
+    assert posted_json["command"].startswith("bash -c ")
+    # The inner (bashism) command must be fully preserved
+    import shlex
+    tokens = shlex.split(posted_json["command"])
+    assert tokens[:2] == ["bash", "-c"]
+    assert tokens[2] == '[[ "a" == "a" ]] && echo ok'
+
+
+@pytest.mark.asyncio
+async def test_exec_command_bash_wrap_composes_with_host_rewrite():
+    """Host rewrite runs before bash wrap, so the final posted command
+    contains host.docker.internal (not localhost) inside the bash -c."""
+    resp = _mock_resp(stdout="ok")
+    session = _mock_session(resp)
+    import aiohttp
+    with patch.object(kr, "ensure_running", AsyncMock(return_value=(True, "running"))), \
+         patch.object(aiohttp, "ClientSession", return_value=session):
+        await kr.exec_command("curl http://localhost:3000")
+    posted_json = session.post.call_args[1]["json"]
+    posted = posted_json["command"]
+    assert posted.startswith("bash -c ")
+    assert "localhost" not in posted
+    assert "host.docker.internal" in posted

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -121,6 +121,14 @@ RUN (apt-get update && apt-get install -y --no-install-recommends nodejs npm \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g promptfoo@0.121.2) || true
 
+# Exploitation payload generators
+# phpggc — PHP deserialization gadget-chain generator (Laravel, Symfony,
+# Twig, Monolog, Guzzle, SwiftMailer, Yii, ...). Used for exploiting
+# PHP unserialize / phar:// sinks. Ships `phpggc` binary + a chains/
+# directory with every supported framework/version combination.
+RUN git clone --depth=1 https://github.com/ambionics/phpggc /opt/phpggc \
+    && ln -s /opt/phpggc/phpggc /usr/local/bin/phpggc
+
 # Layer 11: container & K8s security
 # trivy — container image vulnerability scanner
 # kube-bench — CIS Kubernetes Benchmark auditor

--- a/tools/kali_runner.py
+++ b/tools/kali_runner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shlex
 
 KALI_IMAGE     = "pentest-agent/kali-mcp"
 KALI_CONTAINER = "pentest-kali"
@@ -139,13 +140,36 @@ def _host_rewrite(command: str) -> str:
     return command
 
 
+def _force_bash(command: str) -> str:
+    """Wrap the command in `bash -c` so bash-only syntax works.
+
+    kali-server-mcp executes commands via /bin/sh, which on Kali/Debian is
+    dash — it does NOT support `[[ ]]`, arrays, `<(...)`, brace expansion,
+    `==` in test, and other bashisms. Agents routinely produce bash-shaped
+    one-liners, and without this wrapper every such command hits
+    `[[: not found` and silently returns a partial or empty result.
+
+    The command is quoted with `shlex.quote` so inner quotes, `$`, and
+    backslashes survive intact. Already-wrapped commands (`bash -c '...'`)
+    end up double-wrapped, which is harmless: the outer bash invokes the
+    inner bash.
+    """
+    if not command.strip():
+        return command
+    return f"bash -c {shlex.quote(command)}"
+
+
 async def exec_command(command: str, timeout: int = 600) -> str:
     """
     Run a shell command via the kali-server-mcp HTTP API.
     Auto-starts the container if it isn't already running.
     localhost/127.0.0.1 are transparently rewritten to host.docker.internal.
+    Commands are wrapped in `bash -c` so bashisms like `[[`, arrays, and
+    process substitution work (the upstream /bin/sh is dash, which does not
+    support any of these).
     """
     command = _host_rewrite(command)
+    command = _force_bash(command)
     import aiohttp
 
     ok, msg = await ensure_running()


### PR DESCRIPTION
## Summary

Two small fixes to the kali tooling motivated by a post-mortem of four XBEN benchmarks where the `/pentester` agent identified the correct vulnerability class but was blocked by tooling rather than knowledge. Full investigation at [benchmark-agent-smith/runs/INVESTIGATION.md](https://github.com/0x0pointer/benchmark-agent-smith/blob/main/runs/INVESTIGATION.md).

Pairs with [0x0pointer/skills#18](https://github.com/0x0pointer/skills/pull/18), which adds the matching playbook rules to the pentester skill.

### 1. `tools/kali/Dockerfile` — add **phpggc**

`phpggc` is the canonical generator for PHP deserialization gadget chains (Laravel, Symfony, Twig, Monolog, Guzzle, SwiftMailer, Yii, ...). Agent-smith needs it whenever a target exposes an `unserialize()` or `phar://` sink. The agent knew the vulnerability class on XBEN-092 (Twig/Symfony phar deserialization) but had no way to actually produce a working payload.

Install is a single `git clone --depth=1` + symlink, no apt packages pulled. Image grows by ~few hundred KB.

### 2. `tools/kali_runner.py` — wrap commands in `bash -c`

`kali-server-mcp` (the HTTP API inside the kali container) executes commands via `/bin/sh`, which on Kali/Debian is **dash**. dash does not support:

- `[[ ... ]]` test syntax
- arrays
- brace expansion
- process substitution (`<(...)`)
- `for ((i=0; ...))`
- `==` in `test`

All of which agents routinely emit in bash one-liners. The XBEN-092 agent run burned dozens of turns on commands that failed with `[[: not found` and returned partial/empty output, which the agent misread as *\"endpoint is dead\"*.

Fix is client-side: wrap every command in `bash -c <shlex.quoted>` before posting to the kali API.

- Quotes, `$`, backslashes survive intact (shlex.quote handles escaping)
- Already-wrapped commands (`bash -c '...'`) end up double-wrapped → harmless (outer bash invokes inner bash)
- Empty/whitespace-only commands pass through unchanged
- No caller changes — every path through the `kali` tool goes through `exec_command()`

## Scope

- `tools/kali/Dockerfile`: +8 lines
- `tools/kali_runner.py`: +24 lines

Total: **32 insertions, 0 deletions**. No API changes, no tool interface changes, no submodule bumps.

## Note

This PR does **not** bump the `skills/` submodule. The matching prompt changes are in [skills#18](https://github.com/0x0pointer/skills/pull/18) — once that merges to `skills/main`, a follow-up PR here should bump the submodule to the new HEAD.

## Test plan

- [ ] Rebuild the kali image: `docker build -t pentest-agent/kali-mcp tools/kali/`
- [ ] Verify `phpggc -l` lists available gadget chains inside the container
- [ ] Verify `kali` tool can run a bash-only one-liner (e.g. `[[ \"a\" == \"a\" ]] && echo ok`) and it returns \"ok\"
- [ ] Re-run the 4 failed XBEN benchmarks (034, 066, 079, 092) with the updated kali image — expected: all 4 solved (combined with skills#18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)