### PR TITLE
refactor: unify QA alerts + quick_log into scan_engine wrap()

### DIFF
--- a/mcp_server/_app.py
+++ b/mcp_server/_app.py
@@ -106,32 +106,12 @@ _last_qa_shown_ts: str = ""   # ISO timestamp of last alert batch shown to Smith
 
 def _inject_qa_alerts(result: str) -> str:
     """
-    Append any new high or medium QA alerts to a tool result so Smith sees them inline.
-    Only fires when the qa_state.json has been updated since the last injection.
-    Low-urgency alerts are skipped — they're informational for the dashboard only.
+    DEPRECATED: QA alert injection now happens inside scan_engine.wrap() where
+    alerts are placed into the structured envelope (warnings[] + summary) rather
+    than appended as plaintext. This function is kept for import compatibility
+    only and is a no-op pass-through.
     """
-    global _last_qa_shown_ts
-    try:
-        if not os.path.isfile(_QA_STATE_FILE):
-            return result
-        raw = open(_QA_STATE_FILE).read()
-        state = json.loads(raw)
-        ts = state.get("ts", "")
-        if not ts or ts <= _last_qa_shown_ts:
-            return result   # nothing new
-        alerts = [a for a in state.get("alerts", []) if a.get("urgency") in ("high", "medium")]
-        if not alerts:
-            _last_qa_shown_ts = ts
-            return result
-        _last_qa_shown_ts = ts
-        lines = ["\n\n--- QA AGENT ---"]
-        for a in alerts:
-            lines.append(f"[{a['urgency'].upper()}] {a['message']}")
-        lines.append("(Address these before continuing or call session(action='status') to review.)")
-        lines.append("----------------")
-        return result + "\n".join(lines)
-    except Exception:
-        return result   # never break tool dispatch
+    return result  # no-op — logic lives in scan_engine/envelope.py _inject_qa_alerts_into_envelope()
 
 
 # ── Output clipping ───────────────────────────────────────────────────────────
@@ -154,31 +134,9 @@ def _clip(text: str, limit: int = 8_000) -> str:
 # ── Docker tool runner ────────────────────────────────────────────────────────
 
 async def _append_quick_log(name: str, kwargs: dict, result: str, elapsed: float) -> None:
-    """Append a TOOL or SPIDER entry to quick_log after a successful tool run."""
-    import re as _re
-    from core.quick_log import quick_log as _qlog
-    if name == "spider":
-        m = _re.search(r'(\d+)\s+(?:endpoint|url|path|route|link)', result, _re.IGNORECASE)
-        ep_count = int(m.group(1)) if m else 0
-        opts = kwargs.get("options") or {}
-        if isinstance(opts, str):
-            try:
-                opts = json.loads(opts)
-            except Exception:
-                opts = {}
-        await _qlog.append({
-            "type": "SPIDER",
-            "target": kwargs.get("target", ""),
-            "endpoints_found": ep_count,
-            "mode": opts.get("mode", "katana"),
-        })
-    else:
-        await _qlog.append({
-            "type": "TOOL",
-            "name": name,
-            "target": kwargs.get("target", kwargs.get("url", "")),
-            "duration_s": elapsed,
-        })
+    """DEPRECATED: Quick log now fires inside scan_engine.wrap() via _quick_log_tool().
+    Kept as no-op for import compatibility only."""
+    pass
 
 
 async def _run(name: str, **kwargs) -> str:
@@ -226,12 +184,10 @@ async def _run(name: str, **kwargs) -> str:
         cost_tracker.finish(call_id, result)
         log.tool_result(name, result)
 
-        result = _inject_qa_alerts(result)
-
-        try:
-            await _append_quick_log(name, kwargs, result, elapsed)
-        except Exception:
-            pass  # quick_log failures must never crash tool dispatch
+        # QA alerts and quick_log are now handled inside scan_engine.wrap(),
+        # which every tool handler calls after _run() returns raw output.
+        # Do NOT re-add _inject_qa_alerts or _append_quick_log here — that
+        # would pollute artifacts with QA text and double-log to quick_log.
 
         return result
 

--- a/mcp_server/http_tools.py
+++ b/mcp_server/http_tools.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from core import cost as cost_tracker
 from core import logger as log
-from mcp_server._app import mcp, _ensure_dict, _inject_qa_alerts
+from mcp_server._app import mcp, _ensure_dict
 
 
 @mcp.tool()
@@ -84,7 +84,7 @@ async def _do_request(url, method, headers, body, opts):
     log.tool_result("http_request", result)
 
     from mcp_server.scan_engine import wrap
-    return _inject_qa_alerts(wrap("http_request", result, {"url": url, "method": method}))
+    return wrap("http_request", result, {"url": url, "method": method})
 
 
 def _do_save_poc(url, method, headers, body, opts):

--- a/mcp_server/kali_tools.py
+++ b/mcp_server/kali_tools.py
@@ -4,7 +4,7 @@ Consolidated kali tool — replaces the kali_exec part of exploitation.py
 from core import cost as cost_tracker
 from core import logger as log
 from core import session as scan_session
-from mcp_server._app import mcp, _clip, _record, _inject_qa_alerts
+from mcp_server._app import mcp, _clip, _record
 
 
 @mcp.tool()

--- a/mcp_server/scan_engine/envelope.py
+++ b/mcp_server/scan_engine/envelope.py
@@ -7,6 +7,7 @@ Raw output lives in artifacts, referenced by artifact_id.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field, asdict
 from typing import Any
 
@@ -15,6 +16,11 @@ from mcp_server.scan_engine.budget import enforce_budget, get_tool_budget, get_p
 from mcp_server.scan_engine.planner import compute_next
 from mcp_server.scan_engine.state import get_state
 from mcp_server.scan_engine.summarizers import summarize
