### PR TITLE
feat: merge small-model-testing improvements into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # ── Scan output ──────────────────────────────────────────────────────────────
+artifacts/
 logs/
 findings.json
 coverage_matrix.json
@@ -7,6 +8,8 @@ session_cost.json
 pocs/
 gh-issues.md
 threat-model/
+quick_log.json
+qa_state.json
 
 # ── Test coverage ────────────────────────────────────────────────────────────
 coverage.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Run any security scanner.
 | httpx | URL | |
 | nuclei | URL | templates=cve,exposure,misconfig,default-login |
 | ffuf | URL | wordlist=common.txt, extensions= |
-| spider | URL | depth=3 |
+| spider | URL | depth=3, mode=fast\|playwright, cookies={}, max_pages=200 |
 | semgrep | path | |
 | trufflehog | path | |
 | fuzzyai | URL | attack=jailbreak, provider=openai, model= |
@@ -48,10 +48,11 @@ Log findings, diagrams, notes, and coverage matrix updates.
 
 ### `session(action, options)`
 Scan lifecycle and infrastructure.
-- `action="start"` — options: `{target, depth, scope, out_of_scope, max_cost_usd, max_time_minutes, max_tool_calls}`
+- `action="start"` — options: `{target, depth, scope, out_of_scope, max_cost_usd, max_time_minutes, max_tool_calls, model_profile=full}` (model_profile: full|medium|small)
 - `action="complete"` — options: `{notes}`
 - `action="status"` — returns current scan state (tools run, findings count, cost, remaining calls)
-- `action="recovery"` — returns compact recovery brief after context compaction
+- `action="recovery"` — returns compact recovery brief after context compaction; includes `EXECUTE_NOW` with the next concrete tool call
+- `action="artifact"` — options: `{id, mode=summary, max_chars=4000, pattern=}` — retrieve raw tool output stored by the scan engine
 - `action="start_kali"` / `action="stop_kali"` — Kali container lifecycle
 - `action="start_metasploit"` / `action="stop_metasploit"` — Metasploit container lifecycle
 - `action="pull_images"` — pre-pull all Docker images

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -245,6 +245,13 @@ async def api_clear() -> JSONResponse:
     # findings.json
     _save({"meta": {"created": "", "target": ""}, "findings": [], "diagrams": []})
 
+    # Reset in-memory coverage state before unlinking the file
+    try:
+        from core.coverage import reset as _reset_coverage
+        await _reset_coverage()
+    except Exception:
+        pass
+
     # session.json, coverage_matrix.json, quick_log.json, qa_state.json, session_cost.json
     for path in (_SESSION_FILE, _COVERAGE_FILE, _QUICK_LOG_FILE, _QA_STATE_FILE, _COST_FILE):
         try:

--- a/core/session.py
+++ b/core/session.py
@@ -84,6 +84,7 @@ def start(
     max_time_minutes: int   | None = None,
     max_tool_calls:   int   | None = None,
     skill:            str   | None = None,
+    model_profile:    str        = "full",
 ) -> dict:
     """Initialise a new scan session and write session.json."""
     global _current
@@ -123,6 +124,13 @@ def start(
         "tools_called":  [],
         "current_step":  None,
         "gates":         [],          # triggered gates that block completion
+        "model_profile": model_profile,
+        "tool_invocations": [],
+        "known_assets": {
+            "domains": [], "ips": [], "ports": [],
+            "technologies": [], "endpoints": [],
+        },
+        "context_chars_sent": 0,
     }
     _flush()
     return _current
@@ -295,6 +303,71 @@ def pending_gates() -> list[dict]:
     if _current is None:
         return []
     return [g for g in _current.get("gates", []) if g.get("status") == "pending"]
+
+
+def add_tool_invocation(tool: str, target: str, summary: str, options_hash: str = "") -> None:
+    """Record a tool invocation with summary for dedup and recovery."""
+    if not _current or _current.get("status") != "running":
+        return
+    invocations = _current.setdefault("tool_invocations", [])
+    if options_hash and any(i.get("options_hash") == options_hash for i in invocations):
+        return  # Duplicate — already recorded
+    invocations.append({
+        "seq": len(invocations) + 1,
+        "tool": tool,
+        "target": target,
+        "options_hash": options_hash,
+        "summary": summary[:200],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })
+    if len(invocations) > 100:
+        _current["tool_invocations"] = invocations[-100:]
+    _flush()
+
+
+def update_known_assets(asset_type: str, items: list) -> None:
+    """Accumulate discovered assets into session.json['known_assets']."""
+    if not _current or _current.get("status") != "running" or not items:
+        return
+    assets = _current.setdefault("known_assets", {
+        "domains": [], "ips": [], "ports": [],
+        "technologies": [], "endpoints": [],
+    })
+    if asset_type == "ports":
+        existing = {(p.get("host", ""), p.get("port", 0)) for p in assets.get("ports", [])}
+        for item in items:
+            if isinstance(item, dict):
+                key = (item.get("host", ""), item.get("port", 0))
+                if key not in existing:
+                    assets.setdefault("ports", []).append(item)
+                    existing.add(key)
+    else:
+        target_list = assets.setdefault(asset_type, [])
+        existing = set(target_list)
+        for item in items:
+            val = item if isinstance(item, str) else str(item)
+            if val and val not in existing:
+                target_list.append(val)
+                existing.add(val)
+    _flush()
+
+
+def charge_context(chars: int) -> None:
+    """Track cumulative response chars sent to the model."""
+    if _current and _current.get("status") == "running":
+        _current["context_chars_sent"] = _current.get("context_chars_sent", 0) + chars
+        _flush()
+
+
+def get_context_pressure(profile: dict) -> float:
+    """Return context pressure as 0.0-1.0 ratio. Returns 0.0 if no budget set."""
+    if _current is None:
+        return 0.0
+    budget = profile.get("context_budget_chars")
+    if not budget:
+        return 0.0
+    sent = _current.get("context_chars_sent", 0)
+    return min(1.0, sent / budget)
 
 
 def remaining(cost_summary: dict) -> dict:

--- a/mcp_server/http_tools.py
+++ b/mcp_server/http_tools.py
@@ -82,7 +82,9 @@ async def _do_request(url, method, headers, body, opts):
         })
     cost_tracker.finish(call_id, result)
     log.tool_result("http_request", result)
-    return _inject_qa_alerts(result)
+
+    from mcp_server.scan_engine import wrap
+    return _inject_qa_alerts(wrap("http_request", result, {"url": url, "method": method}))
 
 
 def _do_save_poc(url, method, headers, body, opts):

--- a/mcp_server/kali_tools.py
+++ b/mcp_server/kali_tools.py
@@ -31,4 +31,7 @@ async def kali(command: str, timeout: int = 600) -> str:
     result = _clip(raw_output, 8_000)
     cost_tracker.finish(call_id, result)
     log.tool_result("kali", result)
-    return _inject_qa_alerts(result)
+
+    from mcp_server.scan_engine import wrap
+    tool_key = "kali_sqlmap" if command.strip().startswith("sqlmap") else "kali"
+    return _inject_qa_alerts(wrap(tool_key, raw_output, {"command": command, "_tool": tool_key}))

