### PR TITLE
feat: log skill decisions and chain context to pentest.log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,22 @@ Scan lifecycle and infrastructure.
 - `action="start_kali"` / `action="stop_kali"` — Kali container lifecycle
 - `action="start_metasploit"` / `action="stop_metasploit"` — Metasploit container lifecycle
 - `action="pull_images"` — pre-pull all Docker images
+- `action="set_skill"` — options: `{skill, reason, chained_from}` — log skill selection with reasoning; **call this before invoking any skill** via the Skill tool
 - `action="set_codebase"` — options: `{path}` — set local codebase for semgrep/trufflehog
+
+## Skill Logging (mandatory)
+
+Before invoking **any** skill via the Skill tool, always call:
+
+```
+session(action="set_skill", options={
+  "skill": "<skill-name>",
+  "reason": "<1–2 sentences explaining why you chose this skill>",
+  "chained_from": "<parent skill name when chaining; omit for the first skill>"
+})
+```
+
+This writes a `SKILL_START` or `SKILL_CHAIN` entry to `pentest.log` and enriches `session.json`'s `skill_history` with the decision context. It is mandatory — always call it immediately before the Skill tool invocation.
 
 ## Available Skills
 

--- a/core/logger.py
+++ b/core/logger.py
@@ -11,6 +11,7 @@ tool_result(name, result)    — tool returned
 finding(severity, title, target)
 diagram(title)
 note(message)                — explicit reasoning / decision note from Claude
