### PR TITLE
feat: add Playwright-based spider mode for Hotwire/Turbo Frame apps

### DIFF
--- a/mcp_server/scan_tools.py
+++ b/mcp_server/scan_tools.py
@@ -71,19 +71,34 @@ async def _handle_ffuf(target, flags, options):
 
 async def _handle_spider(target, flags, options):
     from tools import kali_runner
+    import json as _json
 
+    mode = options.get("mode", "fast")
     depth = str(max(1, options.get("depth", 3)))
-    safe_url = shlex.quote(target)
-    safe_flags = shlex.join(shlex.split(flags)) if flags else ""
+    timeout = options.get("timeout", 900)
 
-    rate_flag = "" if "-rate-limit" in flags else "-rate-limit 50"
-    cmd = f"katana -u {safe_url} -d {depth} -silent -no-color {rate_flag}".strip()
-    if safe_flags:
-        cmd += f" {safe_flags}"
-
-    log.tool_call("spider", {"url": target, "depth": depth, "flags": flags})
+    log.tool_call("spider", {"url": target, "depth": depth, "mode": mode, "flags": flags})
     call_id = cost_tracker.start("spider")
-    result = _clip(await kali_runner.exec_command(cmd, timeout=900), 8_000)
+
+    if mode == "playwright":
+        cookies = options.get("cookies", {})
+        max_pages = str(options.get("max_pages", 200))
+        safe_url = shlex.quote(target)
+        safe_cookies = shlex.quote(_json.dumps(cookies))
+        cmd = (
+            f"playwright-spider --url {safe_url} --cookies {safe_cookies} "
+            f"--depth {depth} --max-pages {max_pages}"
+        )
+    else:
+        # Default: katana (fast mode)
+        safe_url = shlex.quote(target)
+        safe_flags = shlex.join(shlex.split(flags)) if flags else ""
+        rate_flag = "" if "-rate-limit" in flags else "-rate-limit 50"
+        cmd = f"katana -u {safe_url} -d {depth} -silent -no-color {rate_flag}".strip()
+        if safe_flags:
+            cmd += f" {safe_flags}"
+
+    result = _clip(await kali_runner.exec_command(cmd, timeout=timeout), 8_000)
     _record("spider")
     cost_tracker.finish(call_id, result)
     log.tool_result("spider", result)