+
+_QA_STATE_FILE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "qa_state.json"
+)
+_last_qa_shown_ts: str = ""  # ISO timestamp of last alert batch shown to the model
 
 
 @dataclass
@@ -90,6 +96,12 @@ def wrap(tool: str, raw_output: str, context: dict | None = None) -> str:
     # 5. Enforce budget (profile-aware) — may truncate facts/evidence
     budget = get_tool_budget(tool)
     enforced = enforce_budget(env, budget, artifact_id)
+
+    # 5.5. QA alerts — inject into warnings (high urgency also prepended to summary)
+    _inject_qa_alerts_into_envelope(enforced)
+
+    # 5.6. Quick log — fire-and-forget, does not block
+    _quick_log_tool(tool, ctx, result.summary)
 
     # 6. Context tracking (P4) — charge and check pressure
     json_str = enforced.to_json()
@@ -168,3 +180,80 @@ def _check_context_pressure(env: Envelope, json_str: str) -> str:
         )
         return env.to_json()
     return json_str
+
+
+# ---------------------------------------------------------------------------
+# P5 — QA alert injection
+# ---------------------------------------------------------------------------
+
+def _inject_qa_alerts_into_envelope(env: Envelope) -> None:
+    """Read qa_state.json and inject new alerts into the envelope.
+
+    High urgency  → appended to env.warnings AND prepended to env.summary.
+                    The model sees it whether it reads summary or warnings.
+    Medium urgency → env.warnings only (dashboard-visible, not summary-loud).
+    Low urgency   → skipped entirely (dashboard-only, not model-facing).
+
+    Uses a module-level timestamp so each alert is shown exactly once across
+    consecutive tool calls, not repeated on every response.
+    """
+    global _last_qa_shown_ts
+    try:
+        if not os.path.isfile(_QA_STATE_FILE):
+            return
+        state = json.loads(open(_QA_STATE_FILE).read())
+        ts = state.get("ts", "")
+        if not ts or ts <= _last_qa_shown_ts:
+            return
+        alerts = [a for a in state.get("alerts", []) if a.get("urgency") in ("high", "medium")]
+        if not alerts:
+            _last_qa_shown_ts = ts
+            return
+        _last_qa_shown_ts = ts
+
+        # Structured entries into warnings[]
+        for a in alerts:
+            env.warnings.append(f"[QA {a['urgency'].upper()}] {a['message']}")
+
+        # High urgency: also surface in summary so no model misses it
+        high = [a for a in alerts if a.get("urgency") == "high"]
+        if high:
+            alert_text = " | ".join(a["message"] for a in high)
+            env.summary = (
+                f"⚠ QA ALERT: {alert_text}\n"
+                f"(Address before continuing or call session(action='status') to review.)\n\n"
+                + env.summary
+            )
+    except Exception:
+        pass  # never break tool dispatch
+
+
+# ---------------------------------------------------------------------------
+# P6 — Quick log
+# ---------------------------------------------------------------------------
+
+def _quick_log_tool(tool: str, ctx: dict, summarizer_summary: str) -> None:
+    """Fire-and-forget quick_log entry. Called from within an async tool handler
+    so asyncio.get_running_loop() is always available.
+
+    Uses the summarizer's summary (before QA injection) so the log reflects
+    what the tool actually found, not the alert state.
+    """
+    import asyncio
+    import re as _re
+    try:
+        from core.quick_log import quick_log as _qlog
+        target = ctx.get("url", ctx.get("host", ctx.get("domain", ctx.get("path", ""))))
+        if tool == "spider":
+            m = _re.search(r'(\d+)\s+unique\s+endpoint', summarizer_summary, _re.IGNORECASE)
+            entry: dict = {
+                "type": "SPIDER",
+                "target": target,
+                "endpoints_found": int(m.group(1)) if m else 0,
+            }
+        else:
+            entry = {"type": "TOOL", "name": tool, "target": target}
+        loop = asyncio.get_running_loop()
+        loop.create_task(_qlog.append(entry))
+    except Exception:
+        pass  # quick_log failures must never affect tool dispatch


### PR DESCRIPTION
## Summary

- Moves QA alert injection and quick_log from scattered call sites (`_run`, `kali`, `http`) into a single integration point: `scan_engine/envelope.wrap()`
- High-urgency alerts: added to `warnings[]` **and** prepended to `summary` so all model sizes see them
- Medium-urgency alerts: `warnings[]` only — structured, no longer appended as plaintext after JSON
- Low-urgency alerts: skipped from model context entirely
- `_inject_qa_alerts()` and `_append_quick_log()` in `_app.py` are now no-ops (kept for import compatibility)
- Artifacts no longer contain QA plaintext; quick_log now covers all tools uniformly (scan, kali, http)

## Files changed

- `mcp_server/scan_engine/envelope.py` — added `_inject_qa_alerts_into_envelope()` + `_quick_log_tool()`, both called inside `wrap()` at steps 5.5/5.6
- `mcp_server/_app.py` — `_inject_qa_alerts()` → no-op pass-through; `_append_quick_log()` → no-op `pass`; removed both calls from `_run()`
- `mcp_server/http_tools.py` — removed `_inject_qa_alerts` import and wrapping
- `mcp_server/kali_tools.py` — removed `_inject_qa_alerts` import

## Test plan

- [ ] Start a scan and verify tool responses return valid JSON envelopes (no plaintext QA appended after `}`)
- [ ] Trigger a QA alert and verify it appears in `warnings[]` and (if high urgency) at the top of `summary`
- [ ] Verify quick_log entries appear for scan, kali, and http tool calls
- [ ] Confirm artifacts directory contains only raw tool output (no QA text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)