+skill_start(name, reason, chained_from)  — skill selected (SKILL_START) or chained (SKILL_CHAIN)
 """
 from __future__ import annotations
 
@@ -82,3 +83,18 @@ def diagram(title: str) -> None:
 def note(message: str) -> None:
     """Log a reasoning note or decision written explicitly by Claude."""
     _log.info("NOTE         %s", message)
+
+
+def skill_start(name: str, reason: str = "", chained_from: str = "") -> None:
+    """Log a skill invocation decision with reasoning and optional chain context.
+
+    Writes SKILL_CHAIN when the agent is chaining from a parent skill, or
+    SKILL_START for the initial skill selection.
+    """
+    if chained_from:
+        _log.info(
+            "SKILL_CHAIN  %-20s  chained_from=%-20s  reason=%s",
+            name, chained_from, reason,
+        )
+    else:
+        _log.info("SKILL_START  %-20s  reason=%s", name, reason)

--- a/core/session.py
+++ b/core/session.py
@@ -112,7 +112,14 @@ def start(
         "stop_reason":  None,
         "limits":       limits,
         "skill":         skill,
-        "skill_history": [skill] if skill else [],
+        "skill_history": [
+            {
+                "skill":        skill,
+                "reason":       "session start",
+                "chained_from": None,
+                "timestamp":    datetime.now(timezone.utc).isoformat(),
+            }
+        ] if skill else [],
         "tools_called":  [],
         "current_step":  None,
         "gates":         [],          # triggered gates that block completion
@@ -179,14 +186,29 @@ def get() -> dict | None:
     return _current
 
 
-def set_skill(skill_name: str) -> dict | None:
-    """Update the active skill (e.g. when chaining skills during a session)."""
+def set_skill(
+    skill_name: str,
+    reason: str = "",
+    chained_from: str = "",
+) -> dict | None:
+    """Update the active skill (e.g. when chaining skills during a session).
+
+    Each call appends a rich entry to skill_history with the reason for the
+    choice and the parent skill when chaining.  Duplicate skill names are
+    silently skipped so re-invoking the same skill mid-session is idempotent.
+    """
     global _current
     if _current is None or _current["status"] != "running":
         return None
     _current["skill"] = skill_name
-    if skill_name not in _current["skill_history"]:
-        _current["skill_history"].append(skill_name)
+    existing_skills = [e["skill"] for e in _current["skill_history"]]
+    if skill_name not in existing_skills:
+        _current["skill_history"].append({
+            "skill":        skill_name,
+            "reason":       reason,
+            "chained_from": chained_from or None,
+            "timestamp":    datetime.now(timezone.utc).isoformat(),
+        })
     _flush()
     return _current
 

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -32,6 +32,8 @@ async def session(action: str, options: dict | None = None) -> str:
 
     set_skill options:
       skill= (name of the active skill, e.g. "pentester", "ai-redteam")
+      reason= (why this skill was chosen — shown in logs)
+      chained_from= (parent skill name when chaining, omit for first skill)
 
     set_step options:
       step= (current workflow step, e.g. "5_nuclei_scan")
@@ -411,7 +413,11 @@ def _determine_resume_step(current: dict, tools_run: set[str]) -> str:
     }
     for step, tools in step_tools.items():
         if step == "6a":
-            if "web-exploit" not in current.get("skill_history", []):
+            skill_names = [
+                (s["skill"] if isinstance(s, dict) else s)
+                for s in current.get("skill_history", [])
+            ]
+            if "web-exploit" not in skill_names:
                 return "6a (chain /web-exploit with endpoint inventory)"
         elif tools and not any(t in tools_run for t in tools):
             return f"{step} ({', '.join(tools)})"
@@ -587,9 +593,10 @@ def _do_pre_chain(opts):
     meta = cov.get("meta", {})
     data = findings_store._load()
 
-    # Set the new skill
-    scan_session.set_skill(next_skill)
-    log.note(f"Pre-chain checkpoint: {prev_skill} -> {next_skill}")
+    # Set the new skill and log the chain decision
+    chain_reason = f"chained from /{prev_skill}"
+    scan_session.set_skill(next_skill, reason=chain_reason, chained_from=prev_skill)
+    log.skill_start(next_skill, reason=chain_reason, chained_from=prev_skill)
 
     result = {
         "action": "pre_chain",
@@ -617,9 +624,11 @@ def _do_pre_chain(opts):
 
 def _do_set_skill(opts):
     skill_name = opts.get("skill", "")
+    reason = opts.get("reason", "")
+    chained_from = opts.get("chained_from", "")
     if not skill_name:
         return "Error: 'skill' option is required"
-    result = scan_session.set_skill(skill_name)
+    result = scan_session.set_skill(skill_name, reason=reason, chained_from=chained_from)
     if result is None:
         return "No active running session — cannot set skill."
 
@@ -630,10 +639,10 @@ def _do_set_skill(opts):
             scan_session.satisfy_gate(gate["id"], skill_name)
             satisfied_gates.append(gate["id"])
 
-    msg = f"Active skill set to: {skill_name}"
+    log.skill_start(skill_name, reason=reason, chained_from=chained_from)
+    msg = f"Skill '{skill_name}' logged"
     if satisfied_gates:
         msg += f" (satisfied gate(s): {', '.join(satisfied_gates)})"
-    log.note(msg)
     return msg
 
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -87,3 +87,52 @@ def test_note_logs_info(caplog):
     with caplog.at_level(logging.INFO, logger="pentest"):
         core.logger.note("Starting reconnaissance phase")
     assert any("NOTE" in r.message and "reconnaissance" in r.message for r in _get_log_records(caplog))
+
+
+def test_skill_start_logs_info(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("pentester", reason="user requested full pentest")
+    records = _get_log_records(caplog)
+    assert any(r.levelno == logging.INFO for r in records)
+
+
+def test_skill_start_uses_skill_start_tag(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("pentester", reason="initial skill")
+    assert any("SKILL_START" in r.message for r in _get_log_records(caplog))
+
+
+def test_skill_start_includes_skill_name(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("ai-redteam", reason="LLM target detected")
+    assert any("ai-redteam" in r.message for r in _get_log_records(caplog))
+
+
+def test_skill_start_includes_reason(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("osint", reason="passive recon phase")
+    assert any("passive recon phase" in r.message for r in _get_log_records(caplog))
+
+
+def test_skill_start_no_skill_start_tag_when_chaining(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("web-exploit", reason="endpoints found", chained_from="pentester")
+    assert not any("SKILL_START" in r.message for r in _get_log_records(caplog))
+
+
+def test_skill_chain_uses_skill_chain_tag(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("web-exploit", reason="endpoints found", chained_from="pentester")
+    assert any("SKILL_CHAIN" in r.message for r in _get_log_records(caplog))
+
+
+def test_skill_chain_includes_chained_from(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("credential-audit", reason="login form found", chained_from="web-exploit")
+    assert any("web-exploit" in r.message for r in _get_log_records(caplog))
+
+
+def test_skill_chain_includes_reason(caplog):
+    with caplog.at_level(logging.INFO, logger="pentest"):
+        core.logger.skill_start("post-exploit", reason="shell obtained", chained_from="metasploit")
+    assert any("shell obtained" in r.message for r in _get_log_records(caplog))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -228,10 +228,24 @@ def test_start_resets_cost_tracker():
 # Skill tracking
 # ---------------------------------------------------------------------------
 
+def _skill_names(sess):
+    """Extract ordered list of skill names from the rich skill_history."""
+    return [e["skill"] for e in sess["skill_history"]]
+
+
 def test_start_with_skill():
     sess = core.session.start("example.com", skill="pentester")
     assert sess["skill"] == "pentester"
-    assert sess["skill_history"] == ["pentester"]
+    assert _skill_names(sess) == ["pentester"]
+
+
+def test_start_skill_history_entry_has_required_keys():
+    sess = core.session.start("example.com", skill="pentester")
+    entry = sess["skill_history"][0]
+    assert entry["skill"] == "pentester"
+    assert entry["reason"] == "session start"
+    assert entry["chained_from"] is None
+    assert "timestamp" in entry
 
 
 def test_start_without_skill():
@@ -249,14 +263,43 @@ def test_set_skill_updates_active():
 def test_set_skill_appends_to_history():
     core.session.start("example.com", skill="pentester")
     core.session.set_skill("ai-redteam")
-    assert core.session.get()["skill_history"] == ["pentester", "ai-redteam"]
+    assert _skill_names(core.session.get()) == ["pentester", "ai-redteam"]
 
 
 def test_set_skill_no_duplicates_in_history():
     core.session.start("example.com", skill="pentester")
     core.session.set_skill("ai-redteam")
     core.session.set_skill("pentester")
-    assert core.session.get()["skill_history"] == ["pentester", "ai-redteam"]
+    assert _skill_names(core.session.get()) == ["pentester", "ai-redteam"]
+
+
+def test_set_skill_stores_reason():
+    core.session.start("example.com")
+    core.session.set_skill("web-exploit", reason="web app confirmed; systematic testing needed")
+    entry = core.session.get()["skill_history"][0]
+    assert entry["reason"] == "web app confirmed; systematic testing needed"
+
+
+def test_set_skill_stores_chained_from():
+    core.session.start("example.com", skill="pentester")
+    core.session.set_skill("web-exploit", reason="endpoints found", chained_from="pentester")
+    entry = core.session.get()["skill_history"][1]
+    assert entry["chained_from"] == "pentester"
+
+
+def test_set_skill_chained_from_none_when_omitted():
+    core.session.start("example.com")
+    core.session.set_skill("pentester", reason="initial skill")
+    entry = core.session.get()["skill_history"][0]
+    assert entry["chained_from"] is None
+
+
+def test_set_skill_history_entry_has_timestamp():
+    core.session.start("example.com")
+    core.session.set_skill("pentester")
+    entry = core.session.get()["skill_history"][0]
+    assert "timestamp" in entry
+    assert entry["timestamp"]  # non-empty
 
 
 def test_set_skill_returns_none_without_session():
@@ -275,7 +318,8 @@ def test_skill_persisted_to_file(tmp_path, monkeypatch):
     core.session.start("example.com", skill="pentester")
     data = json.loads((tmp_path / "session.json").read_text())
     assert data["skill"] == "pentester"
-    assert data["skill_history"] == ["pentester"]
+    assert data["skill_history"][0]["skill"] == "pentester"
+    assert data["skill_history"][0]["reason"] == "session start"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds SKILL_START / SKILL_CHAIN log entries so every skill invocation appears in pentest.log with the agent's reasoning and chain parent. skill_history in session.json is enriched from plain strings to objects carrying skill name, reason, chained_from, and timestamp.

- core/logger.py: add skill_start(name, reason, chained_from)
- core/session.py: set_skill() accepts reason + chained_from; skill_history stores dicts
- mcp_server/session_tools.py: thread reason/chained_from through set_skill and pre_chain; fix skill_history dict-aware check in _determine_resume_step
- CLAUDE.md: mandatory Skill Logging section + set_skill option docs
- tests: 10 new tests for logger and session skill tracking