@@ -292,7 +307,7 @@ async def scan(tool: str, target: str, flags: str = "", options: dict | None = N
     | httpx      | URL         |                                                   |
     | nuclei     | URL         | templates=cve,exposure,misconfig,default-login    |
     | ffuf       | URL         | wordlist=common.txt, extensions=                  |
-    | spider     | URL         | depth=3                                           |
+    | spider     | URL         | depth=3, mode=fast|playwright, cookies={}, max_pages=200 |
     | semgrep    | path        |                                                   |
     | trufflehog | path        |                                                   |
     | fuzzyai    | URL         | attack=jailbreak, provider=openai, model=         |

--- a/tools/kali/playwright_spider.py
+++ b/tools/kali/playwright_spider.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Playwright-based web spider with Hotwire/Turbo Frame support.
+
+Crawls up to --depth levels using headless Chromium, injects session cookies,
+waits for turbo-frame lazy-loaded content, and re-fetches every
+<turbo-frame src=...> URL explicitly to capture dynamically loaded content.
+
+Usage:
+    playwright-spider --url https://example.com --depth 3
+    playwright-spider --url https://example.com --cookies '{"_session_id":"abc"}' --depth 2
+    playwright-spider --url https://example.com --max-pages 100
+"""
+import argparse
+import asyncio
+import json
+import sys
+from urllib.parse import urljoin, urlparse, urlunparse
+
+
+def _same_origin(url: str, base_domain: str) -> bool:
+    return urlparse(url).netloc == base_domain
+
+
+def _normalise(url: str) -> str:
+    """Strip query string and fragment so dedup works on canonical paths."""
+    p = urlparse(url)
+    return urlunparse((p.scheme, p.netloc, p.path, "", "", ""))
+
+
+async def spider(base_url: str, cookies: dict, depth: int, max_pages: int = 200) -> None:
+    from playwright.async_api import async_playwright
+
+    base_domain = urlparse(base_url).netloc
+    visited: set[str] = set()
+    found_urls: set[str] = set()
+    found_forms: set[str] = set()
+    queue: list[tuple[str, int]] = [(base_url, 0)]
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(
+            headless=True,
+            # --remote-debugging-port=0 → random ephemeral port (never 5000)
+            args=["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu", "--remote-debugging-port=0"],
+        )
+        context = await browser.new_context(
+            ignore_https_errors=True,
+            user_agent=(
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            ),
+        )
+
+        if cookies:
+            await context.add_cookies(
+                [{"name": k, "value": v, "domain": base_domain, "path": "/"} for k, v in cookies.items()]
+            )
+
+        async def _fetch_page(url: str, timeout_ms: int = 30_000) -> object | None:
+            page = await context.new_page()
+            try:
+                try:
+                    await page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+                except Exception:
+                    await page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms // 2)
+                return page
+            except Exception as exc:
+                print(f"[warn] {url}: {exc}", file=sys.stderr)
+                await page.close()
+                return None
+
+        async def _collect(page, base: str, current_depth: int) -> None:
+            """Extract links, forms, and turbo-frame srcs from an open page."""
+            # Turbo Frame srcs — re-fetch each one explicitly
+            turbo_srcs: list[str] = await page.eval_on_selector_all(
+                "turbo-frame[src]",
+                "els => els.map(e => e.getAttribute('src')).filter(Boolean)",
+            )
+            for raw_src in turbo_srcs:
+                full_src = urljoin(base, raw_src)
+                if not _same_origin(full_src, base_domain):
+                    continue
+                norm_src = _normalise(full_src)
+                found_urls.add(norm_src)
+                if norm_src not in visited:
+                    # Treat turbo-frame srcs as same depth — they are lazy loads, not navigation
+                    queue.append((norm_src, current_depth))
+
+            # Regular anchor links
+            links: list[str] = await page.eval_on_selector_all(
+                "a[href]",
+                "els => els.map(e => e.href).filter("
+                "  h => h && !h.startsWith('mailto:') && !h.startsWith('javascript:')"
+                ")",
+            )
+            for lnk in links:
+                if _same_origin(lnk, base_domain):
+                    found_urls.add(lnk)
+                    if lnk not in visited and current_depth < depth:
+                        queue.append((lnk, current_depth + 1))
+
+            # Form actions
+            form_actions: list[str] = await page.eval_on_selector_all(
+                "form[action]",
+                "els => els.map(e => e.getAttribute('action')).filter(Boolean)",
+            )
+            for act in form_actions:
+                found_forms.add(urljoin(base, act))
+
+        # BFS crawl
+        while queue and len(visited) < max_pages:
+            url, d = queue.pop(0)
+
+            # Deduplicate — a URL may appear multiple times in the queue
+            if url in visited:
+                continue
+            if not _same_origin(url, base_domain):
+                continue
+
+            visited.add(url)
+            found_urls.add(url)
+
+            page = await _fetch_page(url)
+            if page is None:
+                continue
+            try:
+                await _collect(page, url, d)
+            finally:
+                await page.close()
+
+        await browser.close()
+
+    for u in sorted(found_urls | found_forms):
+        print(u)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Playwright-based web spider with Turbo Frame support")
+    parser.add_argument("--url", required=True, help="Target URL")
+    parser.add_argument("--cookies", default="{}", help="JSON dict of session cookies")
+    parser.add_argument("--depth", type=int, default=3, help="Maximum crawl depth (default: 3)")
+    parser.add_argument("--max-pages", type=int, default=200, help="Maximum pages to visit (default: 200)")
+    args = parser.parse_args()
+
+    try:
+        cookies = json.loads(args.cookies)
+    except json.JSONDecodeError as exc:
+        print(f"[error] Invalid --cookies JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    asyncio.run(spider(args.url, cookies, args.depth, args.max_pages))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a headless Chromium spider (playwright_spider.py) that handles dynamically loaded content via Turbo Frames — catching routes that katana misses in JS-heavy Rails apps. Wired into scan(tool="spider") as mode=playwright with cookie injection, configurable depth, and max_pages cap.