--- a/mcp_server/report_tools.py
+++ b/mcp_server/report_tools.py
@@ -36,10 +36,18 @@ _CLOUD_KEYWORDS = (
 _CLOUD_METADATA_PREFIX = "169.254."
 
 # Keywords in notes that indicate internal network discovery — triggers network gate.
+# Deliberately broad: agents write notes in many styles ("172.18.0.0/24", "host at 10.",
+# "docker network", "reachable from DB container", etc.) — all should fire the gate.
 _INTERNAL_NET_KEYWORDS = (
-    "internal subnet", "internal network", "live hosts on 10.",
-    "live hosts on 172.", "live hosts on 192.168.",
-    "non-public subnet", "pivot",
+    # Explicit phrasing
+    "internal subnet", "internal network", "non-public subnet",
+    "live hosts on 10.", "live hosts on 172.", "live hosts on 192.168.",
+    # Natural phrasing agents actually write
+    "docker network", "container network", "host at 10.", "host at 172.",
+    "hosts at 10.", "hosts at 172.", "hosts at 192.168.",
+    "reachable from", "pivot", "10.0.", "10.1.", "10.2.", "10.10.",
+    "172.16.", "172.17.", "172.18.", "172.19.", "172.20.",
+    "192.168.", "subnet /24", "subnet /16",
 )
 
 # Keywords that indicate auth services — triggers credential-audit gate.
@@ -92,8 +100,15 @@ async def report(action: str, data: Any) -> str:
 
       reset — clear the entire matrix (no additional fields)
     """
-    if isinstance(data, str):
-        data = json.loads(data)
+    try:
+        if isinstance(data, str):
+            data = json.loads(data)
+    except (json.JSONDecodeError, TypeError) as exc:
+        log.note(f"report({action}) data parse error: {exc} — raw: {str(data)[:200]}")
+        return f"Error: could not parse data as JSON: {exc}"
+    if not isinstance(data, dict):
+        log.note(f"report({action}) data is not a dict: {type(data).__name__}")
+        return f"Error: data must be a JSON object/dict, got {type(data).__name__}"
     if action == "finding":
         return await _do_finding(data)
     elif action == "update_finding":
@@ -292,21 +307,59 @@ async def _do_coverage(data):
     from core import coverage as cov
 
     cov_type = data.get("type", "")
+    log.note(f"coverage({cov_type}): {json.dumps(data)[:300]}")
+
+    # --- Resilience: auto-detect type from data shape ---
+    if not cov_type:
+        if "path" in data:
+            cov_type = "endpoint"
+        elif "cell_id" in data:
+            cov_type = "tested"
+        elif "updates" in data:
+            cov_type = "bulk_tested"
 
     if cov_type == "endpoint":
+        path = data.get("path", "")
+        if not path:
+            return (
+                "Error: 'path' is required for endpoint registration. "
+                "Example: report(action='coverage', data={type:'endpoint', path:'/login', "
+                "method:'GET', params:[{name:'q', type:'query', value_hint:'string'}]})"
+            )
+
+        # Resilience: coerce params from various model formats
+        params = data.get("params", [])
+        if isinstance(params, str):
+            try:
+                params = json.loads(params)
+            except json.JSONDecodeError:
+                params = []
+        if not isinstance(params, list):
+            params = []
+        clean_params = []
+        for p in params:
+            if isinstance(p, str):
+                clean_params.append({"name": p, "type": "query", "value_hint": "string"})
+            elif isinstance(p, dict):
+                clean_params.append({
+                    "name": p.get("name", p.get("param", "")),
+                    "type": p.get("type", p.get("param_type", "query")),
+                    "value_hint": p.get("value_hint", p.get("hint", "string")),
+                })
+
         result = await cov.add_endpoint(
-            path=data.get("path", ""),
+            path=path,
             method=data.get("method", "GET"),
-            params=data.get("params", []),
+            params=clean_params,
             discovered_by=data.get("discovered_by", "spider"),
             auth_context=data.get("auth_context", "none"),
         )
         if result["dedup"]:
-            return f"Endpoint already registered (dedup): {data.get('path')} {data.get('method', 'GET')}"
+            return f"Endpoint already registered (dedup): {path} {data.get('method', 'GET')}"
         # Emit COVERAGE event after endpoint registration
         await _emit_coverage_event()
         return (
-            f"Endpoint registered: {data.get('method', 'GET')} {data.get('path')} — "
+            f"Endpoint registered: {data.get('method', 'GET')} {path} — "
             f"{result['new_cells']} test cells auto-generated"
         )
 
@@ -336,11 +389,24 @@ async def _do_coverage(data):
         return msg
 
     elif cov_type == "reset":
+        current = scan_session.get()
+        if current and current.get("status") == "running":
+            log.note("coverage reset BLOCKED — scan is active. Do NOT reset the matrix mid-scan.")
+            return (
+                "BLOCKED: Cannot reset coverage matrix while a scan is running. "
+                "The matrix tracks your testing progress — resetting it mid-scan destroys that state. "
+                "If you need to re-register endpoints, just call coverage(type='endpoint') again — "
+                "duplicates are automatically ignored."
+            )
         await cov.reset()
         return "Coverage matrix reset."
 
     else:
-        return f"Unknown coverage type '{cov_type}'. Use: endpoint, tested, bulk_tested, reset"
+        return (
+            f"Unknown coverage type '{cov_type}'. Use: endpoint, tested, bulk_tested, reset. "
+            f"Example: report(action='coverage', data={{type:'endpoint', path:'/login', method:'GET', "
+            f"params:[{{name:'user', type:'query', value_hint:'string'}}]}})"
+        )
 
 
 async def _emit_coverage_event() -> None:

--- a/mcp_server/scan_engine/__init__.py
+++ b/mcp_server/scan_engine/__init__.py
@@ -1,0 +1,19 @@
+"""
+Scan Engine — context-lean stateful scan engine for small-context LLMs.
+
+All tool responses pass through wrap() which:
+1. Stores raw output as a retrievable artifact
+2. Runs a tool-specific summarizer to extract facts
+3. Enforces per-tool character budgets
+4. Returns a canonical envelope (same shape for every tool)
+
+Usage in tool wrappers:
+    from mcp_server.scan_engine import wrap, retrieve_artifact
+
+    raw = await run_scanner(...)
+    return wrap("httpx", raw, context={"url": target})
+"""
+from mcp_server.scan_engine.envelope import wrap, Envelope
+from mcp_server.scan_engine.artifacts import retrieve_artifact
+
+__all__ = ["wrap", "retrieve_artifact", "Envelope"]

--- a/mcp_server/scan_engine/artifacts.py
+++ b/mcp_server/scan_engine/artifacts.py
@@ -1,0 +1,94 @@
+"""
+Artifact storage — raw tool output stored on disk, retrievable by ID.
+
+Artifacts keep raw output out of the LLM context window while preserving
+full audit trail. Retrieval is bounded: callers specify a mode and max_chars.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+_ARTIFACTS_DIR = Path(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))) / "artifacts"
+
+
+def _ensure_dir() -> Path:
+    _ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    return _ARTIFACTS_DIR
+
+
+def store_artifact(tool: str, raw_output: str) -> str:
+    """Store raw output and return an artifact ID."""
+    artifact_id = f"{tool}_{datetime.now(timezone.utc).strftime('%H%M%S')}_{uuid.uuid4().hex[:8]}"
+    path = _ensure_dir() / f"{artifact_id}.txt"
+    path.write_text(raw_output, encoding="utf-8")
+    return artifact_id
+
+
+def retrieve_artifact(
+    artifact_id: str,
+    mode: str = "summary",
+    max_chars: int = 4000,
+    pattern: str = "",
+) -> str:
+    """Retrieve artifact content with bounded output.
+
+    Modes:
+        summary — first max_chars characters
+        head    — first max_chars characters (alias for summary)
+        tail    — last max_chars characters
+        grep    — lines matching pattern, up to max_chars
+        full    — full content, hard-capped at max_chars
+
+    Returns JSON with {artifact_id, mode, chars_returned, total_chars, content}.
+    """
+    path = _ARTIFACTS_DIR / f"{artifact_id}.txt"
+    if not path.exists():
+        return json.dumps({"error": f"Artifact not found: {artifact_id}"})
+
+    raw = path.read_text(encoding="utf-8")
+    total = len(raw)
+
+    if mode in ("summary", "head"):
+        content = raw[:max_chars]
+    elif mode == "tail":
+        content = raw[-max_chars:] if total > max_chars else raw
+    elif mode == "grep":
+        if not pattern:
+            return json.dumps({"error": "grep mode requires a pattern"})
+        import re
+        try:
+            regex = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            return json.dumps({"error": f"Invalid regex: {e}"})
+        matches = [line for line in raw.splitlines() if regex.search(line)]
+        content = "\n".join(matches)[:max_chars]
+    elif mode == "full":
+        content = raw[:max_chars]
+    else:
+        return json.dumps({"error": f"Unknown mode: {mode}. Use: summary, head, tail, grep, full"})
+
+    return json.dumps({
+        "artifact_id": artifact_id,
+        "mode": mode,
+        "chars_returned": len(content),
+        "total_chars": total,
+        "truncated": len(content) < total,
+        "content": content,
+    })
+
+
+def cleanup_artifacts(max_age_hours: int = 24) -> int:
+    """Remove artifacts older than max_age_hours. Returns count deleted."""
+    if not _ARTIFACTS_DIR.exists():
+        return 0
+    cutoff = datetime.now(timezone.utc).timestamp() - (max_age_hours * 3600)
+    deleted = 0
+    for f in _ARTIFACTS_DIR.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            f.unlink()
+            deleted += 1
+    return deleted

