### PR TITLE
ci: skip SonarCloud scan on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,15 @@ jobs:
             --cov-report=term-missing \
             -v
 
+      # Skip SonarCloud on Dependabot PRs: Dependabot-triggered workflows run
+      # in an isolated security context and cannot read repository secrets
+      # (including SONAR_TOKEN), so the scan fails with "Project not found".
+      # The alternative fix — adding a Dependabot-specific SONAR_TOKEN secret
+      # in repo settings — is cleaner but requires manual admin action. Until
+      # that's set up, skip the scan on Dependabot PRs entirely so dependency
+      # bumps don't block on a failing quality gate.
       - name: SonarCloud Scan
+        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarcloud-github-action@ba3875ecf642b2129de2b589510c81a8b53dbf4e # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Unblocks Dependabot PRs that currently fail CI on the SonarCloud step.

## Problem

Dependabot PR [#48](https://github.com/0x0pointer/agent-smith/pull/48) ("Bump the pip group across 1 directory with 3 updates") failed CI on the SonarCloud scan with:

\`\`\`
Warning: Running this GitHub Action without SONAR_TOKEN is not recommended
...
ERROR Project not found. Please check the 'sonar.projectKey' and 'sonar.organization'
properties, the 'SONAR_TOKEN' environment variable, or contact the project administrator
...
Process completed with exit code 3.
\`\`\`

Tests passed, coverage was generated — but the SonarCloud step couldn't find \`SONAR_TOKEN\` and failed anonymously.

**Root cause**: GitHub Actions does **not** expose repository secrets to workflows triggered by Dependabot PRs by default. This is a security feature — Dependabot could theoretically be exploited via a malicious dependency manifest to exfiltrate secrets. The regular \`secrets.SONAR_TOKEN\` is present and working fine on human-author PRs (see PR #47, which passed with 100% new-code coverage), but the token is simply unavailable inside a Dependabot-triggered workflow run.

## Fix

Add \`if: github.actor != 'dependabot[bot]'\` to the SonarCloud Scan step so it's skipped on Dependabot PRs. Human PRs and pushes to main still run the full scan. 

\`\`\`yaml
      - name: SonarCloud Scan
        if: github.actor != 'dependabot[bot]'
        uses: SonarSource/sonarcloud-github-action@...
\`\`\`

Diff: +8 lines (6 of them are explanatory comment), 0 deletions.

## Alternatives considered

**Add \`SONAR_TOKEN\` as a Dependabot-specific secret** (cleaner): GitHub has a separate Dependabot secrets namespace at *Settings → Secrets and variables → Actions → Dependabot tab*. Adding \`SONAR_TOKEN\` there would expose it to Dependabot workflow runs and allow the scan to succeed.

I did not take that route because it requires:
1. Manual admin action in the web UI (or \`gh secret set --app dependabot\`)
2. The raw token value, which I do not have

Once the Dependabot secret is set up, the \`if:\` guard in this PR can be removed.

**Run SonarCloud only on push-to-main, not on PRs**: would lose per-PR quality-gate feedback on human PRs, which is the main value.

## Test plan

- [ ] Merge this PR
- [ ] Re-run CI on Dependabot PR #48 (close + reopen, or wait for next dependabot cycle)
- [ ] Confirm: tests pass, SonarCloud step is skipped, overall CI is green
- [ ] Confirm: human-author PR still runs SonarCloud (no regression for normal workflow)

## Unrelated cleanup backlog

The CI run also emitted this deprecation warning:

> \`Warning: This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead.\`

\`SonarSource/sonarcloud-github-action\` is deprecated in favor of \`SonarSource/sonarqube-scan-action@v5.0.0\` (drop-in replacement). Worth a separate small PR when convenient — not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)