--- a/mcp_server/scan_engine/budget.py
+++ b/mcp_server/scan_engine/budget.py
@@ -1,0 +1,144 @@
+"""
+Budget enforcement — model-profile-aware character caps per tool.
+
+Each tool has a base budget. Model profiles scale these budgets:
+- full: no enforcement (large-context models like Claude)
+- medium: base budgets as-is (64K context models)
+- small: half budgets (16-32K context models)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp_server.scan_engine.envelope import Envelope
+
+
+# ---------------------------------------------------------------------------
+# Model profiles
+# ---------------------------------------------------------------------------
+
+MODEL_PROFILES: dict[str, dict] = {
+    "full": {
+        "enforce_budget": False,     # No output limits — go full in
+        "budget_multiplier": 1.0,    # unused when enforce_budget=False
+        "context_budget_chars": None,  # no context tracking limit
+        "recovery_cells_shown": None,  # show all cells in recovery
+        "execute_next_in_summary": True,  # still useful, harmless for large models
+    },
+    "medium": {
+        "enforce_budget": True,
+        "budget_multiplier": 1.0,    # base budgets as-is
+        "context_budget_chars": 160_000,  # ~40K tokens
+        "recovery_cells_shown": 10,
+        "execute_next_in_summary": True,
+    },
+    "small": {
+        "enforce_budget": True,
+        "budget_multiplier": 0.5,    # half budgets
+        "context_budget_chars": 64_000,  # ~16K tokens
+        "recovery_cells_shown": 3,
+        "execute_next_in_summary": True,
+    },
+}
+
+
+def get_profile(profile_name: str | None = None) -> dict:
+    """Get model profile. Reads from session if not specified."""
+    if profile_name is None:
+        from core import session as scan_session
+        current = scan_session.get()
+        profile_name = (current or {}).get("model_profile", "full")
+    return MODEL_PROFILES.get(profile_name, MODEL_PROFILES["full"])
+
+
+# ---------------------------------------------------------------------------
+# Per-tool budgets (base values — scaled by profile multiplier)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ToolBudget:
+    max_chars: int
+    max_facts: int = 15
+    max_evidence_chars: int = 2000
+
+
+# Base budgets — tuned for medium profile (current values).
+TOOL_BUDGETS: dict[str, ToolBudget] = {
+    "httpx":         ToolBudget(max_chars=3000, max_facts=10, max_evidence_chars=1500),
+    "http_request":  ToolBudget(max_chars=4000, max_facts=12, max_evidence_chars=2000),
+    "kali_sqlmap":   ToolBudget(max_chars=4000, max_facts=15, max_evidence_chars=2000),
+    "kali":          ToolBudget(max_chars=5000, max_facts=15, max_evidence_chars=2500),
+    "naabu":         ToolBudget(max_chars=2500, max_facts=10, max_evidence_chars=1000),
+    "nmap":          ToolBudget(max_chars=3000, max_facts=10, max_evidence_chars=1500),
+    "subfinder":     ToolBudget(max_chars=2500, max_facts=20, max_evidence_chars=1000),
+    "nuclei":        ToolBudget(max_chars=4000, max_facts=20, max_evidence_chars=2000),
+    "spider":        ToolBudget(max_chars=4000, max_facts=30, max_evidence_chars=2000),
+    "ffuf":          ToolBudget(max_chars=4000, max_facts=25, max_evidence_chars=2000),
+    "_default":      ToolBudget(max_chars=5000, max_facts=15, max_evidence_chars=2500),
+}
+
+
+def get_tool_budget(tool: str) -> ToolBudget:
+    """Get profile-scaled budget for a tool."""
+    profile = get_profile()
+    base = TOOL_BUDGETS.get(tool, TOOL_BUDGETS["_default"])
+    if not profile.get("enforce_budget", True):
+        # Full profile: very generous limits (effectively no enforcement)
+        return ToolBudget(
+            max_chars=base.max_chars * 10,
+            max_facts=base.max_facts * 5,
+            max_evidence_chars=base.max_evidence_chars * 5,
+        )
+    mult = profile.get("budget_multiplier", 1.0)
+    return ToolBudget(
+        max_chars=max(500, int(base.max_chars * mult)),
+        max_facts=max(3, int(base.max_facts * mult)),
+        max_evidence_chars=max(200, int(base.max_evidence_chars * mult)),
+    )
+
+
+def enforce_budget(env: "Envelope", budget: ToolBudget, artifact_id: str) -> "Envelope":
+    """Enforce character budget on an envelope. Mutates and returns env."""
+    import json
+
+    # Truncate facts list
+    if len(env.facts) > budget.max_facts:
+        dropped = len(env.facts) - budget.max_facts
+        env.facts = env.facts[:budget.max_facts]
+        env.warnings.append(f"Truncated {dropped} fact(s) — retrieve full output: artifact={artifact_id}")
+
+    # Truncate evidence
+    ev_str = json.dumps(env.evidence)
+    if len(ev_str) > budget.max_evidence_chars:
+        # Keep only the first N chars worth of evidence keys
+        trimmed: dict = {}
+        current = 2  # {}
+        for k, v in env.evidence.items():
+            entry = json.dumps({k: v})
+            if current + len(entry) > budget.max_evidence_chars:
+                break
+            trimmed[k] = v
+            current += len(entry)
+        dropped_keys = set(env.evidence.keys()) - set(trimmed.keys())
+        env.evidence = trimmed
+        if dropped_keys:
+            env.warnings.append(
+                f"Evidence truncated ({len(dropped_keys)} key(s) dropped) — "
+                f"artifact={artifact_id}"
+            )
+
+    # Final envelope size check
+    serialized = env.to_json()
+    if len(serialized) > budget.max_chars:
+        # Emergency truncation: cut facts from the end until we fit
+        while len(env.to_json()) > budget.max_chars and env.facts:
+            env.facts.pop()
+        if len(env.to_json()) > budget.max_chars:
+            # Last resort: truncate summary
+            overage = len(env.to_json()) - budget.max_chars
+            env.summary = env.summary[:max(50, len(env.summary) - overage)] + "..."
+        env.warnings.append(f"Envelope exceeded {budget.max_chars} char budget — content truncated")
+
+    return env

--- a/mcp_server/scan_engine/envelope.py
+++ b/mcp_server/scan_engine/envelope.py
@@ -1,0 +1,170 @@
+"""
+Canonical response envelope — every tool returns this exact shape.
+
+The envelope is the only thing that enters the LLM context window.
+Raw output lives in artifacts, referenced by artifact_id.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from typing import Any
+
+from mcp_server.scan_engine.artifacts import store_artifact
+from mcp_server.scan_engine.budget import enforce_budget, get_tool_budget, get_profile
+from mcp_server.scan_engine.planner import compute_next
+from mcp_server.scan_engine.state import get_state
+from mcp_server.scan_engine.summarizers import summarize
+
+
+@dataclass
+class Envelope:
+    summary: str = ""
+    facts: list[str] = field(default_factory=list)
+    anomalies: list[str] = field(default_factory=list)
+    evidence: dict[str, Any] = field(default_factory=dict)
+    next: dict[str, list[str]] = field(default_factory=lambda: {"required": [], "recommended": []})
+    artifact: str | None = None
+    session_state: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+def wrap(tool: str, raw_output: str, context: dict | None = None) -> str:
+    """Central entry point: raw tool output in, canonical envelope JSON out.
+
+    Args:
+        tool: tool name (e.g. "httpx", "http_request", "kali_sqlmap")
+        raw_output: the raw string output from the tool
+        context: tool-specific context (url, method, params, etc.)
+
+    Returns:
+        JSON string of the canonical envelope
+    """
+    ctx = context or {}
+
+    # 1. Store raw output as artifact
+    artifact_id = store_artifact(tool, raw_output)
+
+    # 2. Run tool-specific summarizer
+    result = summarize(tool, raw_output, ctx)
+
+    # 2a. Record tool invocation with summary (P1 — dedup + recovery)
+    _record_invocation(tool, ctx, result.summary)
+
+    # 2b. Extract and persist known assets (P2 — auto-accumulation)
+    _extract_and_persist_assets(tool, result, ctx)
+
+    # 3. Compute server-determined state and planner next-actions
+    state = get_state()
+    plan = compute_next(tool, state)
+
+    # Merge: planner required/recommended take priority, summarizer adds tool-specific ones
+    merged_required = plan["required"] + result.required
+    merged_recommended = plan["recommended"] + result.recommended
+    warnings = plan["warnings"]
+
+    # 4. Build envelope — prepend first required action to summary so models see it
+    summary = result.summary
+    if merged_required:
+        # Skip planner "Start scan" directives if session is already running
+        actionable = [r for r in merged_required if not r.startswith("Start scan:")]
+        if actionable:
+            summary += f"\n\nEXECUTE NEXT: {actionable[0]}"
+            if len(actionable) > 1:
+                summary += f"\n(then {len(actionable) - 1} more required action(s) in next.required)"
+
+    env = Envelope(
+        summary=summary,
+        facts=result.facts,
+        anomalies=result.anomalies,
+        evidence=result.evidence,
+        next={"required": merged_required, "recommended": merged_recommended},
+        artifact=artifact_id,
+        session_state=state,
+        warnings=warnings,
+    )
+
+    # 5. Enforce budget (profile-aware) — may truncate facts/evidence
+    budget = get_tool_budget(tool)
+    enforced = enforce_budget(env, budget, artifact_id)
+
+    # 6. Context tracking (P4) — charge and check pressure
+    json_str = enforced.to_json()
+    json_str = _check_context_pressure(enforced, json_str)
+
+    return json_str
+
+
+# ---------------------------------------------------------------------------
+# P1 — Tool invocation recording
+# ---------------------------------------------------------------------------
+
+def _record_invocation(tool: str, ctx: dict, summary: str) -> None:
+    """Record tool invocation with summary for dedup and recovery."""
+    import hashlib
+    from core import session as scan_session
+    target = ctx.get("url", ctx.get("host", ctx.get("domain", ctx.get("path", ""))))
+    hash_input = f"{tool}:{target}:{sorted(ctx.items())}"
+    options_hash = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
+    scan_session.add_tool_invocation(tool, target, summary, options_hash)
+
+
+# ---------------------------------------------------------------------------
+# P2 — Known assets extraction
+# ---------------------------------------------------------------------------
+
+def _extract_and_persist_assets(tool: str, result: Any, ctx: dict) -> None:
+    """Extract discovered assets from summarizer result and persist to session."""
+    from core import session as scan_session
+    evidence = result.evidence
+
+    if tool == "httpx":
+        tech = evidence.get("tech", [])
+        if tech:
+            scan_session.update_known_assets(
+                "technologies", tech if isinstance(tech, list) else [tech])
+        server = evidence.get("server")
+        if server:
+            scan_session.update_known_assets("technologies", [server])
+    elif tool in ("naabu", "nmap"):
+        ports = evidence.get("ports", [])
+        hosts = evidence.get("hosts", [])
+        host = hosts[0] if hosts else ctx.get("host", "")
+        if ports:
+            scan_session.update_known_assets(
+                "ports", [{"host": host, "port": p} for p in ports])
+        if hosts:
+            scan_session.update_known_assets("domains", hosts)
+    elif tool == "subfinder":
+        subs = evidence.get("subdomains", [])
+        if subs:
+            scan_session.update_known_assets("domains", subs[:50])
+    elif tool == "spider":
+        endpoints = evidence.get("endpoints", [])
+        if endpoints:
+            scan_session.update_known_assets(
+                "endpoints",
+                [ep.get("path", "") for ep in endpoints if ep.get("path")])
+
+
+# ---------------------------------------------------------------------------
+# P4 — Context pressure tracking
+# ---------------------------------------------------------------------------
+
+def _check_context_pressure(env: Envelope, json_str: str) -> str:
+    """Track context usage and inject warning if pressure exceeds 80%."""
+    from core import session as scan_session
+    scan_session.charge_context(len(json_str))
+    profile = get_profile()
+    pressure = scan_session.get_context_pressure(profile)
+    if pressure > 0.8:
+        pct = int(pressure * 100)
+        env.warnings.append(
+            f"CONTEXT_WARNING: ~{pct}% of context budget used. "
+            f"Consider calling session(action='recovery') to compact."
+        )
+        return env.to_json()
+    return json_str

--- a/mcp_server/scan_engine/planner.py
+++ b/mcp_server/scan_engine/planner.py
@@ -1,0 +1,213 @@
+"""
+Coverage-driven planner — computes next actions and detects behavioral drift.
+
+Called by the envelope wrapper on every tool response. Returns required actions
+(obligations the model must fulfill) and recommended actions (suggestions).
+Also detects drift: duplicate tests, phase-inappropriate tools, skipped coverage.
+"""
+from __future__ import annotations
+
+from core import session as scan_session
+from core.coverage import get_matrix
+
+
+def compute_next(tool: str, state: dict) -> dict:
+    """Compute next actions based on current state.
+
+    Returns {"required": [...], "recommended": [...], "warnings": [...]}.
+    """
+    required: list[str] = []
+    recommended: list[str] = []
+    warnings: list[str] = []
+
+    phase = state.get("phase", "idle")
+    tools_run = set(state.get("tools_run", []))
+    target = state.get("target", "")
+
+    if phase == "idle":
+        required.append(f"Start scan: session(action='start', options={{target: '{target}', depth: 'thorough'}})")
+        return {"required": required, "recommended": recommended, "warnings": warnings}
+
+    # --- Drift detection ---
+    drift = _detect_drift(tool, phase, tools_run)
+    warnings.extend(drift)
+
+    # --- Phase-specific next actions ---
+    if phase == "recon":
+        if "httpx" not in tools_run:
+            required.append(f"Run httpx: scan(tool='httpx', target='{target}')")
+        if "naabu" not in tools_run and "nmap" not in tools_run:
+            recommended.append(f"Port scan: scan(tool='naabu', target='{target}')")
+        if "subfinder" not in tools_run:
+            recommended.append(f"Subdomain enum: scan(tool='subfinder', target='{target}')")
+
+    elif phase == "discovery":
+        if "spider" not in tools_run:
+            required.append(f"Crawl endpoints: scan(tool='spider', target='{target}')")
+        else:
+            required.append(
+                "Register endpoints in coverage matrix: "
+                "report(action='coverage', data={type:'endpoint', path:'...', method:'GET', "
+                "params:[{name, type, value_hint}], discovered_by:'spider'})"
+            )
+        if "nuclei" not in tools_run:
+            recommended.append(f"Vulnerability scan: scan(tool='nuclei', target='{target}')")
+        if "ffuf" not in tools_run:
+            recommended.append(f"Directory fuzzing: scan(tool='ffuf', target='{target}')")
+
+    elif phase == "testing":
+        _add_testing_actions(required, recommended, target)
+
+    elif phase == "validation":
+        recommended.append("Save PoCs: http(action='save_poc', ...) for each finding")
+        recommended.append("Create architecture diagram: report(action='diagram', data={title, mermaid})")
+        recommended.append("Complete scan: session(action='complete')")
+
+    return {"required": required, "recommended": recommended, "warnings": warnings}
+
+
+def _add_testing_actions(required: list[str], recommended: list[str], target: str) -> None:
+    """Compute next testing action from coverage matrix."""
+    cov = get_matrix()
+    endpoints = {ep["id"]: ep for ep in cov.get("endpoints", [])}
+
+    # Find highest-priority pending cell
+    pending = [c for c in cov.get("matrix", []) if c["status"] == "pending"]
+    in_progress = [c for c in cov.get("matrix", []) if c["status"] == "in_progress"]
+
+    if in_progress:
+        cell = in_progress[0]
+        ep = endpoints.get(cell["endpoint_id"], {})
+        required.append(
+            f"Continue testing: {cell['injection_type']} on "
+            f"{ep.get('method', '?')} {ep.get('path', '?')} param={cell['param']} "
+            f"(cell {cell['id']})"
+        )
+        return
+
+    if not pending:
+        recommended.append("All cells addressed — proceed to validation/reporting")
+        return
+
+    # Prioritize: sqli > xss > ssti > cmdi > ssrf > others
+    priority_order = ["sqli", "xss", "ssti", "cmdi", "ssrf", "xxe", "nosqli", "idor"]
+    best = None
+    for inj_type in priority_order:
+        candidates = [c for c in pending if c["injection_type"] == inj_type]
+        if candidates:
+            best = candidates[0]
+            break
+    if not best:
+        best = pending[0]
+
+    ep = endpoints.get(best["endpoint_id"], {})
+    path = ep.get("path", "?")
+    method = ep.get("method", "?")
+    param = best["param"]
+    param_type = best.get("param_type", "query")
+    inj = best["injection_type"]
+
+    # Build concrete tool call for each injection type
+    test_cmd = _concrete_test_command(inj, target, path, method, param, param_type)
+    required.append(f"{test_cmd} (cell {best['id']})")
+
+    total = len(pending)
+    if total > 1:
+        recommended.append(f"{total - 1} more pending cells after this one")
+
+
+def _resolve_url(target: str, path: str, param: str, param_type: str, payload: str) -> str:
+    """Build the test URL, handling path vs query params correctly."""
+    import re
+    if param_type == "path":
+        # Replace {id} or {param_name} in path with payload
+        resolved = re.sub(r'\{[^}]+\}', payload, path, count=1)
+        return f"{target}{resolved}"
+    if param == "_endpoint":
+        # Endpoint-level test (no specific param) — just use the URL
+        return f"{target}{path}"
+    # Query param
+    return f"{target}{path}?{param}={payload}"
+
+
+def _concrete_test_command(inj: str, target: str, path: str, method: str, param: str, param_type: str = "query") -> str:
+    """Return an exact tool call string for the given injection type."""
+    url = f"{target}{path}"
+    if inj == "sqli":
+        if param_type == "path":
+            test_url = _resolve_url(target, path, param, param_type, "1*")
+            return f"kali(command=\"sqlmap -u '{test_url}' --batch --level=2\")"
+        return f"kali(command=\"sqlmap -u '{_resolve_url(target, path, param, param_type, 'test')}' --batch --level=2\")"
+    if inj == "xss":
+        test_url = _resolve_url(target, path, param, param_type, "<script>alert(1)</script>")
+        return f"http(action='request', url='{test_url}', method='{method}')"
+    if inj == "ssti":
+        test_url = _resolve_url(target, path, param, param_type, "{{7*7}}")
+        return f"http(action='request', url='{test_url}', method='{method}')"
+    if inj == "cmdi":
+        test_url = _resolve_url(target, path, param, param_type, ";id")
+        return f"http(action='request', url='{test_url}', method='{method}')"
+    if inj == "ssrf":
+        test_url = _resolve_url(target, path, param, param_type, "http://127.0.0.1:80")
+        return f"http(action='request', url='{test_url}', method='{method}')"
+    if inj == "idor":
+        # Test IDOR by accessing another user's resource
+        test_url = _resolve_url(target, path, param, param_type, "1")
+        test_url2 = _resolve_url(target, path, param, param_type, "2")
+        return f"http(action='request', url='{test_url}', method='{method}') then compare with url='{test_url2}'"
+    if inj == "traversal":
+        test_url = _resolve_url(target, path, param, param_type, "....//....//etc/passwd")
+        return f"http(action='request', url='{test_url}', method='{method}')"
+    if inj == "cors":
+        return f"http(action='request', url='{url}', method='GET', headers={{\"Origin\": \"https://evil.com\"}})"
+    if inj == "security_headers":
+        return f"http(action='request', url='{url}', method='GET')"
+    if inj == "csrf":
+        return f"http(action='request', url='{url}', method='POST', headers={{\"Content-Type\": \"application/x-www-form-urlencoded\"}}, body='test=1')"
+    if inj == "method_tampering":
+        return f"http(action='request', url='{url}', method='PUT')"
+    if inj == "rate_limit":
+        return f"http(action='request', url='{url}', method='GET')"
+    if inj == "jwt":
+        return f"http(action='request', url='{url}', method='GET')"
+    if inj == "cache":
+        return f"http(action='request', url='{url}', method='GET', headers={{\"X-Forwarded-Host\": \"evil.com\"}})"
+    if inj == "race":
+        return f"http(action='request', url='{url}', method='GET')"
+    # Fallback
+    return f"http(action='request', url='{url}', method='{method}')"
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+# ---------------------------------------------------------------------------
+
+_RECON_ONLY_TOOLS = {"naabu", "subfinder", "nmap"}
+_EXPLOITATION_TOOLS = {"kali_sqlmap", "kali"}  # kali used for sqlmap/hydra/etc
+
+
+def _detect_drift(tool: str, phase: str, tools_run: set) -> list[str]:
+    """Detect behavioral drift and return warning strings."""
+    warnings: list[str] = []
+
+    # Exploitation during recon
+    if phase == "recon" and tool in _EXPLOITATION_TOOLS:
+        warnings.append(
+            f"DRIFT: Running {tool} during recon phase. "
+            f"Complete discovery first: httpx → spider → register endpoints → then test."
+        )
+
+    # Recon tool during testing (going backwards)
+    if phase == "testing" and tool in _RECON_ONLY_TOOLS:
+        warnings.append(
+            f"DRIFT: Running {tool} during testing phase. "
+            f"Recon is already complete. Focus on pending coverage cells."
+        )
+
+    # httpx not run but trying to spider/test
+    if tool == "spider" and "httpx" not in tools_run:
+        warnings.append(
+            "DRIFT: Spider called before httpx. Run httpx first to confirm target is live."
+        )
+
+    return warnings

--- a/mcp_server/scan_engine/state.py
+++ b/mcp_server/scan_engine/state.py
@@ -1,0 +1,79 @@
+"""
+Scan state — server-determined phase tracking and progress computation.
+
+Reads session.json + coverage_matrix.json to compute the current scan phase.
+Phase transitions are automatic, not model-declared.
+"""
+from __future__ import annotations
+
+from core import session as scan_session
+from core import cost as cost_tracker
+from core.coverage import get_matrix
+
+
+# Phase order — each phase has entry criteria based on tools run + coverage state
+PHASES = ["recon", "discovery", "testing", "validation", "reporting"]
+
+# Tools that indicate recon is done
+_RECON_TOOLS = {"naabu", "subfinder", "nmap"}
+_DISCOVERY_TOOLS = {"httpx", "spider", "ffuf"}
+_TESTING_TOOLS = {"kali", "nuclei"}
+
+
+def get_state() -> dict:
+    """Compute current scan state from session.json + coverage_matrix.json.
+
+    Returns a compact dict suitable for embedding in every tool response envelope.
+    """
+    current = scan_session.get()
+    if not current or current.get("status") != "running":
+        return {"phase": "idle", "status": "no_active_scan"}
+
+    tools_run = set(current.get("tools_called", []))
+    cov = get_matrix()
+    meta = cov.get("meta", {})
+    total_cells = meta.get("total_cells", 0)
+    tested = meta.get("tested", 0) + meta.get("not_applicable", 0) + meta.get("skipped", 0)
+    vulnerable = meta.get("vulnerable", 0)
+    endpoints = len(cov.get("endpoints", []))
+
+    # Determine phase
+    phase = _compute_phase(tools_run, endpoints, total_cells, tested)
+
+    # Cost/time remaining
+    summary = cost_tracker.get_summary()
+    remaining = scan_session.remaining(summary)
+
+    return {
+        "target": current.get("target", ""),
+        "phase": phase,
+        "tools_run": sorted(tools_run),
+        "endpoints": endpoints,
+        "coverage": f"{tested}/{total_cells}" if total_cells else "no endpoints registered",
+        "findings": vulnerable,
+        "calls_used": summary.get("tool_calls_total", 0),
+        "time_pct": remaining.get("time_pct", 0),
+    }
+
+
+def _compute_phase(tools_run: set, endpoints: int, total_cells: int, tested: int) -> str:
+    """Server-determined phase based on actual state, not model declaration."""
+    has_recon = bool(tools_run & _RECON_TOOLS)
+    has_discovery = bool(tools_run & _DISCOVERY_TOOLS)
+
+    if not has_recon and not has_discovery:
+        return "recon"
+
+    if has_recon and not has_discovery:
+        return "recon"
+
+    if has_discovery and endpoints == 0:
+        return "discovery"
+
+    if total_cells > 0 and tested < total_cells:
+        return "testing"
+
+    if total_cells > 0 and tested >= total_cells:
+        return "validation"
+
+    return "discovery"

--- a/mcp_server/scan_engine/summarizers.py
+++ b/mcp_server/scan_engine/summarizers.py
@@ -1,0 +1,510 @@
+"""
+Parser-first summarizers — extract structured facts from raw tool output.
+
+Each summarizer returns a SummaryResult. If a tool has no dedicated summarizer,
+the generic fallback is used (first N lines + tail).
+
+Adding a new summarizer: define a function `_summarize_<tool>(raw, ctx) -> SummaryResult`
+and register it in _SUMMARIZERS.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SummaryResult:
+    summary: str = ""
+    facts: list[str] = field(default_factory=list)
+    anomalies: list[str] = field(default_factory=list)
+    evidence: dict[str, Any] = field(default_factory=dict)
+    required: list[str] = field(default_factory=list)
+    recommended: list[str] = field(default_factory=list)
+
+
+def summarize(tool: str, raw: str, ctx: dict) -> SummaryResult:
+    """Dispatch to tool-specific summarizer or fall back to generic."""
+    fn = _SUMMARIZERS.get(tool, _summarize_generic)
+    return fn(raw, ctx)
+
+
+# ---------------------------------------------------------------------------
+# httpx summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_httpx(raw: str, ctx: dict) -> SummaryResult:
+    """Parse httpx output to extract tech stack, status, WAF, headers."""
+    result = SummaryResult()
+    lines = raw.strip().splitlines()
+
+    status = None
+    tech = []
+    title = ""
+    content_type = ""
+    server = ""
+    cdn_or_waf = ""
+    url = ctx.get("url", "")
+
+    for line in lines:
+        line = line.strip()
+        # httpx JSON mode
+        if line.startswith("{"):
+            try:
+                data = json.loads(line)
+                status = data.get("status_code") or data.get("status-code")
+                tech = data.get("tech", [])
+                title = data.get("title", "")
+                content_type = data.get("content_type", data.get("content-type", ""))
+                server = data.get("webserver", data.get("server", ""))
+                cdn_or_waf = data.get("cdn", "") or data.get("waf", "")
+                url = data.get("url", url)
+                break
+            except json.JSONDecodeError:
+                pass
+        # httpx text mode: "http://target [200] [nginx] [text/html] [Title]"
+        m = re.match(r'(https?://\S+)\s+\[(\d+)\]', line)
+        if m:
+            url = m.group(1)
+            status = int(m.group(2))
+            brackets = re.findall(r'\[([^\]]+)\]', line)
+            if len(brackets) >= 2:
+                server = brackets[1] if len(brackets) > 1 else ""
+                content_type = brackets[2] if len(brackets) > 2 else ""
+                title = brackets[3] if len(brackets) > 3 else ""
+
+    if status:
+        result.summary = f"{url} is live (HTTP {status})"
+        if server:
+            result.summary += f", server: {server}"
+    else:
+        result.summary = f"httpx scan of {url} — could not parse status"
+        result.anomalies.append("Could not parse httpx output format")
+
+    if status:
+        result.facts.append(f"Status: {status}")
+    if server:
+        result.facts.append(f"Server: {server}")
+    if content_type:
+        result.facts.append(f"Content-Type: {content_type}")
+    if title:
+        result.facts.append(f"Title: {title}")
+    if tech:
+        result.facts.append(f"Tech: {', '.join(tech) if isinstance(tech, list) else tech}")
+    if cdn_or_waf:
+        result.facts.append(f"CDN/WAF: {cdn_or_waf}")
+
+    result.evidence = {
+        "url": url,
+        "status": status,
+        "server": server,
+        "tech": tech,
+    }
+
+    # Recommendations
+    result.recommended.append("Run scan(tool='spider') to crawl endpoints")
+    if not cdn_or_waf:
+        result.recommended.append("No WAF detected — direct testing likely viable")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# http_request summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_http_request(raw: str, ctx: dict) -> SummaryResult:
+    """Parse HTTP response from http(action='request')."""
+    result = SummaryResult()
+    url = ctx.get("url", "")
+    method = ctx.get("method", "GET")
+
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        result.summary = f"{method} {url} — raw response (not JSON)"
+        result.facts.append(f"Raw length: {len(raw)} chars")
+        result.evidence = {"raw_length": len(raw)}
+        return result
+
+    if "error" in data:
+        result.summary = f"{method} {url} — ERROR: {data['error']}"
+        result.anomalies.append(data["error"])
+        if "hint" in data:
+            result.facts.append(data["hint"])
+        result.evidence = {"error": data["error"]}
+        return result
+
+    status = data.get("status", 0)
+    headers = data.get("headers", {})
+    body = data.get("body", "")
+
+    result.summary = f"{method} {url} returned HTTP {status}"
+
+    result.facts.append(f"Status: {status}")
+    if headers.get("Content-Type"):
+        result.facts.append(f"Content-Type: {headers['Content-Type']}")
+    if headers.get("Server"):
+        result.facts.append(f"Server: {headers['Server']}")
+    result.facts.append(f"Body length: {len(body)} chars")
+
+    # Extract interesting patterns from body
+    _extract_body_signals(body, result)
+
+    result.evidence = {
+        "status": status,
+        "content_type": headers.get("Content-Type", ""),
+        "body_preview": body[:500],
+    }
+
+    # Security-relevant headers
+    security_headers = ["X-Frame-Options", "Content-Security-Policy",
+                        "Strict-Transport-Security", "X-Content-Type-Options"]
+    missing = [h for h in security_headers if h.lower() not in {k.lower() for k in headers}]
+    if missing:
+        result.facts.append(f"Missing security headers: {', '.join(missing)}")
+
+    return result
+
+
+def _extract_body_signals(body: str, result: SummaryResult) -> None:
+    """Detect interesting patterns in response body."""
+    lower = body.lower()
+
+    if "werkzeug" in lower and "debugger" in lower:
+        result.anomalies.append("Werkzeug debugger detected — potential RCE")
+    if "traceback" in lower or "stack trace" in lower:
+        result.anomalies.append("Stack trace in response — information disclosure")
+    if "sql" in lower and ("syntax" in lower or "error" in lower):
+        result.anomalies.append("Possible SQL error in response")
+    if any(kw in lower for kw in ("password", "secret", "api_key", "apikey", "token")):
+        result.anomalies.append("Sensitive keyword detected in response body")
+
+
+# ---------------------------------------------------------------------------
+# kali_sqlmap summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_kali_sqlmap(raw: str, ctx: dict) -> SummaryResult:
+    """Parse sqlmap output for injection results."""
+    result = SummaryResult()
+    lines = raw.strip().splitlines()
+
+    injectable_params: list[str] = []
+    db_type = ""
+    databases: list[str] = []
+    tables: list[str] = []
+    is_vulnerable = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # "Parameter: q (GET)" or "Parameter: id (POST)"
+        m = re.match(r"Parameter:\s+(\S+)\s+\((\w+)\)", stripped)
+        if m:
+            injectable_params.append(f"{m.group(1)} ({m.group(2)})")
+
+        if "is vulnerable" in stripped.lower():
+            is_vulnerable = True
+
+        # "back-end DBMS: MySQL"
+        m = re.match(r"back-end DBMS:\s+(.+)", stripped, re.I)
+        if m:
+            db_type = m.group(1).strip()
+
+        # "available databases" section
+        if re.match(r"\[\*\]\s+\w+", stripped):
+            db_name = stripped.lstrip("[*] ").strip()
+            if db_name and db_name not in databases:
+                databases.append(db_name)
+
+        # Table names
+        m = re.match(r"\|\s+(\w+)\s+\|", stripped)
+        if m:
+            tables.append(m.group(1))
+
+        # "not injectable" signals
+        if "all tested parameters do not appear to be injectable" in stripped.lower():
+            result.summary = f"sqlmap: no injection found"
+            result.facts.append("All tested parameters not injectable")
+            return result
+
+    # Finding injectable params is itself proof of vulnerability
+    is_vulnerable = is_vulnerable or bool(injectable_params)
+
+    if is_vulnerable:
+        params_str = ", ".join(injectable_params) if injectable_params else "unknown"
+        result.summary = f"SQLi CONFIRMED on parameter(s): {params_str}"
+        if db_type:
+            result.summary += f" (DBMS: {db_type})"
+        result.facts.append(f"Injectable: {params_str}")
+        if db_type:
+            result.facts.append(f"DBMS: {db_type}")
+        if databases:
+            result.facts.append(f"Databases: {', '.join(databases[:10])}")
+        if tables:
+            result.facts.append(f"Tables: {', '.join(tables[:20])}")
+        result.recommended.append("Dump credentials: kali(command='sqlmap ... --dump -T users')")
+        result.recommended.append("Try OS shell: kali(command='sqlmap ... --os-shell')")
+    else:
+        result.summary = f"sqlmap scan completed — check artifact for details"
+
+    result.evidence = {
+        "injectable_params": injectable_params,
+        "dbms": db_type,
+        "databases": databases[:10],
+        "tables": tables[:20],
+        "vulnerable": is_vulnerable,
+    }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# naabu summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_naabu(raw: str, ctx: dict) -> SummaryResult:
+    """Parse naabu JSON lines output for open ports."""
+    result = SummaryResult()
+    ports: dict[str, set[int]] = {}  # host -> set of ports
+
+    for line in raw.strip().splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            data = json.loads(line)
+            host = data.get("host", "?")
+            port = data.get("port")
+            if port:
+                ports.setdefault(host, set()).add(int(port))
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+    if ports:
+        all_ports = sorted(set().union(*ports.values()))
+        result.summary = f"Found {len(all_ports)} open port(s): {', '.join(str(p) for p in all_ports)}"
+        for host, host_ports in ports.items():
+            result.facts.append(f"{host}: {', '.join(str(p) for p in sorted(host_ports))}")
+        result.evidence = {"ports": all_ports, "hosts": list(ports.keys())}
+    else:
+        result.summary = "naabu: no open ports found"
+        result.evidence = {"ports": [], "hosts": []}
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# subfinder summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_subfinder(raw: str, ctx: dict) -> SummaryResult:
+    """Parse subfinder output — one subdomain per line."""
+    result = SummaryResult()
+    subs = [l.strip() for l in raw.strip().splitlines() if l.strip() and not l.startswith("[")]
+
+    if subs:
+        result.summary = f"Found {len(subs)} subdomain(s)"
+        result.facts = subs[:20]
+        if len(subs) > 20:
+            result.facts.append(f"... and {len(subs) - 20} more")
+        result.evidence = {"subdomains": subs[:50], "count": len(subs)}
+    else:
+        result.summary = "subfinder: no subdomains found"
+        result.evidence = {"subdomains": [], "count": 0}
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# nuclei summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_nuclei(raw: str, ctx: dict) -> SummaryResult:
+    """Parse nuclei output for vulnerability findings."""
+    result = SummaryResult()
+    findings: list[dict] = []
+
+    for line in raw.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # nuclei JSON output
+        if line.startswith("{"):
+            try:
+                data = json.loads(line)
+                findings.append({
+                    "template": data.get("template-id", data.get("templateID", "?")),
+                    "severity": data.get("info", {}).get("severity", "?"),
+                    "name": data.get("info", {}).get("name", "?"),
+                    "matched": data.get("matched-at", data.get("matched", "?")),
+                })
+            except json.JSONDecodeError:
+                pass
+            continue
+        # nuclei text output: "[template-id] [severity] matched-url"
+        m = re.match(r'\[([^\]]+)\]\s+\[([^\]]+)\]\s+\[([^\]]+)\]\s+(.*)', line)
+        if m:
+            findings.append({
+                "template": m.group(1),
+                "severity": m.group(2),
+                "name": m.group(1),
+                "matched": m.group(4).strip(),
+            })
+
+    if findings:
+        crit_high = [f for f in findings if f["severity"] in ("critical", "high")]
+        result.summary = f"nuclei found {len(findings)} issue(s)"
+        if crit_high:
+            result.summary += f" ({len(crit_high)} critical/high)"
+        for f in findings[:20]:
+            result.facts.append(f"[{f['severity']}] {f['template']}: {f['matched']}")
+        result.evidence = {"findings": findings[:30], "total": len(findings)}
+    else:
+        result.summary = "nuclei: no vulnerabilities found"
+        result.evidence = {"findings": [], "total": 0}
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# ffuf summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_ffuf(raw: str, ctx: dict) -> SummaryResult:
+    """Parse ffuf output for discovered paths."""
+    result = SummaryResult()
+    paths: list[dict] = []
+
+    # Try JSON first (ffuf -of json)
+    try:
+        data = json.loads(raw)
+        for r in data.get("results", []):
+            paths.append({
+                "url": r.get("url", "?"),
+                "status": r.get("status", 0),
+                "length": r.get("length", 0),
+            })
+    except (json.JSONDecodeError, TypeError):
+        # Text output: one URL per line or "STATUS  SIZE  URL" format
+        for line in raw.strip().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("["):
+                continue
+            # Try to extract URL and status
+            m = re.match(r'(\d{3})\s+\S+\s+\S+\s+(.*)', line)
+            if m:
+                paths.append({"url": m.group(2).strip(), "status": int(m.group(1)), "length": 0})
+            elif line.startswith("http"):
+                paths.append({"url": line, "status": 0, "length": 0})
+
+    if paths:
+        result.summary = f"ffuf found {len(paths)} path(s)"
+        for p in paths[:25]:
+            status_str = f" [{p['status']}]" if p["status"] else ""
+            result.facts.append(f"{p['url']}{status_str}")
+        result.evidence = {"paths": paths[:50], "total": len(paths)}
+    else:
+        result.summary = "ffuf: no paths discovered"
+        result.evidence = {"paths": [], "total": 0}
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# spider summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_spider(raw: str, ctx: dict) -> SummaryResult:
+    """Parse katana/spider output — one URL per line. Extract endpoints for registration."""
+    from urllib.parse import urlparse, parse_qs
+    result = SummaryResult()
+    urls = [l.strip() for l in raw.strip().splitlines() if l.strip() and l.strip().startswith("http")]
+
+    if not urls:
+        result.summary = "Spider: no URLs discovered"
+        result.evidence = {"urls": [], "count": 0}
+        return result
+
+    # Extract unique dynamic endpoints (not static assets)
+    static_ext = {".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".woff", ".woff2", ".ttf", ".eot", ".map"}
+    seen_paths: set[str] = set()
+    endpoints: list[dict] = []
+
+    for url in urls:
+        parsed = urlparse(url)
+        path = parsed.path.rstrip("/") or "/"
+        ext = "." + path.rsplit(".", 1)[-1].lower() if "." in path.split("/")[-1] else ""
+        if ext in static_ext:
+            continue
+        # Normalize numeric path segments to {id}
+        norm = re.sub(r'/\d+', '/{id}', path)
+        if norm in seen_paths:
+            continue
+        seen_paths.add(norm)
+
+        # Extract params from query string
+        params = []
+        for name, vals in parse_qs(parsed.query).items():
+            if name.startswith("__"):  # skip debugger params
+                continue
+            params.append({"name": name, "type": "query", "value_hint": "string"})
+        # Detect path params (segments that were numeric)
+        for i, seg in enumerate(path.split("/")):
+            if seg.isdigit():
+                params.append({"name": f"id_{i}", "type": "path", "value_hint": "integer"})
+
+        endpoints.append({"path": norm, "method": "GET", "params": params})
+
+    result.summary = f"Spider crawled {len(urls)} URL(s), {len(endpoints)} unique endpoint(s)"
+    result.facts = [f"{ep['path']}" + (f" params={[p['name'] for p in ep['params']]}" if ep['params'] else "") for ep in endpoints[:20]]
+    result.evidence = {"endpoints": endpoints[:30], "all_urls_count": len(urls)}
+
+    # Generate concrete registration commands for top endpoints
+    for ep in endpoints[:10]:
+        params_json = json.dumps(ep["params"]) if ep["params"] else "[]"
+        result.required.append(
+            f"report(action='coverage', data={{\"type\":\"endpoint\", \"path\":\"{ep['path']}\", "
+            f"\"method\":\"{ep['method']}\", \"params\":{params_json}, \"discovered_by\":\"spider\"}})"
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Generic fallback summarizer
+# ---------------------------------------------------------------------------
+
+def _summarize_generic(raw: str, ctx: dict) -> SummaryResult:
+    """Fallback: first 5 lines + line count."""
+    result = SummaryResult()
+    lines = raw.strip().splitlines()
+    tool = ctx.get("_tool", "tool")
+
+    result.summary = f"{tool} returned {len(lines)} line(s) of output"
+    result.facts = [l.strip()[:300] for l in lines[:5] if l.strip()]
+    if len(lines) > 5:
+        result.facts.append(f"... and {len(lines) - 5} more line(s)")
+    result.evidence = {"total_lines": len(lines), "total_chars": len(raw)}
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_SUMMARIZERS: dict[str, Any] = {
+    "httpx": _summarize_httpx,
+    "http_request": _summarize_http_request,
+    "kali_sqlmap": _summarize_kali_sqlmap,
+    "naabu": _summarize_naabu,
+    "nmap": _summarize_naabu,  # similar JSON lines format
+    "subfinder": _summarize_subfinder,
+    "nuclei": _summarize_nuclei,
+    "ffuf": _summarize_ffuf,
+    "spider": _summarize_spider,
+}

--- a/mcp_server/scan_tools.py
+++ b/mcp_server/scan_tools.py
@@ -9,31 +9,55 @@ from core import session as scan_session
 from mcp_server._app import mcp, _clip, _ensure_dict, _record, _run
 
 
+def _strip_scheme(target: str) -> str:
+    """Strip http(s):// and trailing path — models often pass URLs to host-only tools."""
+    from urllib.parse import urlparse
+    if target.startswith(("http://", "https://")):
+        return urlparse(target).hostname or target
+    return target
+
+
 async def _handle_nmap(target, flags, options):
-    return await _run("nmap", host=target, ports=options.get("ports", "top-1000"), flags=flags)
+    _record("nmap")
+    raw = await _run("nmap", host=_strip_scheme(target), ports=options.get("ports", "top-1000"), flags=flags)
+    from mcp_server.scan_engine import wrap
+    return wrap("nmap", raw, {"host": _strip_scheme(target)})
 
 
 async def _handle_naabu(target, flags, options):
-    return await _run("naabu", host=target, ports=options.get("ports", "top-100"), flags=flags)
+    _record("naabu")
+    raw = await _run("naabu", host=_strip_scheme(target), ports=options.get("ports", "top-100"), flags=flags)
+    from mcp_server.scan_engine import wrap
+    return wrap("naabu", raw, {"host": _strip_scheme(target)})
 
 
 async def _handle_subfinder(target, flags, options):
-    return await _run("subfinder", domain=target, flags=flags)
+    _record("subfinder")
+    raw = await _run("subfinder", domain=_strip_scheme(target), flags=flags)
+    from mcp_server.scan_engine import wrap
+    return wrap("subfinder", raw, {"domain": _strip_scheme(target)})
 
 
 async def _handle_httpx(target, flags, options):
     _record("httpx")
-    return await _run("httpx", url=target, flags=flags)
+    raw = await _run("httpx", url=target, flags=flags)
+    if options.get("_raw"):
+        return raw
+    from mcp_server.scan_engine import wrap
+    return wrap("httpx", raw, {"url": target})
 
 
 async def _handle_nuclei(target, flags, options):
+    _record("nuclei")
     if "-rate-limit" not in flags:
         flags = f"-rate-limit 50 {flags}".strip()
-    return await _run(
+    raw = await _run(
         "nuclei", url=target,
         templates=options.get("templates", "cve,exposure,misconfig,default-login"),
         flags=flags,
     )
+    from mcp_server.scan_engine import wrap
+    return wrap("nuclei", raw, {"url": target})
 
 
 def _build_ffuf_cmd(
@@ -63,10 +87,12 @@ async def _handle_ffuf(target, flags, options):
 
     log.tool_call("ffuf", {"url": target, "wordlist": wordlist, "extensions": extensions, "flags": flags})
     call_id = cost_tracker.start("ffuf")
-    result = _clip(await kali_runner.exec_command(cmd, timeout=900), 8_000)
-    cost_tracker.finish(call_id, result)
-    log.tool_result("ffuf", result)
-    return result
+    raw = _clip(await kali_runner.exec_command(cmd, timeout=900), 8_000)
+    _record("ffuf")
+    cost_tracker.finish(call_id, raw)
+    log.tool_result("ffuf", raw)
+    from mcp_server.scan_engine import wrap
+    return wrap("ffuf", raw, {"url": target})
 
 
 async def _handle_spider(target, flags, options):
@@ -98,11 +124,12 @@ async def _handle_spider(target, flags, options):
         if safe_flags:
             cmd += f" {safe_flags}"
 
-    result = _clip(await kali_runner.exec_command(cmd, timeout=timeout), 8_000)
+    raw = _clip(await kali_runner.exec_command(cmd, timeout=timeout), 8_000)
     _record("spider")
-    cost_tracker.finish(call_id, result)
-    log.tool_result("spider", result)
-    return result
+    cost_tracker.finish(call_id, raw)
+    log.tool_result("spider", raw)
+    from mcp_server.scan_engine import wrap
+    return wrap("spider", raw, {"url": target})
 
 
 async def _handle_semgrep(target, flags, options):
@@ -317,6 +344,12 @@ async def scan(tool: str, target: str, flags: str = "", options: dict | None = N
     | metasploit | host/IP     | module=, payload=, rport=, lhost=, lport=4444     |
     """
     options = _ensure_dict(options) or {}
+
+    # Auto-start session if model skipped session(action="start")
+    current = scan_session.get()
+    if not current or current.get("status") != "running":
+        scan_session.start(target=target, depth="thorough")
+        log.note(f"Auto-started session for target={target} (model skipped session start)")
 
     handler = _DISPATCH.get(tool)
     if not handler:

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -15,6 +15,11 @@ from mcp_server._app import mcp, _ensure_dict, _session_tools_called
 
 _background_tasks: set[asyncio.Task] = set()  # keeps fire-and-forget tasks alive
 
+# Track completion attempts to break infinite loops in small models
+_complete_attempts = 0
+_MAX_COMPLETE_ATTEMPTS = 5
+_force_completed = False
+
 
 # ── CTF flag pattern (e.g. CTF{...}, flag{...}, HTB{...}) ─────────────────────
 _FLAG_RE = re.compile(r'[A-Za-z0-9_]{2,10}\{[A-Za-z0-9_\-!@#$%^&*()+=,.?]{4,}\}')
@@ -53,19 +58,23 @@ def _effective_tools() -> set[str]:
 async def session(action: str, options: dict | None = None) -> str:
     """Scan lifecycle and infrastructure management.
 
-    action  : start | complete | status | recovery | set_skill | set_step | start_kali | stop_kali | start_metasploit | stop_metasploit | pull_images | set_codebase
+    action  : start | complete | status | recovery | artifact | set_skill | set_step | start_kali | stop_kali | start_metasploit | stop_metasploit | pull_images | set_codebase
 
     start options:
       target, depth=standard (recon|standard|thorough), scope=[],
-      out_of_scope=[], max_cost_usd=, max_time_minutes=, max_tool_calls=, skill=
+      out_of_scope=[], max_cost_usd=, max_time_minutes=, max_tool_calls=,
+      model_profile=full (full|medium|small) — controls output verbosity
 
-    complete options:
-      notes=
+    complete options: notes=
 
-    status: returns current scan state (target, tools run, findings, cost, skill)
+    status: returns current scan state (target, tools run, findings, cost)
 
-    recovery: returns compact recovery brief after context compaction — resume step,
-              in-progress cells with technique notes, pending escalation leads, action list
+    recovery: returns compact recovery brief after context compaction — tells you
+              exactly what to do next. Call this if you lost context.
+
+    artifact options:
+      id= (artifact ID from tool response), mode=summary (summary|head|tail|grep|full),
+      max_chars=4000, pattern= (regex for grep mode)
 
     set_skill options:
       skill= (name of the active skill, e.g. "pentester", "ai-redteam")
@@ -106,13 +115,22 @@ async def session(action: str, options: dict | None = None) -> str:
         return _do_set_codebase(opts)
     elif action == "recovery":
         return _do_recovery()
+    elif action == "artifact":
+        return _do_artifact(opts)
     elif action == "pre_chain":
         return _do_pre_chain(opts)
     else:
-        return f"Unknown action '{action}'. Use: start, complete, status, recovery, pre_chain, set_skill, set_step, start_kali, stop_kali, start_metasploit, stop_metasploit, pull_images, set_codebase"
+        return f"Unknown action '{action}'. Use: start, complete, status, recovery, artifact, pre_chain, set_skill, set_step, start_kali, stop_kali, start_metasploit, stop_metasploit, pull_images, set_codebase"
 
 
 def _do_start(opts):
+    global _complete_attempts, _force_completed
+    if _force_completed:
+        return (
+            "BLOCKED: Scan was already force-completed. "
+            "STOP — do not call any more tools. The scan is done."
+        )
+    _complete_attempts = 0
     _session_tools_called.clear()
     target = opts.get("target", "")
 
@@ -171,30 +189,30 @@ def _do_start(opts):
         max_time_minutes=opts.get("max_time_minutes"),
         max_tool_calls=opts.get("max_tool_calls"),
         skill=opts.get("skill"),
+        model_profile=opts.get("model_profile", "full"),
     )
     lim = cfg["limits"]
     log.note(
         f"Scan started — target={target}  depth={depth}  "
         f"limits: ${lim['max_cost_usd']} / {lim['max_time_minutes']}min / {lim['max_tool_calls']} calls"
     )
-    lines = [
-        "Scan session started.",
-        f"  Target      : {target}",
-        f"  Depth       : {cfg['depth_label']} — {cfg['description']}",
-        f"  Scope       : {', '.join(cfg['scope'])}",
-    ]
-    if cfg["out_of_scope"]:
-        lines.append(f"  Out-of-scope: {', '.join(cfg['out_of_scope'])}")
     call_limit_str = f"{lim['max_tool_calls']} tool calls" if lim['max_tool_calls'] > 0 else "unlimited"
-    lines += [
-        f"  Cost limit  : ${lim['max_cost_usd']}",
-        f"  Time limit  : {lim['max_time_minutes']} min",
-        f"  Call limit  : {call_limit_str}",
+    lines = [
+        "Scan started.",
+        f"  Target: {target} | Depth: {cfg['depth_label']} | Limits: ${lim['max_cost_usd']}/{lim['max_time_minutes']}min/{call_limit_str}",
         "",
-        f"Proceed with the {depth} scan workflow.",
-        "Stop and call session(action='complete') when finished or when a limit is hit.",
+        "EXECUTE NOW (do not ask questions, do not output text):",
+        f"  report(action='dashboard', data={{'port': 5000}})",
+        f"  scan(tool='httpx', target='{target}')",
         "",
-        "Skills available (invoke these instead of improvising workflows):",
+        "Then in order:",
+        f"  scan(tool='naabu', target='{target}')",
+        f"  scan(tool='spider', target='{target}')",
+        f"  Register endpoints with report(action='coverage', data=...)",
+        f"  scan(tool='nuclei', target='{target}')",
+        f"  Test each coverage cell with http() or kali()",
+        "",
+        "Skills available for full workflow automation (invoke instead of improvising):",
         "  /pentester /web-exploit /codebase /ai-redteam /cloud-security /ad-assessment",
         "  /network-assess /lateral-movement /credential-audit /post-exploit",
         "  /container-k8s-security /osint /ssl-tls-audit /email-security /metasploit",
@@ -235,10 +253,31 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
 
     addressed = meta.get("tested", 0) + meta.get("not_applicable", 0) + meta.get("skipped", 0)
     pct = (addressed / total) * 100
-    if pct < 80:
+
+    # Model-profile-aware: only enforce 80% coverage threshold for "full" profile.
+    # Medium/small models can't invoke /web-exploit and end up with dozens of
+    # auto-generated cells they can't address, causing completion loops.
+    from mcp_server.scan_engine.budget import get_profile
+    profile = get_profile()
+    coverage_enforced = not profile.get("enforce_budget", True)  # full=enforce, medium/small=skip
+
+    if coverage_enforced and pct < 80:
+        all_cells_tmp = cov.get("matrix", [])
+        pending = [c["id"] for c in all_cells_tmp if c.get("status", "pending") == "pending"]
+        hint = (
+            f"Use bulk_tested to address them:\n"
+            f'  report(action="coverage", data={{"type": "bulk_tested", "updates": ['
+        )
+        hint += ", ".join(
+            f'{{"cell_id": "{cid}", "status": "skipped", "notes": "not tested"}}'
+            for cid in pending[:10]
+        )
+        if len(pending) > 10:
+            hint += f", ... ({len(pending) - 10} more)"
+        hint += "]})"
         blockers.append(
             f"LOW COVERAGE: only {addressed}/{total} matrix cells addressed ({pct:.0f}%). "
-            f"Review pending cells in the coverage matrix — test, skip with reason, or mark N/A."
+            f"{len(pending)} pending cell(s). {hint}"
         )
 
     all_cells = cov.get("matrix", [])
@@ -305,6 +344,8 @@ def _escalation_lead_blockers(data: dict) -> list[str]:
 
 
 async def _do_complete(opts):
+    global _complete_attempts
+    _complete_attempts += 1
     notes = opts.get("notes", "")
     blockers: list[str] = []
 
@@ -343,15 +384,29 @@ async def _do_complete(opts):
     blockers.extend(_coverage_blockers(get_matrix(), ctf_mode=_has_ctf_flag(data)))
 
     if blockers:
-        msg = "complete BLOCKED — fix the following first:\n\n"
+        # Force-complete after max attempts to break model loops
+        if _complete_attempts >= _MAX_COMPLETE_ATTEMPTS:
+            global _force_completed
+            attempts = _complete_attempts
+            _force_completed = True
+            log.note(f"Force-completing after {attempts} blocked attempts. Remaining blockers: {'; '.join(blockers)}")
+            cfg = scan_session.complete(f"{notes} [FORCE-COMPLETED: {len(blockers)} blocker(s) unresolved after {attempts} attempts]")
+            _complete_attempts = 0
+            return (
+                f"Scan FORCE-COMPLETED (exceeded {attempts} attempt limit). "
+                f"{len(blockers)} blocker(s) were unresolved. session.json updated. "
+                f"STOP — do not call any more tools. The scan is done."
+            )
+        msg = f"complete BLOCKED (attempt {_complete_attempts}/{_MAX_COMPLETE_ATTEMPTS}) — fix the following first:\n\n"
         msg += "\n\n".join(f"  [{i+1}] {b}" for i, b in enumerate(blockers))
-        log.note(f"complete blocked: {'; '.join(blockers)}")
+        log.note(f"complete blocked (attempt {_complete_attempts}): {'; '.join(blockers)}")
         return msg
 
     cfg = scan_session.complete(notes)
     status = cfg.get("status", "complete")
     log.note(f"Scan complete — {notes}")
-    return f"Scan marked {status}. session.json updated."
+    _complete_attempts = 0
+    return f"Scan marked {status}. session.json updated. STOP — do not call any more tools. The scan is done."
 
 
 def _do_status():
@@ -510,7 +565,16 @@ def _do_recovery():
     """Compact recovery brief — one call gives the agent everything to resume."""
     current = scan_session.get() or {}
     if not current or current.get("status") != "running":
-        return json.dumps({"error": "No active scan session to recover."})
+        # No session exists — tell the model to start one
+        return json.dumps({
+            "EXECUTE_NOW": "session(action='start', options={\"target\": \"<TARGET_URL>\", \"depth\": \"thorough\"})",
+            "status": "no_session",
+            "TOOLS": (
+                "Only use these 5 MCP tools. Do NOT use Skill or Read tools. "
+                "scan(tool, target) | kali(command) | http(action, url) | "
+                "report(action, data) | session(action)"
+            ),
+        }, indent=2)
 
     summary = cost_tracker.get_summary()
     remaining = scan_session.remaining(summary)
@@ -561,28 +625,95 @@ def _do_recovery():
         for g in scan_session.pending_gates()
     ]
 
+    # Profile-aware: limit cells shown in recovery for small models
+    from mcp_server.scan_engine.budget import get_profile
+    profile = get_profile(current.get("model_profile", "full"))
+    max_cells = profile.get("recovery_cells_shown")
+    extra_cells = 0
+    if max_cells and len(in_progress_cells) > max_cells:
+        extra_cells = len(in_progress_cells) - max_cells
+        in_progress_cells = in_progress_cells[:max_cells]
+
+    target = current.get("target", "")
+    action_list = _build_action_list(
+        integrity_warnings, in_progress_cells, pending_escalations,
+        resume_step, unsatisfied_gates,
+    )
+    next_call = _concrete_next_call(target, tools_run, in_progress_cells, pending_count)
+
     result = {
-        "target": current.get("target", ""),
-        "depth": current.get("depth", ""),
-        "skill": current.get("skill"),
-        "resume_from_step": resume_step,
-        "tools_already_run": sorted(tools_run),  # merged: in-memory + session.json
-        "findings_count": len(data.get("findings", [])),
-        "cost_usd": summary.get("est_cost_usd", 0),
-        "remaining": remaining,
-        "pending_gates": unsatisfied_gates,
-        "coverage_in_progress": in_progress_cells,
-        "coverage_pending_cells": pending_count,
-        "coverage_tested": meta.get("tested", 0),
-        "pending_escalations": pending_escalations,
-        "integrity_warnings": integrity_warnings,
-        "action_required": _build_action_list(
-            integrity_warnings, in_progress_cells, pending_escalations,
-            resume_step, unsatisfied_gates,
+        "EXECUTE_NOW": next_call,
+        "target": target,
+        "phase": resume_step,
+        "tools_already_run": sorted(tools_run),
+        "coverage": f"{meta.get('tested', 0)}/{meta.get('total_cells', 0)}",
+        "findings": len(data.get("findings", [])),
+        "action_required": action_list,
+        "TOOLS": (
+            "Only use these 5 MCP tools. Do NOT use Skill or Read tools. "
+            "scan(tool, target) | kali(command) | http(action, url) | "
+            "report(action, data) | session(action)"
         ),
     }
 
+    # Include known assets summary
+    known_assets = current.get("known_assets", {})
+    compact_assets = {k: v[:10] for k, v in known_assets.items() if v}
+    if compact_assets:
+        result["known_assets"] = compact_assets
+
+    # Include recent tool invocations for context
+    invocations = current.get("tool_invocations", [])
+    if invocations:
+        result["recent_tools"] = [
+            {"tool": i["tool"], "summary": i["summary"]}
+            for i in invocations[-5:]
+        ]
+
+    if extra_cells > 0:
+        result["more_in_progress_cells"] = extra_cells
+
+    if unsatisfied_gates:
+        result["pending_gates"] = unsatisfied_gates
+    if pending_escalations:
+        result["pending_escalations"] = pending_escalations
+    if integrity_warnings:
+        result["integrity_warnings"] = integrity_warnings
+
     return json.dumps(result, indent=2)
+
+
+def _concrete_next_call(target: str, tools_run: set, in_progress: list, pending_count: int) -> str:
+    """Return a single concrete tool call string the model should execute next."""
+    if in_progress:
+        cell = in_progress[0]
+        return (
+            f"Continue testing {cell['injection']} on {cell['endpoint']} param={cell['param']} "
+            f"(cell {cell['cell_id']})"
+        )
+    if "httpx" not in tools_run:
+        return f"scan(tool='httpx', target='{target}')"
+    if "naabu" not in tools_run:
+        return f"scan(tool='naabu', target='{target}')"
+    if "spider" not in tools_run:
+        return f"scan(tool='spider', target='{target}')"
+    if "nuclei" not in tools_run:
+        return f"scan(tool='nuclei', target='{target}')"
+    if pending_count > 0:
+        return f"Test the next pending coverage cell — {pending_count} cells remaining"
+    return "session(action='complete', options={\"notes\": \"all testing complete\"})"
+
+
+def _do_artifact(opts):
+    """Retrieve raw tool output stored by the scan engine."""
+    from mcp_server.scan_engine.artifacts import retrieve_artifact
+    artifact_id = opts.get("id", "")
+    if not artifact_id:
+        return "Error: 'id' option is required"
+    mode = opts.get("mode", "summary")
+    max_chars = opts.get("max_chars", 4000)
+    pattern = opts.get("pattern", "")
+    return retrieve_artifact(artifact_id, mode=mode, max_chars=max_chars, pattern=pattern)
 
 
 def _build_action_list(

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -671,6 +671,11 @@
 
 <!-- ── Tab: Coverage ────────────────────────────────────────────────────── -->
 <div id="tab-coverage" class="tab-content">
+  <p style="font-size:.8rem;color:#8b949e;margin:0 0 .75rem;padding:.5rem .75rem;background:#161b22;border:1px solid #30363d;border-radius:6px">
+    <strong style="color:#f0f6fc">Coverage matrix</strong> tracks web endpoint &amp; parameter injection testing (SQLi, XSS, SSRF, etc.).
+    Post-exploitation skills (<code style="font-size:.75rem">network-assess</code>, <code style="font-size:.75rem">post-exploit</code>, <code style="font-size:.75rem">lateral-movement</code>, etc.)
+    operate at the OS/network layer and are tracked separately in the <strong style="color:#f0f6fc">Skills</strong> tab.
+  </p>
   <div id="coverage-summary"></div>
   <div id="coverage-wrap"><div class="empty-placeholder">No coverage data yet — run a scan with web-exploit.</div></div>
 </div>


### PR DESCRIPTION
## Summary

Merges all improvements from `small-model-testing` into `main` without conflicts, preserving all new features from both branches.

**Scan Engine (new module — `mcp_server/scan_engine/`)**
- `wrap()` routes every tool result through a canonical JSON envelope: `summary`, `facts`, `anomalies`, `evidence`, `next.required`, `artifact_id`, `session_state`
- Raw output stored on disk as retrievable artifacts — kept out of the LLM context window
- Tool-specific summarizers extract structured facts (httpx, naabu, nuclei, spider, ffuf, sqlmap, http_request)
- Coverage-driven planner computes concrete next tool calls and detects behavioral drift
- Model-profile budget system (`full`/`medium`/`small`) scales output sizes per tool

**Small-model compatibility**
- `session(action="start")` now accepts `model_profile=full|medium|small`
- Directive-style start response tells the model exactly what to call next
- `session(action="recovery")` returns compact `EXECUTE_NOW` field with the single next call
- `session(action="artifact")` lets models retrieve full raw output on demand
- Completion loop breaker: force-completes after 5 blocked `session(action="complete")` attempts
- Profile-aware coverage enforcement: `medium`/`small` skip the 80% threshold that caused loops
- Auto-start session if model skips `session(action="start")`

**Resilience improvements (report_tools)**
- Resilient JSON parsing in `report()` with actionable error messages
- Coverage type auto-detected from data shape (path → endpoint, cell_id → tested, updates → bulk_tested)
- Param coercion from various model formats (string, missing fields, wrong key names)
- Coverage reset blocked while scan is active

**Other**
- Broader `_INTERNAL_NET_KEYWORDS` catches natural agent phrasing (docker network, host at 10., etc.)
- `http()` and `kali()` now chain `wrap()` inside `_inject_qa_alerts()` — both envelope + QA alerts delivered
- All scan handlers (`nmap`, `naabu`, `subfinder`, `httpx`, `nuclei`, `ffuf`, `spider`) route through `wrap()`
- `_strip_scheme()` prevents passing URLs to host-only tools
- `core/session.py`: `tool_invocations`, `known_assets`, `context_chars_sent` tracking
- `/api/clear` now calls `reset_coverage()` for in-memory sync before unlinking the file
- Dashboard coverage tab: descriptive banner explaining scope vs Skills tab
- `.gitignore`: `artifacts/`, `quick_log.json`, `qa_state.json`
- `CLAUDE.md`: `model_profile`, spider playwright mode, `artifact` action documented

## Test plan

- [ ] Run existing test suite: `pytest tests/`
- [ ] Start a scan with `model_profile=small` and verify compact envelope responses
- [ ] Verify `session(action="recovery")` returns `EXECUTE_NOW` field
- [ ] Verify `session(action="artifact", options={"id": "<id>"})` retrieves stored output
- [ ] Confirm `/api/clear` resets in-memory coverage state (no stale cell counts after clear)
- [ ] Check dashboard coverage tab shows the description banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)