### PR TITLE
chore: bump skills submodule — gh-export optional + business-logic skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ Log findings, diagrams, notes, and coverage matrix updates.
 Scan lifecycle and infrastructure.
 - `action="start"` — options: `{target, depth, scope, out_of_scope, max_cost_usd, max_time_minutes, max_tool_calls, model_profile=full}` (model_profile: full|medium|small)
 - `action="complete"` — options: `{notes}`
-- `action="status"` — returns current scan state (tools run, findings count, cost, remaining calls)
+- `action="status"` — returns current scan state (tools run, findings count, cost, remaining calls). **When the response includes `qa_alerts`, immediately call `session(action="qa_reply")` with your acknowledgment before continuing.**
+- `action="qa_reply"` — options: `{message}` — log your response to the QA agent's alerts. Call this every time `session(action="status")` returns non-empty `qa_alerts`. Write one sentence per alert: what you acknowledge and what you will do. This is what the human sees in the QA ↔ Smith conversation view.
 - `action="recovery"` — returns compact recovery brief after context compaction; includes `EXECUTE_NOW` with the next concrete tool call
 - `action="artifact"` — options: `{id, mode=summary, max_chars=4000, pattern=}` — retrieve raw tool output stored by the scan engine
 - `action="start_kali"` / `action="stop_kali"` — Kali container lifecycle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Skills are slash commands that contain full structured workflows. In Claude Code
 |---------|---------|-------------|
 | `/pentester` | Full pentest orchestrator — recon → exploitation → report | General web/network pentest request |
 | `/web-exploit` | Deep injection, auth, logic, and business-logic exploitation | Web app confirmed; systematic endpoint testing needed |
+| `/business-logic` | Understanding-first BL testing: BOLA, BFLA, workflow bypass, financial logic, trust boundary, multi-tenant isolation | Financial/SaaS/transactional app; systematic BL coverage needed |
 | `/codebase` | OWASP ASVS 5.0 white-box source code review | Local codebase path provided |
 | `/ai-redteam` | OWASP LLM Top 10 red-team — prompt injection, jailbreaks, data extraction | AI/chatbot/LLM target |
 | `/cloud-security` | AWS/Azure/GCP IAM, storage, serverless posture assessment | Cloud account target |

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -237,6 +237,41 @@ async def api_delete_finding(finding_id: str) -> JSONResponse:
         return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
 
 
+def _safe_unlink(path) -> None:
+    """Unlink a file, ignoring errors."""
+    try:
+        path.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def _clear_dir_files(directory) -> None:
+    """Delete all regular files inside a directory, ignoring errors."""
+    try:
+        if not directory.exists():
+            return
+        for f in directory.iterdir():
+            try:
+                if f.is_file():
+                    f.unlink()
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def _clear_log_files(log_dir) -> None:
+    """Truncate all *.log files in log_dir to zero bytes."""
+    try:
+        for log_file in log_dir.glob("*.log"):
+            try:
+                log_file.write_text("")
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
 @app.delete("/api/clear")
 async def api_clear() -> JSONResponse:
     """Wipe all scan state — findings, session, coverage, logs, quick_log, qa_state."""
@@ -254,19 +289,12 @@ async def api_clear() -> JSONResponse:
 
     # session.json, coverage_matrix.json, quick_log.json, qa_state.json, session_cost.json
     for path in (_SESSION_FILE, _COVERAGE_FILE, _QUICK_LOG_FILE, _QA_STATE_FILE, _COST_FILE):
-        try:
-            path.unlink(missing_ok=True)
-        except Exception:
-            pass
+        _safe_unlink(path)
 
     # log files in logs/
     try:
         from core.logger import _LOG_DIR
-        for log_file in _LOG_DIR.glob("*.log"):
-            try:
-                log_file.write_text("")
-            except Exception:
-                pass
+        _clear_log_files(_LOG_DIR)
     except Exception:
         pass
 
@@ -275,44 +303,18 @@ async def api_clear() -> JSONResponse:
         pocs_dir = _REPO_ROOT / "pocs"
         if pocs_dir.exists():
             for poc_file in pocs_dir.glob("*.http"):
-                try:
-                    poc_file.unlink()
-                except Exception:
-                    pass
+                _safe_unlink(poc_file)
     except Exception:
         pass
 
     # artifacts/ — raw scanner output files
-    try:
-        artifacts_dir = _REPO_ROOT / "artifacts"
-        if artifacts_dir.exists():
-            for f in artifacts_dir.iterdir():
-                try:
-                    if f.is_file():
-                        f.unlink()
-                except Exception:
-                    pass
-    except Exception:
-        pass
+    _clear_dir_files(_REPO_ROOT / "artifacts")
 
     # threat-model/ — generated HTML/MD reports
-    try:
-        tm_dir = _REPO_ROOT / "threat-model"
-        if tm_dir.exists():
-            for f in tm_dir.iterdir():
-                try:
-                    if f.is_file():
-                        f.unlink()
-                except Exception:
-                    pass
-    except Exception:
-        pass
+    _clear_dir_files(_REPO_ROOT / "threat-model")
 
     # gh-issues.md — exported GitHub issue blocks
-    try:
-        (_REPO_ROOT / "gh-issues.md").unlink(missing_ok=True)
-    except Exception:
-        pass
+    _safe_unlink(_REPO_ROOT / "gh-issues.md")
 
     await _cleanup_tunnels()
     return JSONResponse({"ok": True})

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -282,6 +282,38 @@ async def api_clear() -> JSONResponse:
     except Exception:
         pass
 
+    # artifacts/ — raw scanner output files
+    try:
+        artifacts_dir = _REPO_ROOT / "artifacts"
+        if artifacts_dir.exists():
+            for f in artifacts_dir.iterdir():
+                try:
+                    if f.is_file():
+                        f.unlink()
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    # threat-model/ — generated HTML/MD reports
+    try:
+        tm_dir = _REPO_ROOT / "threat-model"
+        if tm_dir.exists():
+            for f in tm_dir.iterdir():
+                try:
+                    if f.is_file():
+                        f.unlink()
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    # gh-issues.md — exported GitHub issue blocks
+    try:
+        (_REPO_ROOT / "gh-issues.md").unlink(missing_ok=True)
+    except Exception:
+        pass
+
     await _cleanup_tunnels()
     return JSONResponse({"ok": True})
 

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -43,6 +43,14 @@ _lock = asyncio.Lock()
 
 
 # ---------------------------------------------------------------------------
+# Which statuses count as "addressed" for coverage percentage purposes.
+# skipped is intentionally excluded — it is a deferral, not evidence of testing.
+# ---------------------------------------------------------------------------
+
+ADDRESSED_STATUSES: frozenset[str] = frozenset({"tested_clean", "vulnerable", "not_applicable"})
+
+
+# ---------------------------------------------------------------------------
 # Injection types that have known bypass techniques — marking these N/A
 # requires the notes to explain WHY the bypass doesn't apply.
 # ---------------------------------------------------------------------------
@@ -68,7 +76,7 @@ _APPLICABILITY: dict[str, list[str]] = {
     "body_json/default": ["nosqli", "prototype", "mass_assignment", "sqli"],
     "header/default":    ["crlf", "xss", "ssrf", "smuggling"],
     "cookie/default":    ["sqli", "xss", "deserial"],
-    "endpoint/default":  ["cors", "csrf", "security_headers", "rate_limit", "method_tampering", "cache", "jwt", "race"],
+    "endpoint/default":  ["cors", "csrf", "security_headers", "rate_limit", "method_tampering", "cache", "jwt", "race", "bfla"],
 }
 
 # Fallback: if no specific hint matches, use param_type/default
@@ -109,12 +117,13 @@ def _save(data: dict) -> None:
 def _recount(data: dict) -> None:
     """Recompute meta counters from the matrix."""
     cells = data["matrix"]
-    data["meta"]["total_cells"] = len(cells)
-    data["meta"]["tested"] = sum(1 for c in cells if c["status"] in ("tested_clean", "vulnerable"))
-    data["meta"]["in_progress"] = sum(1 for c in cells if c["status"] == "in_progress")
-    data["meta"]["vulnerable"] = sum(1 for c in cells if c["status"] == "vulnerable")
+    data["meta"]["total_cells"]    = len(cells)
+    data["meta"]["tested"]         = sum(1 for c in cells if c["status"] in ("tested_clean", "vulnerable"))
+    data["meta"]["in_progress"]    = sum(1 for c in cells if c["status"] == "in_progress")
+    data["meta"]["vulnerable"]     = sum(1 for c in cells if c["status"] == "vulnerable")
     data["meta"]["not_applicable"] = sum(1 for c in cells if c["status"] == "not_applicable")
-    data["meta"]["skipped"] = sum(1 for c in cells if c["status"] == "skipped")
+    data["meta"]["skipped"]        = sum(1 for c in cells if c["status"] == "skipped")
+    data["meta"]["addressed"]      = sum(1 for c in cells if c["status"] in ADDRESSED_STATUSES)
 
 
 def _normalize_path(path: str) -> str:
@@ -271,12 +280,19 @@ async def update_cell(
 ) -> bool | str:
     """Update a single matrix cell.
 
-    Returns True if updated, False if cell not found, or a warning string
-    if the update was applied but violated an integrity rule.
+    Returns True if updated, False if cell not found, or a warning/rejection string
+    if the update was applied but violated an integrity rule (or was rejected).
+
+    Hard rule: tested_clean and vulnerable require a non-empty tested_by.
     """
     valid = {"pending", "in_progress", "tested_clean", "vulnerable", "not_applicable", "skipped"}
     if status not in valid:
         return False
+    if status in ("tested_clean", "vulnerable") and not tested_by.strip():
+        return (
+            f"REJECTED: status '{status}' requires a non-empty tested_by field. "
+            f"Record the tool used (e.g. tested_by='sqlmap') before marking this cell."
+        )
 
     async with _lock:
         data = _load()
@@ -319,24 +335,37 @@ def _apply_bulk_cell(cell: dict, upd: dict, warnings: list[str]) -> None:
 async def bulk_update(updates: list[dict]) -> dict:
     """Update multiple cells. Each update: {cell_id, status, notes?, finding_id?, tested_by?}.
 
-    Returns {"updated": N, "warnings": [str]} — warnings for integrity violations.
+    Returns {"updated": N, "rejected": N, "warnings": [str]}.
+
+    Hard rules (reject without applying):
+    - tested_clean or vulnerable requires a non-empty tested_by (tool that produced the result).
     """
     valid = {"pending", "in_progress", "tested_clean", "vulnerable", "not_applicable", "skipped"}
+    _TESTED_FINAL = {"tested_clean", "vulnerable"}
 
     async with _lock:
         data = _load()
         cell_map = {c["id"]: c for c in data["matrix"]}
         count = 0
+        rejected = 0
         warnings: list[str] = []
         for upd in updates:
             cid = upd.get("cell_id", "")
-            if upd.get("status", "") not in valid or cid not in cell_map:
+            st  = upd.get("status", "")
+            if st not in valid or cid not in cell_map:
+                continue
+            if st in _TESTED_FINAL and not upd.get("tested_by", "").strip():
+                warnings.append(
+                    f"REJECTED cell {cid}: status '{st}' requires a non-empty tested_by field. "
+                    f"Record the tool used (e.g. tested_by='sqlmap') before marking this cell."
+                )
+                rejected += 1
                 continue
             _apply_bulk_cell(cell_map[cid], upd, warnings)
             count += 1
         _recount(data)
         _save(data)
-    return {"updated": count, "warnings": warnings}
+    return {"updated": count, "rejected": rejected, "warnings": warnings}
 
 
 def get_matrix() -> dict:

--- a/core/findings.py
+++ b/core/findings.py
@@ -106,6 +106,7 @@ async def add_finding(
 _UPDATABLE_FIELDS = {
     "severity", "title", "description", "evidence", "status",
     "gh_issue", "remediation", "reproduction", "escalation_leads", "business_impact",
+    "poc_files",
 }
 
 
@@ -124,6 +125,24 @@ async def update_finding(finding_id: str, **fields) -> bool:
         for entry in data["findings"]:
             if entry.get("id") == finding_id:
                 entry.update(updates)
+                _save(data)
+                return True
+    return False
+
+
+async def link_poc(finding_id: str, filepath: str) -> bool:
+    """Append a PoC file path to finding.poc_files[]. Creates the list if absent.
+
+    Returns True if the finding was found and updated, False otherwise.
+    """
+    async with _lock:
+        data = _load()
+        for entry in data["findings"]:
+            if entry.get("id") == finding_id:
+                if "poc_files" not in entry:
+                    entry["poc_files"] = []
+                if filepath not in entry["poc_files"]:
+                    entry["poc_files"].append(filepath)
                 _save(data)
                 return True
     return False

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -45,6 +45,120 @@ _COVERAGE_FILE  = _REPO_ROOT / "coverage_matrix.json"
 
 # ── Deterministic checks ──────────────────────────────────────────────────────
 
+def _check_scope_drift(summary: str) -> dict | None:
+    if "Possible off-scope targets used:" not in summary:
+        return None
+    m = re.search(r"Possible off-scope targets used: (.+)", summary)
+    targets = m.group(1).strip() if m else "unknown"
+    return {"code": "SCOPE_DRIFT", "urgency": "high", "blocking": False,
+            "message": f"Scope drift: tools ran against {targets}"}
+
+
+def _check_coverage_stall(summary: str) -> dict | None:
+    stall_m   = re.search(r"WARNING: coverage stale \((\d+) min", summary)
+    pending_m = re.search(r",\s*(\d+) pending", summary)
+    if not stall_m or not pending_m:
+        return None
+    pending = int(pending_m.group(1))
+    if pending == 0:
+        return None
+    mins = int(stall_m.group(1))
+    return {"code": "COVERAGE_STALL", "urgency": "high", "blocking": False,
+            "message": f"Coverage stall — {pending} cells untested, last update {mins}min ago"}
+
+
+def _check_spider_without_coverage(summary: str, coverage_data: dict) -> dict | None:
+    if "Endpoints found:" not in summary:
+        return None
+    if coverage_data.get("meta", {}).get("total_cells", 0) != 0:
+        return None
+    m = re.search(r"Endpoints found: (\S+)", summary)
+    count = m.group(1) if m else "?"
+    return {"code": "SPIDER_WITHOUT_COVERAGE", "urgency": "high", "blocking": False,
+            "message": f"Spider found {count} endpoint(s) but coverage matrix is empty — register endpoints"}
+
+
+def _check_poc_gap(findings_data: dict) -> dict | None:
+    high_crit   = [f for f in findings_data.get("findings", [])
+                   if f.get("severity") in ("high", "critical")]
+    missing_poc = [f for f in high_crit if not f.get("poc_files")]
+    if not missing_poc:
+        return None
+    titles = ", ".join(f["title"] for f in missing_poc[:3])
+    if len(missing_poc) > 3:
+        titles += f" +{len(missing_poc) - 3} more"
+    return {"code": "POC_GAP", "urgency": "medium", "blocking": False,
+            "message": f"PoC gap: {len(missing_poc)}/{len(high_crit)} high/critical findings have no saved PoC: {titles}"}
+
+
+def _check_skill_chain_gap(summary: str) -> dict | None:
+    if "Findings:" not in summary or "web-exploit" in summary:
+        return None
+    sev_m = re.search(r"Findings: (.+)", summary)
+    if not sev_m:
+        return None
+    sev_str = sev_m.group(1)
+    if "critical" not in sev_str and " high" not in sev_str:
+        return None
+    return {"code": "SKILL_CHAIN_GAP", "urgency": "medium", "blocking": False,
+            "message": "High/critical findings but web-exploit not yet chained — run /web-exploit"}
+
+
+def _check_tool_inactivity(summary: str) -> dict | None:
+    inact_m = re.search(r"Last tool call: (\d+) minutes ago", summary)
+    if not inact_m:
+        return None
+    mins = int(inact_m.group(1))
+    if mins <= 10:
+        return None
+    return {"code": "TOOL_INACTIVITY", "urgency": "low", "blocking": False,
+            "message": f"No tool activity in {mins}min — is Smith stuck?"}
+
+
+def _check_bulk_marking(summary: str) -> dict | None:
+    if "Bulk-marking warning:" not in summary:
+        return None
+    m = re.search(r"Bulk-marking warning: (.+)(?:\n|$)", summary)
+    detail = m.group(1).strip() if m else "N/A cells have no tested_by tool"
+    return {"code": "BULK_MARKING", "urgency": "high", "blocking": True,
+            "message": f"Bulk-marking detected: {detail}"}
+
+
+def _check_coverage_integrity(summary: str) -> dict | None:
+    integ_m = re.search(r"(\d+) tested/vulnerable cells have no tested_by tool", summary)
+    if not integ_m:
+        return None
+    count = integ_m.group(1)
+    return {"code": "COVERAGE_INTEGRITY", "urgency": "high", "blocking": True,
+            "message": f"Coverage integrity: {count} tested/vulnerable cells lack tested_by tool"}
+
+
+def _check_gate_alerts(summary: str) -> list[dict]:
+    alerts: list[dict] = []
+    gate_m = re.search(r"Pending gates: (.+)(?:\n|$)", summary)
+    if not gate_m:
+        return alerts
+    gate_info = gate_m.group(1)
+    time_m  = re.search(r"triggered (\d+)min ago", gate_info)
+    elapsed = int(time_m.group(1)) if time_m else 0
+    if elapsed >= 5:
+        urgency  = "high" if elapsed >= 15 else "medium"
+        gid_m    = re.search(r"^(\S+) \(", gate_info)
+        gate_id  = gid_m.group(1) if gid_m else "unknown"
+        req_m    = re.search(r"requires: (.+?)\)", gate_info)
+        requires = req_m.group(1) if req_m else "required skill"
+        alerts.append({"code": "GATE_PENDING", "urgency": urgency, "blocking": False,
+                       "message": f"Gate {gate_id} pending {elapsed}min — chain {requires} or dismiss"})
+    if "rce" in gate_info.lower():
+        sev_m = re.search(r"Findings: (.+)", summary)
+        if sev_m:
+            sev_str = sev_m.group(1)
+            if "critical" not in sev_str and " high" not in sev_str:
+                alerts.append({"code": "RCE_GATE_FALSE_POSITIVE", "urgency": "medium", "blocking": False,
+                               "message": "RCE gate may be a false positive — verify finding severity"})
+    return alerts
+
+
 def _deterministic_qa_checks(
     summary: str,
     findings_data: dict,
@@ -54,118 +168,18 @@ def _deterministic_qa_checks(
 
     Returns a list of alert dicts: {code, urgency, blocking, message}.
     """
-    alerts: list[dict] = []
-
-    # SCOPE_DRIFT — tool ran against a target outside the declared scope
-    if "Possible off-scope targets used:" in summary:
-        m = re.search(r"Possible off-scope targets used: (.+)", summary)
-        targets = m.group(1).strip() if m else "unknown"
-        alerts.append({
-            "code": "SCOPE_DRIFT", "urgency": "high", "blocking": False,
-            "message": f"Scope drift: tools ran against {targets}",
-        })
-
-    # COVERAGE_STALL — no coverage update for >30 min and cells still pending
-    stall_m   = re.search(r"WARNING: coverage stale \((\d+) min", summary)
-    pending_m = re.search(r",\s*(\d+) pending", summary)
-    if stall_m and pending_m:
-        mins    = int(stall_m.group(1))
-        pending = int(pending_m.group(1))
-        if pending > 0:
-            alerts.append({
-                "code": "COVERAGE_STALL", "urgency": "high", "blocking": False,
-                "message": f"Coverage stall — {pending} cells untested, last update {mins}min ago",
-            })
-
-    # SPIDER_WITHOUT_COVERAGE — spider ran but matrix is still empty
-    if "Endpoints found:" in summary:
-        cov_meta = coverage_data.get("meta", {})
-        if cov_meta.get("total_cells", 0) == 0:
-            m = re.search(r"Endpoints found: (\S+)", summary)
-            count = m.group(1) if m else "?"
-            alerts.append({
-                "code": "SPIDER_WITHOUT_COVERAGE", "urgency": "high", "blocking": False,
-                "message": f"Spider found {count} endpoint(s) but coverage matrix is empty — register endpoints",
-            })
-
-    # POC_GAP — high/critical finding has no linked PoC file (per-finding check)
-    high_crit   = [f for f in findings_data.get("findings", [])
-                   if f.get("severity") in ("high", "critical")]
-    missing_poc = [f for f in high_crit if not f.get("poc_files")]
-    if missing_poc:
-        titles = ", ".join(f["title"] for f in missing_poc[:3])
-        if len(missing_poc) > 3:
-            titles += f" +{len(missing_poc) - 3} more"
-        alerts.append({
-            "code": "POC_GAP", "urgency": "medium", "blocking": False,
-            "message": f"PoC gap: {len(missing_poc)}/{len(high_crit)} high/critical findings have no saved PoC: {titles}",
-        })
-
-    # SKILL_CHAIN_GAP — high/critical findings but web-exploit skill never invoked
-    if "Findings:" in summary and "web-exploit" not in summary:
-        sev_m = re.search(r"Findings: (.+)", summary)
-        if sev_m and ("critical" in sev_m.group(1) or " high" in sev_m.group(1)):
-            alerts.append({
-                "code": "SKILL_CHAIN_GAP", "urgency": "medium", "blocking": False,
-                "message": "High/critical findings but web-exploit not yet chained — run /web-exploit",
-            })
-
-    # TOOL_INACTIVITY — no tool call for >10 min
-    inact_m = re.search(r"Last tool call: (\d+) minutes ago", summary)
-    if inact_m:
-        mins = int(inact_m.group(1))
-        if mins > 10:
-            alerts.append({
-                "code": "TOOL_INACTIVITY", "urgency": "low", "blocking": False,
-                "message": f"No tool activity in {mins}min — is Smith stuck?",
-            })
-
-    # BULK_MARKING — many N/A cells without tested_by tool
-    if "Bulk-marking warning:" in summary:
-        m = re.search(r"Bulk-marking warning: (.+)(?:\n|$)", summary)
-        detail = m.group(1).strip() if m else "N/A cells have no tested_by tool"
-        alerts.append({
-            "code": "BULK_MARKING", "urgency": "high", "blocking": True,
-            "message": f"Bulk-marking detected: {detail}",
-        })
-
-    # COVERAGE_INTEGRITY — tested/vulnerable cells with no tested_by
-    integ_m = re.search(r"(\d+) tested/vulnerable cells have no tested_by tool", summary)
-    if integ_m:
-        count = integ_m.group(1)
-        alerts.append({
-            "code": "COVERAGE_INTEGRITY", "urgency": "high", "blocking": True,
-            "message": f"Coverage integrity: {count} tested/vulnerable cells lack tested_by tool",
-        })
-
-    # GATE_PENDING — mandatory skill gate not yet satisfied
-    gate_m = re.search(r"Pending gates: (.+)(?:\n|$)", summary)
-    if gate_m:
-        gate_info = gate_m.group(1)
-        time_m    = re.search(r"triggered (\d+)min ago", gate_info)
-        elapsed   = int(time_m.group(1)) if time_m else 0
-        if elapsed >= 5:
-            urgency   = "high" if elapsed >= 15 else "medium"
-            gid_m     = re.search(r"^(\S+) \(", gate_info)
-            gate_id   = gid_m.group(1) if gid_m else "unknown"
-            req_m     = re.search(r"requires: (.+?)\)", gate_info)
-            requires  = req_m.group(1) if req_m else "required skill"
-            alerts.append({
-                "code": "GATE_PENDING", "urgency": urgency, "blocking": False,
-                "message": f"Gate {gate_id} pending {elapsed}min — chain {requires} or dismiss",
-            })
-
-    # RCE_GATE_FALSE_POSITIVE — rce gate open but only low/medium/info findings
-    if gate_m and "rce" in gate_m.group(1).lower():
-        sev_m = re.search(r"Findings: (.+)", summary)
-        if sev_m:
-            sev_str = sev_m.group(1)
-            if "critical" not in sev_str and " high" not in sev_str:
-                alerts.append({
-                    "code": "RCE_GATE_FALSE_POSITIVE", "urgency": "medium", "blocking": False,
-                    "message": "RCE gate may be a false positive — verify finding severity",
-                })
-
+    checks = [
+        _check_scope_drift(summary),
+        _check_coverage_stall(summary),
+        _check_spider_without_coverage(summary, coverage_data),
+        _check_poc_gap(findings_data),
+        _check_skill_chain_gap(summary),
+        _check_tool_inactivity(summary),
+        _check_bulk_marking(summary),
+        _check_coverage_integrity(summary),
+    ]
+    alerts = [c for c in checks if c is not None]
+    alerts.extend(_check_gate_alerts(summary))
     return alerts
 
 
@@ -366,6 +380,20 @@ class QADaemon:
             except Exception as exc:
                 _log.warning("QA Daemon cycle error: %s", exc)
 
+    async def _run_semantic_review(self, finding_text: str) -> list[dict]:
+        graph = self._get_graph()
+        if graph is None:
+            return []
+        try:
+            result = await asyncio.to_thread(
+                graph.invoke,
+                {"summary": finding_text, "raw_response": "", "alerts": []},
+            )
+            return result.get("alerts", [])
+        except Exception as exc:
+            _log.warning("QA Daemon: semantic review failed — %s", exc)
+            return []
+
     async def _cycle(self) -> None:
         if not _session_is_running():
             return
@@ -382,19 +410,8 @@ class QADaemon:
         determ_alerts = _deterministic_qa_checks(summary, findings_data, coverage_data)
 
         # Layer 2: semantic LLM review — only when there are high/critical findings
-        semantic_alerts: list[dict] = []
-        finding_text = _format_findings_for_semantic_review(findings_data)
-        if finding_text:
-            graph = self._get_graph()
-            if graph is not None:
-                try:
-                    result = await asyncio.to_thread(
-                        graph.invoke,
-                        {"summary": finding_text, "raw_response": "", "alerts": []},
-                    )
-                    semantic_alerts = result.get("alerts", [])
-                except Exception as exc:
-                    _log.warning("QA Daemon: semantic review failed — %s", exc)
+        finding_text    = _format_findings_for_semantic_review(findings_data)
+        semantic_alerts = await self._run_semantic_review(finding_text) if finding_text else []
 
         all_alerts = determ_alerts + semantic_alerts
 

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -196,10 +196,12 @@ def _sanitize_history(raw: list) -> list[dict]:
     for entry in raw:
         if not isinstance(entry, dict):
             continue
+        reply = entry.get("smith_reply")
         result.append({
             "ts":            str(entry.get("ts", ""))[:50],
             "summary_sent":  str(entry.get("summary_sent", "")),
             "alerts":        [a for a in entry.get("alerts", []) if isinstance(a, dict)][:10],
+            "smith_reply":   str(reply)[:2000] if reply else None,
             "smith_actions": [a for a in entry.get("smith_actions", []) if isinstance(a, dict)][:50],
         })
     return result
@@ -268,12 +270,20 @@ class QADaemon:
         post_existing = _read_qa_state()
         history = _sanitize_history(post_existing.get("history", []))
         prev_cycle_ts = history[-1]["ts"] if history else ""
-        smith_actions = quick_log.read_since(prev_cycle_ts) if prev_cycle_ts else []
+        events_since = quick_log.read_since(prev_cycle_ts) if prev_cycle_ts else []
+
+        # Separate QA_REPLY events (Smith's words) from tool actions
+        smith_reply = " ".join(
+            e["message"] for e in events_since
+            if e.get("type") == "QA_REPLY" and e.get("message")
+        ).strip() or None
+        smith_actions = [e for e in events_since if e.get("type") != "QA_REPLY"]
 
         history.append({
             "ts":            ts_before,
             "summary_sent":  summary,
             "alerts":        alerts,
+            "smith_reply":   smith_reply,
             "smith_actions": smith_actions,
         })
 

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -1,20 +1,28 @@
 """
 QA Agent
 ========
-LangGraph-based QA reviewer that reads quick_log.json and surfaces
-workflow gaps as alerts every 2 minutes during an active scan.
+Two-layer QA reviewer that runs every 2 minutes during an active scan.
 
-Runs as a background asyncio task inside the FastAPI dashboard server.
-Provider-agnostic via QA_MODEL env var:
+Layer 1 — Deterministic Python rules
+  Reads quick_log.summarize(), findings.json, and coverage_matrix.json.
+  Produces coded, typed alerts without any LLM call.
 
-  QA_MODEL=openai:gpt-4o-mini               (default)
-  QA_MODEL=anthropic:claude-haiku-4-5-20251001
-  QA_MODEL=ollama:qwen2.5:7b               (recommended local — reliable JSON output)
+Layer 2 — Semantic LLM review
+  Only invoked when there are high/critical findings to review.
+  Checks: overclaimed severity, vague descriptions, missing attack chains.
+  Provider-agnostic via QA_MODEL env var:
 
-Install only the provider package you need:
-  pip install langchain-openai     # OpenAI
-  pip install langchain-anthropic  # Anthropic
-  pip install langchain-ollama     # Ollama
+    QA_MODEL=openai:gpt-4o-mini               (default)
+    QA_MODEL=anthropic:claude-haiku-4-5-20251001
+    QA_MODEL=ollama:qwen2.5:7b
+
+Alert schema
+  {
+    "code":     str,   — machine-readable code (SCOPE_DRIFT, COVERAGE_STALL, …)
+    "urgency":  str,   — "high" | "medium" | "low"
+    "blocking": bool,  — true = this alert blocks scan completion
+    "message":  str,   — human-readable description
+  }
 """
 from __future__ import annotations
 
@@ -22,6 +30,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypedDict
@@ -30,72 +39,158 @@ _log = logging.getLogger(__name__)
 _REPO_ROOT      = Path(__file__).parent.parent
 _QA_STATE_FILE  = _REPO_ROOT / "qa_state.json"
 _SESSION_FILE   = _REPO_ROOT / "session.json"
+_FINDINGS_FILE  = _REPO_ROOT / "findings.json"
+_COVERAGE_FILE  = _REPO_ROOT / "coverage_matrix.json"
 
+
+# ── Deterministic checks ──────────────────────────────────────────────────────
+
+def _deterministic_qa_checks(
+    summary: str,
+    findings_data: dict,
+    coverage_data: dict,
+) -> list[dict]:
+    """Rule-based checks over the summary text and structured state.
+
+    Returns a list of alert dicts: {code, urgency, blocking, message}.
+    """
+    alerts: list[dict] = []
+
+    # SCOPE_DRIFT — tool ran against a target outside the declared scope
+    if "Possible off-scope targets used:" in summary:
+        m = re.search(r"Possible off-scope targets used: (.+)", summary)
+        targets = m.group(1).strip() if m else "unknown"
+        alerts.append({
+            "code": "SCOPE_DRIFT", "urgency": "high", "blocking": False,
+            "message": f"Scope drift: tools ran against {targets}",
+        })
+
+    # COVERAGE_STALL — no coverage update for >30 min and cells still pending
+    stall_m   = re.search(r"WARNING: coverage stale \((\d+) min", summary)
+    pending_m = re.search(r",\s*(\d+) pending", summary)
+    if stall_m and pending_m:
+        mins    = int(stall_m.group(1))
+        pending = int(pending_m.group(1))
+        if pending > 0:
+            alerts.append({
+                "code": "COVERAGE_STALL", "urgency": "high", "blocking": False,
+                "message": f"Coverage stall — {pending} cells untested, last update {mins}min ago",
+            })
+
+    # SPIDER_WITHOUT_COVERAGE — spider ran but matrix is still empty
+    if "Endpoints found:" in summary:
+        cov_meta = coverage_data.get("meta", {})
+        if cov_meta.get("total_cells", 0) == 0:
+            m = re.search(r"Endpoints found: (\S+)", summary)
+            count = m.group(1) if m else "?"
+            alerts.append({
+                "code": "SPIDER_WITHOUT_COVERAGE", "urgency": "high", "blocking": False,
+                "message": f"Spider found {count} endpoint(s) but coverage matrix is empty — register endpoints",
+            })
+
+    # POC_GAP — high/critical finding has no linked PoC file (per-finding check)
+    high_crit   = [f for f in findings_data.get("findings", [])
+                   if f.get("severity") in ("high", "critical")]
+    missing_poc = [f for f in high_crit if not f.get("poc_files")]
+    if missing_poc:
+        titles = ", ".join(f["title"] for f in missing_poc[:3])
+        if len(missing_poc) > 3:
+            titles += f" +{len(missing_poc) - 3} more"
+        alerts.append({
+            "code": "POC_GAP", "urgency": "medium", "blocking": False,
+            "message": f"PoC gap: {len(missing_poc)}/{len(high_crit)} high/critical findings have no saved PoC: {titles}",
+        })
+
+    # SKILL_CHAIN_GAP — high/critical findings but web-exploit skill never invoked
+    if "Findings:" in summary and "web-exploit" not in summary:
+        sev_m = re.search(r"Findings: (.+)", summary)
+        if sev_m and ("critical" in sev_m.group(1) or " high" in sev_m.group(1)):
+            alerts.append({
+                "code": "SKILL_CHAIN_GAP", "urgency": "medium", "blocking": False,
+                "message": "High/critical findings but web-exploit not yet chained — run /web-exploit",
+            })
+
+    # TOOL_INACTIVITY — no tool call for >10 min
+    inact_m = re.search(r"Last tool call: (\d+) minutes ago", summary)
+    if inact_m:
+        mins = int(inact_m.group(1))
+        if mins > 10:
+            alerts.append({
+                "code": "TOOL_INACTIVITY", "urgency": "low", "blocking": False,
+                "message": f"No tool activity in {mins}min — is Smith stuck?",
+            })
+
+    # BULK_MARKING — many N/A cells without tested_by tool
+    if "Bulk-marking warning:" in summary:
+        m = re.search(r"Bulk-marking warning: (.+?)(?:\n|$)", summary)
+        detail = m.group(1).strip() if m else "N/A cells have no tested_by tool"
+        alerts.append({
+            "code": "BULK_MARKING", "urgency": "high", "blocking": True,
+            "message": f"Bulk-marking detected: {detail}",
+        })
+
+    # COVERAGE_INTEGRITY — tested/vulnerable cells with no tested_by
+    integ_m = re.search(r"(\d+) tested/vulnerable cells have no tested_by tool", summary)
+    if integ_m:
+        count = integ_m.group(1)
+        alerts.append({
+            "code": "COVERAGE_INTEGRITY", "urgency": "high", "blocking": True,
+            "message": f"Coverage integrity: {count} tested/vulnerable cells lack tested_by tool",
+        })
+
+    # GATE_PENDING — mandatory skill gate not yet satisfied
+    gate_m = re.search(r"Pending gates: (.+?)(?:\n|$)", summary)
+    if gate_m:
+        gate_info = gate_m.group(1)
+        time_m    = re.search(r"triggered (\d+)min ago", gate_info)
+        elapsed   = int(time_m.group(1)) if time_m else 0
+        if elapsed >= 5:
+            urgency   = "high" if elapsed >= 15 else "medium"
+            gid_m     = re.search(r"^(\S+) \(", gate_info)
+            gate_id   = gid_m.group(1) if gid_m else "unknown"
+            req_m     = re.search(r"requires: (.+?)\)", gate_info)
+            requires  = req_m.group(1) if req_m else "required skill"
+            alerts.append({
+                "code": "GATE_PENDING", "urgency": urgency, "blocking": False,
+                "message": f"Gate {gate_id} pending {elapsed}min — chain {requires} or dismiss",
+            })
+
+    # RCE_GATE_FALSE_POSITIVE — rce gate open but only low/medium/info findings
+    if gate_m and "rce" in gate_m.group(1).lower():
+        sev_m = re.search(r"Findings: (.+)", summary)
+        if sev_m:
+            sev_str = sev_m.group(1)
+            if "critical" not in sev_str and " high" not in sev_str:
+                alerts.append({
+                    "code": "RCE_GATE_FALSE_POSITIVE", "urgency": "medium", "blocking": False,
+                    "message": "RCE gate may be a false positive — verify finding severity",
+                })
+
+    return alerts
+
+
+# ── Semantic LLM review ───────────────────────────────────────────────────────
+
+# Prompt focuses only on what a Python rule cannot assess: semantic quality.
 QA_SYSTEM_PROMPT = """\
-You are a QA reviewer for a live penetration test. Work through the checklist below
-IN ORDER. For each check: read the exact line required, answer YES or NO, then act.
-Never infer, guess, or apply a rule to data that is not literally present in the summary.
+You are a QA reviewer for a penetration test. Review the finding quality below.
 
-## CHECKLIST
+For each high or critical finding, check:
+1. Is the severity plausibly overclaimed? (e.g. an info-disclosure marked critical)
+2. Is the description so vague it is not actionable by a developer?
+3. Is business impact absent or generic for a high/critical finding?
+4. Is an obvious next attack path missing? (e.g. auth bypass + IDOR suggests priv-esc path)
 
-CHECK 1 — Scope drift
-  Required line: "Possible off-scope targets used: <targets>"
-  If that EXACT line exists → flag high: "Scope drift: tools ran against <targets>"
-  If absent → SKIP. Do NOT mention scope drift.
+Only flag issues you can justify from the finding text. Do NOT flag missing PoCs or coverage
+gaps — those are handled by deterministic checks and will appear separately.
 
-CHECK 2 — RCE false-positive gate
-  Required: "Pending gates:" line contains the word "rce" or "post_exploit_rce"
-  AND "Findings:" line shows only medium/low/info severity
-  If BOTH true → flag medium: "RCE gate may be a false positive — verify finding severity"
-  Otherwise → SKIP. Do NOT apply this check to any other gate name (e.g. credential_audit).
-
-CHECK 3 — Pending gate (first time or escalation)
-  Required: "Pending gates:" line exists
-  Read the elapsed time shown in parentheses, e.g. "(triggered 8min ago)"
-  - 5–14 min AND gate not in "Previously flagged" → flag medium: "Gate <id> pending <N>min — chain <skill> or dismiss"
-  - 15–29 min AND high not already flagged for this gate → flag high
-  - ≥30 min → flag high
-  - <5 min OR already flagged at same/higher urgency → SKIP
-
-CHECK 4 — Coverage stall
-  Required: "Coverage last updated: N minutes ago" line exists AND N > 30
-  AND "pending" cell count > 0
-  If both true → flag high: "Coverage stall — <pending> cells untested, last update <N>min ago"
-  Otherwise → SKIP. Do NOT flag this if the line is absent or N ≤ 30.
-
-CHECK 5 — Spider without coverage
-  Required: "Endpoints found:" line exists AND coverage shows 0 cells tested AND 0 cells pending
-  If true → flag high: "Spider found endpoints but coverage matrix is empty — register endpoints"
-  Otherwise → SKIP
-
-CHECK 6 — Missing PoC files
-  Required: "PoC files saved: X / Y" line exists AND X < Y
-  If true → flag medium: "PoC gap: <X> of <Y> high/critical findings have no saved PoC"
-  If line is absent → SKIP. Do NOT mention PoCs.
-
-CHECK 7 — Skill chaining gap
-  Required: "Findings:" line shows critical or high AND "Skills invoked:" does NOT contain "web-exploit"
-  If true AND not in "Previously flagged" → flag medium: "High/critical findings but web-exploit not yet chained — run /web-exploit"
-  Otherwise → SKIP
-
-CHECK 8 — Tool inactivity
-  Required: "Last tool call:" line shows > 10 minutes ago
-  If true → flag low: "No tool activity in <N>min — is Smith stuck?"
-  Otherwise → SKIP
-
-## Deduplication
-"Previously flagged (last cycle):" lists what was already raised. Do NOT repeat the same
-alert unless the situation materially escalated (e.g. elapsed time crossed a new threshold).
-
-## Minimum data threshold
-If summary contains only a skill invocation (no findings, no tools, no coverage) → return {"alerts": []}
-
-## Output format
 Output ONLY valid JSON — no markdown, no explanation:
-{"alerts": [{"urgency": "high|medium|low", "message": "..."}]}
-Max 3 alerts. If nothing to flag, return {"alerts": []}.
+{"alerts": [{"code": "FINDING_QUALITY", "urgency": "high|medium", "blocking": false, "message": "..."}]}
+Max 2 alerts. If no semantic issues, return {"alerts": []}.
 """
 
+
+# ── LangGraph wiring ──────────────────────────────────────────────────────────
 
 class QAState(TypedDict):
     summary: str
@@ -104,7 +199,6 @@ class QAState(TypedDict):
 
 
 def _init_llm(model_name: str, max_tokens: int = 512):
-    """Direct provider dispatch — no dependency on langchain.chat_models.init_chat_model."""
     provider, _, model = model_name.partition(":")
     if not model:
         provider, model = "openai", model_name
@@ -121,16 +215,11 @@ def _init_llm(model_name: str, max_tokens: int = 512):
 
 
 def _build_graph():
-    """Build and return the LangGraph QA graph, or None if deps are missing."""
+    """Build and return the LangGraph semantic QA graph, or None if deps are missing."""
     try:
         from langgraph.graph import StateGraph, END
-        from langchain_core.messages import SystemMessage, HumanMessage
     except ImportError as exc:
-        _log.warning(
-            "QA Agent: langgraph / langchain-core not installed (%s). "
-            "Install them to enable the QA daemon.",
-            exc,
-        )
+        _log.warning("QA Agent: langgraph / langchain-core not installed (%s). Semantic review disabled.", exc)
         return None
 
     model_name = os.getenv("QA_MODEL", "openai:gpt-4o-mini")
@@ -155,7 +244,17 @@ def _build_graph():
                 alerts = []
         except (json.JSONDecodeError, AttributeError):
             alerts = []
-        return {**state, "alerts": alerts}
+        # Ensure every alert has the required schema fields
+        cleaned = []
+        for a in alerts:
+            if isinstance(a, dict) and a.get("message"):
+                cleaned.append({
+                    "code":     str(a.get("code", "FINDING_QUALITY")),
+                    "urgency":  str(a.get("urgency", "medium")),
+                    "blocking": bool(a.get("blocking", False)),
+                    "message":  str(a["message"]),
+                })
+        return {**state, "alerts": cleaned}
 
     graph = StateGraph(QAState)
     graph.add_node("invoke_llm", invoke_llm)
@@ -165,6 +264,27 @@ def _build_graph():
     graph.add_edge("parse_response", END)
     return graph.compile()
 
+
+def _format_findings_for_semantic_review(findings_data: dict) -> str:
+    """Format high/critical findings as compact text for the LLM."""
+    high_crit = [
+        f for f in findings_data.get("findings", [])
+        if f.get("severity") in ("high", "critical")
+    ]
+    if not high_crit:
+        return ""
+    lines = []
+    for f in high_crit[:10]:
+        lines.append(
+            f"[{f['severity'].upper()}] {f['title']}\n"
+            f"  description: {(f.get('description') or '')[:300]}\n"
+            f"  evidence: {(f.get('evidence') or '')[:200]}\n"
+            f"  business_impact: {(f.get('business_impact') or 'not set')}"
+        )
+    return "\n\n".join(lines)
+
+
+# ── State helpers ─────────────────────────────────────────────────────────────
 
 def _session_is_running() -> bool:
     try:
@@ -183,15 +303,32 @@ def _read_qa_state() -> dict:
         return {}
 
 
-def _build_context_summary(summary: str, previous_alerts: list[dict]) -> str:
-    if not previous_alerts:
-        return summary
-    prev_lines = "\n".join(f"- [{a['urgency']}] {a['message']}" for a in previous_alerts)
-    return summary + f"\n\nPreviously flagged (last cycle):\n{prev_lines}"
+def _load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text()) if path.exists() else {}
+    except Exception:
+        return {}
+
+
+def _deduplicate(new_alerts: list[dict], previous_alerts: list[dict]) -> list[dict]:
+    """Drop alerts whose code+message were already raised at same/higher urgency last cycle."""
+    _URGENCY = {"high": 2, "medium": 1, "low": 0}
+    prev_by_code: dict[str, dict] = {}
+    for a in previous_alerts:
+        code = a.get("code", "")
+        if code and (_URGENCY.get(a.get("urgency", ""), 0) >= _URGENCY.get(prev_by_code.get(code, {}).get("urgency", "low"), 0)):
+            prev_by_code[code] = a
+
+    result = []
+    for a in new_alerts:
+        prev = prev_by_code.get(a.get("code", ""))
+        if prev and prev.get("message") == a.get("message"):
+            continue  # unchanged — skip to avoid noise
+        result.append(a)
+    return result
 
 
 def _sanitize_history(raw: list) -> list[dict]:
-    """Reconstruct history entries from known fields, breaking the taint chain from disk reads."""
     result = []
     for entry in raw:
         if not isinstance(entry, dict):
@@ -206,6 +343,8 @@ def _sanitize_history(raw: list) -> list[dict]:
         })
     return result
 
+
+# ── Daemon ────────────────────────────────────────────────────────────────────
 
 class QADaemon:
     def __init__(self):
@@ -231,48 +370,53 @@ class QADaemon:
         if not _session_is_running():
             return
 
-        graph = self._get_graph()
-        if graph is None:
-            return
-
         from core.quick_log import quick_log
         summary = quick_log.summarize()
         if not summary.strip() or summary == "No activity logged yet.":
             return
 
-        existing = _read_qa_state()
+        findings_data = _load_json(_FINDINGS_FILE)
+        coverage_data = _load_json(_COVERAGE_FILE)
+
+        # Layer 1: deterministic checks — always run, no LLM cost
+        determ_alerts = _deterministic_qa_checks(summary, findings_data, coverage_data)
+
+        # Layer 2: semantic LLM review — only when there are high/critical findings
+        semantic_alerts: list[dict] = []
+        finding_text = _format_findings_for_semantic_review(findings_data)
+        if finding_text:
+            graph = self._get_graph()
+            if graph is not None:
+                try:
+                    result = await asyncio.to_thread(
+                        graph.invoke,
+                        {"summary": finding_text, "raw_response": "", "alerts": []},
+                    )
+                    semantic_alerts = result.get("alerts", [])
+                except Exception as exc:
+                    _log.warning("QA Daemon: semantic review failed — %s", exc)
+
+        all_alerts = determ_alerts + semantic_alerts
+
+        existing       = _read_qa_state()
         previous_alerts: list[dict] = existing.get("alerts", [])
-        summary_with_ctx = _build_context_summary(summary, previous_alerts)
+
+        # Deduplicate against last cycle to reduce noise
+        unique_alerts = _deduplicate(all_alerts, previous_alerts)
+        if not unique_alerts and not all_alerts:
+            return
+
+        # Cap at 4 alerts (deterministic takes priority over semantic)
+        final_alerts = (all_alerts if not unique_alerts else unique_alerts)[:4]
+
         ts_before = datetime.now(timezone.utc).isoformat()
 
-        result = await asyncio.to_thread(
-            graph.invoke,
-            {"summary": summary_with_ctx, "raw_response": "", "alerts": []},
-        )
-        alerts = result.get("alerts", [])
-
-        # Guard against malformed LLM output (alerts not a list of dicts).
-        if not isinstance(alerts, list) or not all(isinstance(a, dict) for a in alerts):
-            _QA_STATE_FILE.write_text(json.dumps({
-                "ts":      datetime.now(timezone.utc).isoformat(),
-                "alerts":  alerts,
-                "history": [],
-            }))
-            return
-
-        new_msgs  = sorted(a.get("message", "") for a in alerts)
-        prev_msgs = sorted(a.get("message", "") for a in previous_alerts)
-        if new_msgs and new_msgs == prev_msgs:
-            _log.info("QA Daemon: alerts unchanged — skipping write")
-            return
-
-        # Re-read after LLM call so a Clear All during inference is respected.
+        # Re-read after async work so a Clear All during inference is respected
         post_existing = _read_qa_state()
-        history = _sanitize_history(post_existing.get("history", []))
+        history       = _sanitize_history(post_existing.get("history", []))
         prev_cycle_ts = history[-1]["ts"] if history else ""
-        events_since = quick_log.read_since(prev_cycle_ts) if prev_cycle_ts else []
+        events_since  = quick_log.read_since(prev_cycle_ts) if prev_cycle_ts else []
 
-        # Separate QA_REPLY events (Smith's words) from tool actions
         smith_reply = " ".join(
             e["message"] for e in events_since
             if e.get("type") == "QA_REPLY" and e.get("message")
@@ -282,18 +426,19 @@ class QADaemon:
         history.append({
             "ts":            ts_before,
             "summary_sent":  summary,
-            "alerts":        alerts,
+            "alerts":        final_alerts,
             "smith_reply":   smith_reply,
             "smith_actions": smith_actions,
         })
 
         _QA_STATE_FILE.write_text(json.dumps({
             "ts":      datetime.now(timezone.utc).isoformat(),
-            "alerts":  alerts,
+            "alerts":  final_alerts,
             "history": history[-20:],
         }))
 
-        _log.info("QA Daemon: %d alert(s) written to qa_state.json", len(alerts))
+        _log.info("QA Daemon: %d alert(s) written (%d determ, %d semantic)",
+                  len(final_alerts), len(determ_alerts), len(semantic_alerts))
 
 
 qa_daemon = QADaemon()

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -122,7 +122,7 @@ def _deterministic_qa_checks(
 
     # BULK_MARKING — many N/A cells without tested_by tool
     if "Bulk-marking warning:" in summary:
-        m = re.search(r"Bulk-marking warning: (.+?)(?:\n|$)", summary)
+        m = re.search(r"Bulk-marking warning: (.+)(?:\n|$)", summary)
         detail = m.group(1).strip() if m else "N/A cells have no tested_by tool"
         alerts.append({
             "code": "BULK_MARKING", "urgency": "high", "blocking": True,
@@ -139,7 +139,7 @@ def _deterministic_qa_checks(
         })
 
     # GATE_PENDING — mandatory skill gate not yet satisfied
-    gate_m = re.search(r"Pending gates: (.+?)(?:\n|$)", summary)
+    gate_m = re.search(r"Pending gates: (.+)(?:\n|$)", summary)
     if gate_m:
         gate_info = gate_m.group(1)
         time_m    = re.search(r"triggered (\d+)min ago", gate_info)

--- a/core/quick_log.py
+++ b/core/quick_log.py
@@ -10,6 +10,7 @@ Entry types:
   SPIDER   — spider completed (TOOL subtype with endpoint count)
   FINDING  — report(action="finding") called
   COVERAGE — coverage matrix updated (endpoint registered or bulk_tested)
+  QA_REPLY — Smith's textual response to QA alerts (session action="qa_reply")
 """
 from __future__ import annotations
 

--- a/core/quick_log.py
+++ b/core/quick_log.py
@@ -108,16 +108,30 @@ def _scope_drift_lines(declared_target: str, tools_all: list[dict]) -> list[str]
 def _coverage_lines(coverages: list[dict], now: datetime) -> list[str]:
     if not coverages:
         return []
-    last_cov   = coverages[-1]
-    pending    = last_cov.get("pending", 0)
-    tested     = last_cov.get("tested", 0)
-    registered = last_cov.get("registered", 0)
-    total_cells = pending + tested
-    pct = f"{round(pending / total_cells * 100)}%" if total_cells > 0 else "?"
+    last_cov       = coverages[-1]
+    pending        = last_cov.get("pending", 0)
+    tested         = last_cov.get("tested", 0)
+    registered     = last_cov.get("registered", 0)
+    not_applicable = last_cov.get("not_applicable", 0)
+    skipped        = last_cov.get("skipped", 0)
+    na_untooled    = last_cov.get("na_untooled", 0)
+    untooled       = last_cov.get("untooled", 0)
+    total_cells    = pending + tested + not_applicable + skipped
+    addressed      = tested + not_applicable
+    pct = f"{round(addressed / total_cells * 100)}%" if total_cells > 0 else "?"
     lines = [
         f"Coverage: {registered} endpoints, {total_cells} cells — "
-        f"{tested} tested, {pending} pending ({pct} pending)"
+        f"{tested} tested, {not_applicable} N/A, {skipped} skipped, {pending} pending ({pct} addressed)"
     ]
+    integrity_issues: list[str] = []
+    if untooled > 0:
+        integrity_issues.append(f"{untooled} tested/vulnerable cells have no tested_by tool")
+    if na_untooled > 10:
+        integrity_issues.append(
+            f"Bulk-marking warning: {na_untooled} N/A cells have no tested_by tool — "
+            f"cells must be tested individually, not bulk-marked without tool evidence"
+        )
+    lines.extend(integrity_issues)
     try:
         cov_dt = datetime.fromisoformat(last_cov["ts"])
         cov_elapsed = round((now - cov_dt).total_seconds() / 60)

--- a/core/session.py
+++ b/core/session.py
@@ -179,13 +179,23 @@ def check_limits(cost_summary: dict) -> str | None:
     return None
 
 
-def complete(notes: str = "", stop_reason: str | None = None) -> dict:
-    """Mark the scan as done (called by Claude when finished)."""
+def complete(
+    notes: str = "",
+    stop_reason: str | None = None,
+    quality_gate: str | None = None,
+) -> dict:
+    """Mark the scan as done (called by Claude when finished).
+
+    quality_gate="failed" sets status to "incomplete_with_unresolved_blockers"
+    so dashboards and exports can distinguish a force-completed scan from a clean one.
+    """
     global _current
     if _current and _current["status"] == "running":
-        _current["status"]   = "complete"
+        _current["status"]   = "incomplete_with_unresolved_blockers" if quality_gate == "failed" else "complete"
         _current["finished"] = datetime.now(timezone.utc).isoformat()
         _current["notes"]    = notes
+        if quality_gate:
+            _current["quality_gate"] = quality_gate
         if stop_reason is not None:
             _current["stop_reason"] = stop_reason
         _flush()

--- a/core/session.py
+++ b/core/session.py
@@ -179,13 +179,15 @@ def check_limits(cost_summary: dict) -> str | None:
     return None
 
 
-def complete(notes: str = "") -> dict:
+def complete(notes: str = "", stop_reason: str | None = None) -> dict:
     """Mark the scan as done (called by Claude when finished)."""
     global _current
     if _current and _current["status"] == "running":
         _current["status"]   = "complete"
         _current["finished"] = datetime.now(timezone.utc).isoformat()
         _current["notes"]    = notes
+        if stop_reason is not None:
+            _current["stop_reason"] = stop_reason
         _flush()
     return _current or {}
 

--- a/mcp_server/http_tools.py
+++ b/mcp_server/http_tools.py
@@ -35,6 +35,7 @@ async def http(
     save_poc options:
       title=poc        — filename label
       notes=           — description written as comment in the .http file
+      finding_id=      — finding UUID to auto-link this PoC (adds filepath to finding.poc_files)
     """
     if isinstance(body, dict):
         body = json.dumps(body)
@@ -44,7 +45,7 @@ async def http(
     if action == "request":
         return await _do_request(url, method, headers, body, opts)
     elif action == "save_poc":
-        return _do_save_poc(url, method, headers, body, opts)
+        return await _do_save_poc(url, method, headers, body, opts)
     else:
         return f"Unknown action '{action}'. Use: request, save_poc"
 
@@ -87,12 +88,13 @@ async def _do_request(url, method, headers, body, opts):
     return wrap("http_request", result, {"url": url, "method": method})
 
 
-def _do_save_poc(url, method, headers, body, opts):
+async def _do_save_poc(url, method, headers, body, opts):
     import datetime as dt
     from urllib.parse import urlparse
 
-    title = opts.get("title", "poc")
-    notes = opts.get("notes", "")
+    title      = opts.get("title", "poc")
+    notes      = opts.get("notes", "")
+    finding_id = opts.get("finding_id", "")
 
     parsed = urlparse(url)
     host = parsed.netloc
@@ -121,9 +123,15 @@ def _do_save_poc(url, method, headers, body, opts):
             f.write(f"# {notes}\n\n")
         f.write(raw)
 
+    linked = False
+    if finding_id:
+        from core import findings as findings_store
+        linked = await findings_store.link_poc(finding_id, filepath)
+
     result = json.dumps({
-        "saved": filepath,
-        "hint": "Open Burp Repeater and paste this file to load the request",
+        "saved":      filepath,
+        "linked_to":  finding_id if linked else None,
+        "hint":       "Open Burp Repeater and paste this file to load the request",
     })
     log.tool_result("save_poc", result)
     return result

--- a/mcp_server/http_tools.py
+++ b/mcp_server/http_tools.py
@@ -1,6 +1,7 @@
 """
 Consolidated HTTP tool — replaces http_request and save_poc from exploitation.py
 """
+import asyncio
 import json
 import os
 from typing import Any
@@ -8,6 +9,11 @@ from typing import Any
 from core import cost as cost_tracker
 from core import logger as log
 from mcp_server._app import mcp, _ensure_dict
+
+
+def _write_text(path: str, content: str) -> None:
+    with open(path, "w") as fh:
+        fh.write(content)
 
 
 @mcp.tool()
@@ -118,10 +124,8 @@ async def _do_save_poc(url, method, headers, body, opts):
     timestamp = dt.datetime.now().strftime("%Y%m%d_%H%M%S")
     filepath = os.path.join(pocs_dir, f"{timestamp}_{safe_title}.http")
 
-    with open(filepath, "w") as f:
-        if notes:
-            f.write(f"# {notes}\n\n")
-        f.write(raw)
+    poc_content = (f"# {notes}\n\n" if notes else "") + raw
+    await asyncio.to_thread(_write_text, filepath, poc_content)
 
     linked = False
     if finding_id:

--- a/mcp_server/report_tools.py
+++ b/mcp_server/report_tools.py
@@ -414,14 +414,22 @@ async def _emit_coverage_event() -> None:
     try:
         from core.quick_log import quick_log as _qlog
         from core import coverage as _cov
-        matrix = _cov.get_matrix()
-        meta   = matrix.get("meta", {})
+        matrix    = _cov.get_matrix()
+        meta      = matrix.get("meta", {})
+        all_cells = matrix.get("matrix", [])
         await _qlog.append({
-            "type":       "COVERAGE",
-            "registered": len(matrix.get("endpoints", [])),
-            "pending":    sum(1 for c in matrix.get("matrix", []) if c["status"] == "pending"),
-            "tested":     meta.get("tested", 0),
-            "vulnerable": meta.get("vulnerable", 0),
+            "type":           "COVERAGE",
+            "registered":     len(matrix.get("endpoints", [])),
+            "pending":        sum(1 for c in all_cells if c["status"] == "pending"),
+            "tested":         meta.get("tested", 0),
+            "vulnerable":     meta.get("vulnerable", 0),
+            "not_applicable": sum(1 for c in all_cells if c["status"] == "not_applicable"),
+            "skipped":        sum(1 for c in all_cells if c["status"] == "skipped"),
+            "na_untooled":    sum(1 for c in all_cells
+                                  if c["status"] == "not_applicable" and not c.get("tested_by")),
+            "untooled":       sum(1 for c in all_cells
+                                  if c["status"] in ("tested_clean", "vulnerable")
+                                  and not c.get("tested_by")),
         })
     except Exception:
         pass

--- a/mcp_server/scan_engine/state.py
+++ b/mcp_server/scan_engine/state.py
@@ -33,7 +33,9 @@ def get_state() -> dict:
     cov = get_matrix()
     meta = cov.get("meta", {})
     total_cells = meta.get("total_cells", 0)
-    tested = meta.get("tested", 0) + meta.get("not_applicable", 0) + meta.get("skipped", 0)
+    # Use the pre-computed "addressed" counter so phase logic agrees with coverage blockers.
+    # skipped is not addressed — it is a deferral. See core/coverage.ADDRESSED_STATUSES.
+    tested = meta.get("addressed", meta.get("tested", 0) + meta.get("not_applicable", 0))
     vulnerable = meta.get("vulnerable", 0)
     endpoints = len(cov.get("endpoints", []))
 

--- a/mcp_server/scan_tools.py
+++ b/mcp_server/scan_tools.py
@@ -141,26 +141,15 @@ async def _handle_trufflehog(target, flags, options):
 
 
 async def _handle_fuzzyai(target, flags, options):
-    from tools import kali_runner
-
-    attack = options.get("attack", "jailbreak")
+    # FuzzyAI runs as its own Docker image (ghcr.io/cyberark/fuzzyai) via docker_runner,
+    # NOT inside the Kali container — it is not installed in the Kali Dockerfile.
+    _record("fuzzyai")
+    attack   = options.get("attack",   "jailbreak")
     provider = options.get("provider", "openai")
-    model = options.get("model", "")
-    timeout = options.get("timeout", 900)
-
-    safe_target = shlex.quote(target)
-    cmd = f"fuzzyai --target {safe_target} --attack {shlex.quote(attack)} --provider {shlex.quote(provider)}"
-    if model:
-        cmd += f" --model {shlex.quote(model)}"
-    if flags:
-        cmd += f" {shlex.join(shlex.split(flags))}"
-
-    log.tool_call("fuzzyai", {"target": target, "attack": attack, "provider": provider, "model": model})
-    call_id = cost_tracker.start("fuzzyai")
-    result = _clip(await kali_runner.exec_command(cmd, timeout=timeout), 12_000)
-    cost_tracker.finish(call_id, result)
-    log.tool_result("fuzzyai", result)
-    return result
+    model    = options.get("model",    "")
+    raw = await _run("fuzzyai", target=target, attack=attack, provider=provider, model=model, flags=flags)
+    from mcp_server.scan_engine import wrap
+    return wrap("fuzzyai", raw, {"target": target, "attack": attack})
 
 
 async def _handle_pyrit(target, flags, options):

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -58,7 +58,7 @@ def _effective_tools() -> set[str]:
 async def session(action: str, options: dict | None = None) -> str:
     """Scan lifecycle and infrastructure management.
 
-    action  : start | complete | status | recovery | artifact | set_skill | set_step | start_kali | stop_kali | start_metasploit | stop_metasploit | pull_images | set_codebase
+    action  : start | complete | status | recovery | artifact | qa_reply | set_skill | set_step | start_kali | stop_kali | start_metasploit | stop_metasploit | pull_images | set_codebase
 
     start options:
       target, depth=standard (recon|standard|thorough), scope=[],
@@ -66,6 +66,11 @@ async def session(action: str, options: dict | None = None) -> str:
       model_profile=full (full|medium|small) — controls output verbosity
 
     complete options: notes=
+
+    qa_reply options:
+      message= (your response to the QA agent's alerts — what you acknowledge and what
+                you plan to do. Call this immediately after session(action="status")
+                returns qa_alerts so the QA ↔ Smith conversation log is complete.)
 
     status: returns current scan state (target, tools run, findings, cost)
 
@@ -113,6 +118,8 @@ async def session(action: str, options: dict | None = None) -> str:
         return await _do_pull_images()
     elif action == "set_codebase":
         return _do_set_codebase(opts)
+    elif action == "qa_reply":
+        return await _do_qa_reply(opts)
     elif action == "recovery":
         return _do_recovery()
     elif action == "artifact":
@@ -120,7 +127,7 @@ async def session(action: str, options: dict | None = None) -> str:
     elif action == "pre_chain":
         return _do_pre_chain(opts)
     else:
-        return f"Unknown action '{action}'. Use: start, complete, status, recovery, artifact, pre_chain, set_skill, set_step, start_kali, stop_kali, start_metasploit, stop_metasploit, pull_images, set_codebase"
+        return f"Unknown action '{action}'. Use: start, complete, status, qa_reply, recovery, artifact, pre_chain, set_skill, set_step, start_kali, stop_kali, start_metasploit, stop_metasploit, pull_images, set_codebase"
 
 
 def _do_start(opts):
@@ -424,6 +431,16 @@ async def _do_complete(opts):
     log.note(f"Scan complete — {notes}")
     _complete_attempts = 0
     return f"Scan marked {status}. session.json updated. STOP — do not call any more tools. The scan is done."
+
+
+async def _do_qa_reply(opts):
+    """Log Smith's textual response to QA alerts so the conversation record is complete."""
+    from core.quick_log import quick_log
+    message = str(opts.get("message", "")).strip()
+    if not message:
+        return "qa_reply requires a non-empty message= option."
+    await quick_log.append({"type": "QA_REPLY", "message": message})
+    return "QA reply logged."
 
 
 def _do_status():

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -364,7 +364,8 @@ def _qa_blockers() -> list[str]:
     qa_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "qa_state.json")
     try:
         if os.path.exists(qa_path):
-            qa = json.loads(open(qa_path).read())
+            with open(qa_path) as _fh:
+                qa = json.loads(_fh.read())
             return [
                 f"QA BLOCKER [{a.get('code', '?')}]: {a.get('message', '')}"
                 for a in qa.get("alerts", [])
@@ -581,7 +582,8 @@ def _do_status():
     _qa_path = _os.path.join(_os.path.dirname(_os.path.dirname(__file__)), "qa_state.json")
     try:
         if _os.path.exists(_qa_path):
-            _qa = json.loads(open(_qa_path).read())
+            with open(_qa_path) as _fh:
+                _qa = json.loads(_fh.read())
             result["qa_alerts"] = _qa.get("alerts", [])
             result["qa_last_check"] = _qa.get("ts", "")
         else:

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -232,6 +232,52 @@ def _do_start(opts):
     return "\n".join(lines)
 
 
+def _low_coverage_blocker(
+    cov: dict, coverage_enforced: bool, total: int, addressed: int, pct: float
+) -> str | None:
+    if not coverage_enforced or pct >= 80:
+        return None
+    all_cells = cov.get("matrix", [])
+    pending = [c["id"] for c in all_cells if c.get("status", "pending") == "pending"]
+    hint = (
+        "For each pending cell: either test it (set status=tested_clean/vulnerable with "
+        "tested_by=<tool>) or mark it not_applicable if the injection type is inherently "
+        "irrelevant to the param/endpoint type (with a specific reason in notes). "
+        "Do NOT bulk-skip — skipped cells are excluded from coverage. Sample pending cells:\n"
+        '  report(action="coverage", data={"type": "bulk_tested", "updates": ['
+    )
+    hint += ", ".join(
+        f'{{"cell_id": "{cid}", "status": "not_applicable", "notes": "<specific reason>"}}'
+        for cid in pending[:10]
+    )
+    if len(pending) > 10:
+        hint += f", ... ({len(pending) - 10} more)"
+    hint += "]})"
+    return (
+        f"LOW COVERAGE: only {addressed}/{total} matrix cells tested or marked N/A ({pct:.0f}%). "
+        f"{len(pending)} pending cell(s). {hint}"
+    )
+
+
+def _skipped_no_evidence_blocker(all_cells: list[dict]) -> str | None:
+    _WAF_KEYWORDS = ("403", "429", "waf", "blocked", "rate limit", "firewall")
+    skipped = [
+        c for c in all_cells
+        if c["status"] == "skipped"
+        and not any(kw in c.get("notes", "").lower() for kw in _WAF_KEYWORDS)
+    ]
+    if not skipped:
+        return None
+    sample = ", ".join(c["id"] for c in skipped[:5])
+    if len(skipped) > 5:
+        sample += f" ... ({len(skipped) - 5} more)"
+    return (
+        f"INTEGRITY: {len(skipped)} cell(s) marked skipped without WAF block "
+        f"evidence (403/429/WAF) in notes: {sample}. "
+        f"'skipped' is only valid when a WAF blocked the request — add the response evidence or re-test."
+    )
+
+
 def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
     """Return coverage-related completion blockers for the given matrix state.
 
@@ -274,27 +320,9 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
     profile = get_profile()
     coverage_enforced = not profile.get("enforce_budget", True)  # full=enforce, medium/small=skip
 
-    if coverage_enforced and pct < 80:
-        all_cells_tmp = cov.get("matrix", [])
-        pending = [c["id"] for c in all_cells_tmp if c.get("status", "pending") == "pending"]
-        hint = (
-            f"For each pending cell: either test it (set status=tested_clean/vulnerable with "
-            f"tested_by=<tool>) or mark it not_applicable if the injection type is inherently "
-            f"irrelevant to the param/endpoint type (with a specific reason in notes). "
-            f"Do NOT bulk-skip — skipped cells are excluded from coverage. Sample pending cells:\n"
-            '  report(action="coverage", data={"type": "bulk_tested", "updates": ['
-        )
-        hint += ", ".join(
-            f'{{"cell_id": "{cid}", "status": "not_applicable", "notes": "<specific reason>"}}'
-            for cid in pending[:10]
-        )
-        if len(pending) > 10:
-            hint += f", ... ({len(pending) - 10} more)"
-        hint += "]})"
-        blockers.append(
-            f"LOW COVERAGE: only {addressed}/{total} matrix cells tested or marked N/A ({pct:.0f}%). "
-            f"{len(pending)} pending cell(s). {hint}"
-        )
+    low_cov = _low_coverage_blocker(cov, coverage_enforced, total, addressed, pct)
+    if low_cov:
+        blockers.append(low_cov)
 
     all_cells = cov.get("matrix", [])
     untooled = [c for c in all_cells
@@ -313,21 +341,9 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
             f"techniques: {sample}. Test the bypass before marking N/A."
         )
 
-    _WAF_KEYWORDS = ("403", "429", "waf", "blocked", "rate limit", "firewall")
-    skipped_no_evidence = [
-        c for c in all_cells
-        if c["status"] == "skipped"
-        and not any(kw in c.get("notes", "").lower() for kw in _WAF_KEYWORDS)
-    ]
-    if skipped_no_evidence:
-        sample = ", ".join(c["id"] for c in skipped_no_evidence[:5])
-        if len(skipped_no_evidence) > 5:
-            sample += f" ... ({len(skipped_no_evidence) - 5} more)"
-        blockers.append(
-            f"INTEGRITY: {len(skipped_no_evidence)} cell(s) marked skipped without WAF block "
-            f"evidence (403/429/WAF) in notes: {sample}. "
-            f"'skipped' is only valid when a WAF blocked the request — add the response evidence or re-test."
-        )
+    skipped_blocker = _skipped_no_evidence_blocker(all_cells)
+    if skipped_blocker:
+        blockers.append(skipped_blocker)
 
     na_untooled = [
         c for c in all_cells
@@ -408,6 +424,27 @@ def _escalation_lead_blockers(data: dict) -> list[str]:
     ]
 
 
+def _finding_quality_blockers(high_findings: list[dict]) -> str | None:
+    """Return a blocker string if any high/critical finding lacks evidence or reproduction."""
+    quality_issues: list[str] = []
+    for f in high_findings:
+        missing: list[str] = []
+        if not str(f.get("evidence", "")).strip():
+            missing.append("evidence")
+        if not f.get("reproduction"):
+            missing.append("reproduction")
+        if missing:
+            quality_issues.append(f"[{f['severity'].upper()}] {f['title']}: missing {', '.join(missing)}")
+    if not quality_issues:
+        return None
+    sample = "\n    ".join(quality_issues[:5])
+    more   = f"\n    (+{len(quality_issues) - 5} more)" if len(quality_issues) > 5 else ""
+    return (
+        f"FINDING QUALITY: {len(quality_issues)} high/critical finding(s) missing required fields. "
+        f"Add evidence and reproduction steps before completing:\n    {sample}{more}"
+    )
+
+
 async def _do_complete(opts):
     global _complete_attempts
     _complete_attempts += 1
@@ -447,22 +484,9 @@ async def _do_complete(opts):
         )
 
     # ── Finding quality blockers ──────────────────────────────────────────────
-    quality_issues: list[str] = []
-    for f in high_findings:
-        missing: list[str] = []
-        if not str(f.get("evidence", "")).strip():
-            missing.append("evidence")
-        if not f.get("reproduction"):
-            missing.append("reproduction")
-        if missing:
-            quality_issues.append(f"[{f['severity'].upper()}] {f['title']}: missing {', '.join(missing)}")
-    if quality_issues:
-        sample = "\n    ".join(quality_issues[:5])
-        more   = f"\n    (+{len(quality_issues) - 5} more)" if len(quality_issues) > 5 else ""
-        blockers.append(
-            f"FINDING QUALITY: {len(quality_issues)} high/critical finding(s) missing required fields. "
-            f"Add evidence and reproduction steps before completing:\n    {sample}{more}"
-        )
+    quality_blocker = _finding_quality_blockers(high_findings)
+    if quality_blocker:
+        blockers.append(quality_blocker)
 
     from core.coverage import get_matrix
     blockers.extend(_coverage_blockers(get_matrix(), ctf_mode=_has_ctf_flag(data)))

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -20,6 +20,8 @@ _complete_attempts = 0
 _MAX_COMPLETE_ATTEMPTS = 5
 _force_completed = False
 
+_QA_STATE_FILENAME = "qa_state.json"
+
 
 # ── CTF flag pattern (e.g. CTF{...}, flag{...}, HTB{...}) ─────────────────────
 _FLAG_RE = re.compile(r'[A-Za-z0-9_]{2,10}\{[A-Za-z0-9_\-!@#$%^&*()+=,.?]{4,}\}')
@@ -161,7 +163,7 @@ def _do_start(opts):
         archive_path = archive_dir / f"coverage_matrix_{ts}.json"
         shutil.copy2(COVERAGE_FILE, archive_path)
         log.note(f"Coverage matrix archived to {archive_path.name} (previous target: {prev_target})")
-        for stale in ("quick_log.json", "qa_state.json"):
+        for stale in ("quick_log.json", _QA_STATE_FILENAME):
             p = COVERAGE_FILE.parent / stale
             p.unlink(missing_ok=True)
         _cov_save({
@@ -280,7 +282,7 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
             f"tested_by=<tool>) or mark it not_applicable if the injection type is inherently "
             f"irrelevant to the param/endpoint type (with a specific reason in notes). "
             f"Do NOT bulk-skip — skipped cells are excluded from coverage. Sample pending cells:\n"
-            f'  report(action="coverage", data={{"type": "bulk_tested", "updates": ['
+            '  report(action="coverage", data={"type": "bulk_tested", "updates": ['
         )
         hint += ", ".join(
             f'{{"cell_id": "{cid}", "status": "not_applicable", "notes": "<specific reason>"}}'
@@ -361,7 +363,7 @@ def _suspect_na_cells(cells: list[dict], bypass_types: dict) -> list[str]:
 
 def _qa_blockers() -> list[str]:
     """Return completion blockers from open high-urgency, blocking QA alerts."""
-    qa_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "qa_state.json")
+    qa_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), _QA_STATE_FILENAME)
     try:
         if os.path.exists(qa_path):
             with open(qa_path) as _fh:
@@ -579,7 +581,7 @@ def _do_status():
 
     # QA alerts — injected from qa_state.json so Smith can self-correct
     import os as _os
-    _qa_path = _os.path.join(_os.path.dirname(_os.path.dirname(__file__)), "qa_state.json")
+    _qa_path = _os.path.join(_os.path.dirname(_os.path.dirname(__file__)), _QA_STATE_FILENAME)
     try:
         if _os.path.exists(_qa_path):
             with open(_qa_path) as _fh:

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -260,7 +260,9 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
 
     # skipped cells do NOT count toward coverage — they are deferrals, not evidence.
     # Only tested_clean, vulnerable, and not_applicable are real coverage signals.
-    addressed = meta.get("tested", 0) + meta.get("not_applicable", 0)
+    # Use the pre-computed "addressed" counter from _recount(); fall back to the sum for
+    # matrices written before this field existed.
+    addressed = meta.get("addressed", meta.get("tested", 0) + meta.get("not_applicable", 0))
     pct = (addressed / total) * 100
 
     # Model-profile-aware: only enforce 80% coverage threshold for "full" profile.
@@ -308,6 +310,38 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
             f"INTEGRITY: {len(suspect_na)} cell(s) marked N/A without testing bypass "
             f"techniques: {sample}. Test the bypass before marking N/A."
         )
+
+    _WAF_KEYWORDS = ("403", "429", "waf", "blocked", "rate limit", "firewall")
+    skipped_no_evidence = [
+        c for c in all_cells
+        if c["status"] == "skipped"
+        and not any(kw in c.get("notes", "").lower() for kw in _WAF_KEYWORDS)
+    ]
+    if skipped_no_evidence:
+        sample = ", ".join(c["id"] for c in skipped_no_evidence[:5])
+        if len(skipped_no_evidence) > 5:
+            sample += f" ... ({len(skipped_no_evidence) - 5} more)"
+        blockers.append(
+            f"INTEGRITY: {len(skipped_no_evidence)} cell(s) marked skipped without WAF block "
+            f"evidence (403/429/WAF) in notes: {sample}. "
+            f"'skipped' is only valid when a WAF blocked the request — add the response evidence or re-test."
+        )
+
+    na_untooled = [
+        c for c in all_cells
+        if c["status"] == "not_applicable"
+        and not c.get("tested_by")
+        and c.get("injection_type") in _BYPASS_REQUIRED_TYPES
+    ]
+    if na_untooled:
+        sample = ", ".join(f"{c['id']} ({c['injection_type']})" for c in na_untooled[:5])
+        if len(na_untooled) > 5:
+            sample += f" ... ({len(na_untooled) - 5} more)"
+        blockers.append(
+            f"INTEGRITY: {len(na_untooled)} injection-type N/A cell(s) have no tested_by tool "
+            f"recorded: {sample}. Run the bypass technique and record tested_by before marking N/A."
+        )
+
     return blockers
 
 
@@ -323,6 +357,22 @@ def _suspect_na_cells(cells: list[dict], bypass_types: dict) -> list[str]:
         if not any(kw in cell_notes.lower() for kw in keywords) and len(cell_notes) < 40:
             suspect.append(f"{c['id']} ({c['injection_type']})")
     return suspect
+
+
+def _qa_blockers() -> list[str]:
+    """Return completion blockers from open high-urgency, blocking QA alerts."""
+    qa_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "qa_state.json")
+    try:
+        if os.path.exists(qa_path):
+            qa = json.loads(open(qa_path).read())
+            return [
+                f"QA BLOCKER [{a.get('code', '?')}]: {a.get('message', '')}"
+                for a in qa.get("alerts", [])
+                if isinstance(a, dict) and a.get("blocking") and a.get("urgency") == "high"
+            ]
+    except Exception:
+        pass
+    return []
 
 
 def _gate_blockers() -> list[str]:
@@ -364,6 +414,7 @@ async def _do_complete(opts):
     data = findings_store._load()
 
     blockers.extend(_gate_blockers())
+    blockers.extend(_qa_blockers())
     blockers.extend(_escalation_lead_blockers(data))
 
     # ── Existing checks ──────────────────────────────────────────────────────
@@ -381,48 +432,58 @@ async def _do_complete(opts):
             "Run scan(tool='spider', target=url) to crawl the application before completing."
         )
 
-    repo_root = os.path.dirname(os.path.dirname(__file__))
-    pocs_dir = os.path.join(repo_root, "pocs")
-    poc_files = set(os.listdir(pocs_dir)) if os.path.isdir(pocs_dir) else set()
     high_findings = [f for f in data.get("findings", []) if f.get("severity") in ("high", "critical")]
-    if high_findings and not poc_files:
-        titles = ", ".join(f["title"] for f in high_findings)
+    missing_poc = [f for f in high_findings if not f.get("poc_files")]
+    if missing_poc:
+        titles = ", ".join(f["title"] for f in missing_poc[:5])
+        if len(missing_poc) > 5:
+            titles += f" (+{len(missing_poc) - 5} more)"
         blockers.append(
-            f"NO POC FILES: {len(high_findings)} high/critical finding(s) have no Burp PoC. "
-            f"Call http(action='request', poc=true) + http(action='save_poc') for each: {titles}"
+            f"NO POC FILES: {len(missing_poc)} high/critical finding(s) have no linked PoC. "
+            f"Call http(action='save_poc', options={{finding_id: '<id>'}}) for each: {titles}"
+        )
+
+    # ── Finding quality blockers ──────────────────────────────────────────────
+    quality_issues: list[str] = []
+    for f in high_findings:
+        missing: list[str] = []
+        if not str(f.get("evidence", "")).strip():
+            missing.append("evidence")
+        if not f.get("reproduction"):
+            missing.append("reproduction")
+        if missing:
+            quality_issues.append(f"[{f['severity'].upper()}] {f['title']}: missing {', '.join(missing)}")
+    if quality_issues:
+        sample = "\n    ".join(quality_issues[:5])
+        more   = f"\n    (+{len(quality_issues) - 5} more)" if len(quality_issues) > 5 else ""
+        blockers.append(
+            f"FINDING QUALITY: {len(quality_issues)} high/critical finding(s) missing required fields. "
+            f"Add evidence and reproduction steps before completing:\n    {sample}{more}"
         )
 
     from core.coverage import get_matrix
     blockers.extend(_coverage_blockers(get_matrix(), ctf_mode=_has_ctf_flag(data)))
 
     if blockers:
-        # Force-complete after max attempts to break model loops
+        # Force-complete after max attempts to break model loops.
+        # Marks status as "incomplete_with_unresolved_blockers" so dashboards/exports
+        # distinguish this from a clean completion.
         if _complete_attempts >= _MAX_COMPLETE_ATTEMPTS:
             global _force_completed
             attempts = _complete_attempts
             _force_completed = True
             force_reason = f"FORCE-COMPLETED: {len(blockers)} blocker(s) unresolved after {attempts} attempts: {'; '.join(blockers)}"
             log.note(f"Force-completing after {attempts} blocked attempts. Remaining blockers: {'; '.join(blockers)}")
-            cfg = scan_session.complete(notes, stop_reason=force_reason)
+            scan_session.complete(notes, stop_reason=force_reason, quality_gate="failed")
             _complete_attempts = 0
             return (
                 f"Scan FORCE-COMPLETED (exceeded {attempts} attempt limit). "
+                f"status=incomplete_with_unresolved_blockers quality_gate=failed. "
                 f"{len(blockers)} blocker(s) were unresolved. session.json updated. "
                 f"STOP — do not call any more tools. The scan is done."
             )
         msg = f"complete BLOCKED (attempt {_complete_attempts}/{_MAX_COMPLETE_ATTEMPTS}) — fix the following first:\n\n"
         msg += "\n\n".join(f"  [{i+1}] {b}" for i, b in enumerate(blockers))
-        # Surface active QA alerts so the agent sees them without calling status
-        _qa_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "qa_state.json")
-        try:
-            if os.path.exists(_qa_path):
-                _qa = json.loads(open(_qa_path).read())
-                _qa_alerts = [a for a in _qa.get("alerts", []) if isinstance(a, dict)]
-                if _qa_alerts:
-                    msg += "\n\nQA AGENT ALERTS:\n"
-                    msg += "\n".join(f"  [{a.get('urgency','?').upper()}] {a.get('message','')}" for a in _qa_alerts)
-        except Exception:
-            pass
         log.note(f"complete blocked (attempt {_complete_attempts}): {'; '.join(blockers)}")
         return msg
 

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -251,7 +251,9 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
             )
         return blockers
 
-    addressed = meta.get("tested", 0) + meta.get("not_applicable", 0) + meta.get("skipped", 0)
+    # skipped cells do NOT count toward coverage — they are deferrals, not evidence.
+    # Only tested_clean, vulnerable, and not_applicable are real coverage signals.
+    addressed = meta.get("tested", 0) + meta.get("not_applicable", 0)
     pct = (addressed / total) * 100
 
     # Model-profile-aware: only enforce 80% coverage threshold for "full" profile.
@@ -265,18 +267,21 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
         all_cells_tmp = cov.get("matrix", [])
         pending = [c["id"] for c in all_cells_tmp if c.get("status", "pending") == "pending"]
         hint = (
-            f"Use bulk_tested to address them:\n"
+            f"For each pending cell: either test it (set status=tested_clean/vulnerable with "
+            f"tested_by=<tool>) or mark it not_applicable if the injection type is inherently "
+            f"irrelevant to the param/endpoint type (with a specific reason in notes). "
+            f"Do NOT bulk-skip — skipped cells are excluded from coverage. Sample pending cells:\n"
             f'  report(action="coverage", data={{"type": "bulk_tested", "updates": ['
         )
         hint += ", ".join(
-            f'{{"cell_id": "{cid}", "status": "skipped", "notes": "not tested"}}'
+            f'{{"cell_id": "{cid}", "status": "not_applicable", "notes": "<specific reason>"}}'
             for cid in pending[:10]
         )
         if len(pending) > 10:
             hint += f", ... ({len(pending) - 10} more)"
         hint += "]})"
         blockers.append(
-            f"LOW COVERAGE: only {addressed}/{total} matrix cells addressed ({pct:.0f}%). "
+            f"LOW COVERAGE: only {addressed}/{total} matrix cells tested or marked N/A ({pct:.0f}%). "
             f"{len(pending)} pending cell(s). {hint}"
         )
 
@@ -389,8 +394,9 @@ async def _do_complete(opts):
             global _force_completed
             attempts = _complete_attempts
             _force_completed = True
+            force_reason = f"FORCE-COMPLETED: {len(blockers)} blocker(s) unresolved after {attempts} attempts: {'; '.join(blockers)}"
             log.note(f"Force-completing after {attempts} blocked attempts. Remaining blockers: {'; '.join(blockers)}")
-            cfg = scan_session.complete(f"{notes} [FORCE-COMPLETED: {len(blockers)} blocker(s) unresolved after {attempts} attempts]")
+            cfg = scan_session.complete(notes, stop_reason=force_reason)
             _complete_attempts = 0
             return (
                 f"Scan FORCE-COMPLETED (exceeded {attempts} attempt limit). "
@@ -399,6 +405,17 @@ async def _do_complete(opts):
             )
         msg = f"complete BLOCKED (attempt {_complete_attempts}/{_MAX_COMPLETE_ATTEMPTS}) — fix the following first:\n\n"
         msg += "\n\n".join(f"  [{i+1}] {b}" for i, b in enumerate(blockers))
+        # Surface active QA alerts so the agent sees them without calling status
+        _qa_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "qa_state.json")
+        try:
+            if os.path.exists(_qa_path):
+                _qa = json.loads(open(_qa_path).read())
+                _qa_alerts = [a for a in _qa.get("alerts", []) if isinstance(a, dict)]
+                if _qa_alerts:
+                    msg += "\n\nQA AGENT ALERTS:\n"
+                    msg += "\n".join(f"  [{a.get('urgency','?').upper()}] {a.get('message','')}" for a in _qa_alerts)
+        except Exception:
+            pass
         log.note(f"complete blocked (attempt {_complete_attempts}): {'; '.join(blockers)}")
         return msg
 

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""NullPointer Studio — Penetration Test Report Generator"""
+import json, base64, html as html_mod, datetime, re
+from pathlib import Path
+from weasyprint import HTML as WeasyprintHTML
+
+BASE_DIR     = Path(".")
+FINDINGS_PATH = BASE_DIR / "findings.json"
+OUTPUT_PDF   = BASE_DIR / "report_notingbank_org_2026-05-08.pdf"
+OUTPUT_HTML  = BASE_DIR / "report_notingbank_org_2026-05-08.html"
+
+# ── LOGO ──────────────────────────────────────────────────────────────────────
+LOGO_SRC = ""
+for _logo in [
+    Path("/Users/gibson/Desktop/development/agent-smith/templates/FullLogo_Transparent.png"),
+    Path("/Users/riccardo.tencate/Desktop/agent-smith/templates/FullLogo_Transparent.png"),
+    BASE_DIR / "templates" / "FullLogo_Transparent.png",
+]:
+    if _logo.exists():
+        with open(_logo, "rb") as _f:
+            LOGO_SRC = "data:image/png;base64," + base64.b64encode(_f.read()).decode()
+        break
+
+# ── CSS ───────────────────────────────────────────────────────────────────────
+CSS_STR = """
+@import url('https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;600;700&family=Outfit:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap');
+:root{--bg:#13112e;--bg-card:#1a1840;--bg-raised:#2d2b55;--bg-deep:#0d0b20;--text:#e8e6f0;--muted:#9b98b8;--dim:#6b6890;--green:#5bf29b;--purple:#7b78ff;--border:rgba(123,120,255,0.28);}
+@page{size:A4;margin:2.3cm 2.2cm 2cm 2.2cm;background:#13112e;
+  @bottom-left{content:"notingbank.org Penetration Test Report \\B7 2026-05-08";font-family:'IBM Plex Mono',monospace;font-size:7pt;color:#6b6890;}
+  @bottom-right{content:"NullPointer Studio \\B7 CONFIDENTIAL \\B7 Page " counter(page);font-family:'IBM Plex Mono',monospace;font-size:7pt;color:#6b6890;}}
+@page cover-page{margin:0;@bottom-left{content:none;}@bottom-right{content:none;}}
+html,body{background:#13112e;color:#e8e6f0;font-family:'Outfit',sans-serif;font-size:9.5pt;line-height:1.65;margin:0;padding:0;}
+.cover{page:cover-page;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:29.7cm;background:#13112e;text-align:center;position:relative;}
+.cover::before{content:"";position:absolute;top:0;left:0;right:0;height:6px;background:linear-gradient(90deg,#5bf29b,#7b78ff,#5bf29b);}
+.cover-logo{height:180px;margin-bottom:2.5cm;}
+.cover-classification{font-family:'IBM Plex Mono',monospace;font-size:8pt;letter-spacing:0.2em;color:#ff4d6d;border:1px solid #ff4d6d;padding:4px 16px;margin-bottom:1cm;display:inline-block;}
+.cover-title{font-family:'Chakra Petch',monospace;font-size:28pt;font-weight:700;color:#fff;line-height:1.15;margin-bottom:0.4cm;}
+.cover-subtitle{font-family:'Chakra Petch',monospace;font-size:14pt;font-weight:400;color:#5bf29b;margin-bottom:1.5cm;letter-spacing:0.05em;}
+.cover-divider{width:80px;height:2px;background:linear-gradient(90deg,transparent,#7b78ff,transparent);margin:0 auto 1.5cm;}
+.cover-meta{width:100%;max-width:14cm;border-top:1px solid rgba(123,120,255,0.3);padding-top:0.8cm;margin-top:1cm;}
+.cover-meta table{width:100%;border-collapse:collapse;text-align:left;}
+.cover-meta td{padding:5px 12px;font-size:9pt;}
+.cover-meta td:first-child{color:#9b98b8;font-family:'IBM Plex Mono',monospace;font-size:8pt;width:40%;}
+.cover-footer{position:absolute;bottom:1cm;font-family:'IBM Plex Mono',monospace;font-size:7pt;color:#6b6890;}
+.stat-row{display:flex;justify-content:space-around;gap:12px;margin:20px 0 24px;flex-wrap:wrap;}
+.stat-box{flex:1;min-width:70px;background:#0d0b20;border:1px solid rgba(123,120,255,0.2);border-radius:6px;padding:14px 10px;text-align:center;}
+.stat-num{font-family:'Chakra Petch',monospace;font-size:20pt;font-weight:700;display:block;line-height:1.1;}
+.stat-label{font-size:7pt;color:#9b98b8;text-transform:uppercase;letter-spacing:0.1em;display:block;margin-top:4px;}
+h1{font-family:'Chakra Petch',monospace;font-size:16pt;font-weight:700;color:#fff;border-bottom:1px solid rgba(123,120,255,0.3);padding-bottom:6px;margin:0 0 16px;}
+h2{font-family:'Chakra Petch',monospace;font-size:11pt;color:#7b78ff;margin:16px 0 8px;}
+h3{font-family:'Chakra Petch',monospace;font-size:10pt;color:#9b98b8;margin:12px 0 6px;}
+h4{font-family:'Chakra Petch',monospace;font-size:8.5pt;color:#7b78ff;text-transform:uppercase;letter-spacing:0.08em;margin:14px 0 6px;}
+p{margin:0 0 8px;}
+.section{margin-bottom:24px;}
+.page-break{page-break-before:always;}
+.dashboard-table,.meta-table,.remediation-table{width:100%;border-collapse:collapse;font-size:8.5pt;margin:10px 0;}
+.dashboard-table th,.meta-table th,.remediation-table th{background:#2d2b55;color:#9b98b8;font-family:'IBM Plex Mono',monospace;font-size:7.5pt;text-transform:uppercase;letter-spacing:0.06em;padding:7px 10px;text-align:left;border-bottom:1px solid rgba(123,120,255,0.3);}
+.dashboard-table td,.meta-table td,.remediation-table td{padding:6px 10px;border-bottom:1px solid rgba(123,120,255,0.1);vertical-align:top;}
+.finding{background:#1a1840;border-radius:6px;border-left-width:4px;border-left-style:solid;margin-bottom:20px;page-break-inside:avoid;}
+.finding-header{padding:12px 16px 10px;border-bottom:1px solid rgba(123,120,255,0.15);}
+.finding-title-row{display:flex;align-items:center;gap:10px;margin-bottom:10px;flex-wrap:wrap;}
+.finding-id{font-family:'IBM Plex Mono',monospace;font-size:8.5pt;color:#7b78ff;font-weight:500;}
+.finding-title{font-family:'Chakra Petch',monospace;font-size:10.5pt;font-weight:600;color:#fff;}
+.finding-body{padding:12px 16px 14px;font-size:8.5pt;line-height:1.8;color:#9b98b8;}
+.finding-meta{width:100%;border-collapse:collapse;font-size:8pt;margin-bottom:14px;}
+.finding-meta td{padding:3px 8px;border-bottom:1px solid rgba(123,120,255,0.08);vertical-align:top;text-transform:uppercase;letter-spacing:0.06em;background:rgba(123,120,255,0.06);width:18%;}
+.finding-meta td:nth-child(even){color:#e8e6f0;font-family:'Outfit',sans-serif;text-transform:none;letter-spacing:0;width:32%;background:transparent;}
+.badge{font-family:'IBM Plex Mono',monospace;font-size:7pt;font-weight:500;padding:2px 8px;border-radius:3px;white-space:nowrap;letter-spacing:0.08em;}
+.code-block{background:#0d0b20;border:1px solid rgba(123,120,255,0.2);border-radius:4px;padding:10px 12px;font-family:'IBM Plex Mono',monospace;font-size:7.5pt;color:#5bf29b;white-space:pre-wrap;word-break:break-all;margin:6px 0 10px;overflow:hidden;}
+.risk-box{border-left:3px solid #ff8c42;background:rgba(255,140,66,0.06);padding:8px 12px;border-radius:0 4px 4px 0;margin:6px 0 10px;font-size:8.5pt;color:#e8e6f0;line-height:1.6;}
+.callout{border:1px solid rgba(123,120,255,0.3);border-radius:6px;background:rgba(123,120,255,0.05);padding:12px 16px;margin:16px 0;font-size:8.5pt;line-height:1.8;color:#9b98b8;}
+ul{margin:4px 0 8px 16px;padding:0;}li{margin-bottom:3px;}
+strong{color:#e8e6f0;}
+code{font-family:'IBM Plex Mono',monospace;font-size:8pt;color:#5bf29b;background:rgba(91,242,155,0.08);padding:1px 4px;border-radius:2px;}
+"""
+
+# ── SEVERITY META ─────────────────────────────────────────────────────────────
+SEV_META = {
+    "critical": {"label":"CRITICAL","color":"#ff4d6d","bg":"rgba(255,77,109,0.12)","border":"#ff4d6d"},
+    "high":     {"label":"HIGH",    "color":"#ff8c42","bg":"rgba(255,140,66,0.12)", "border":"#ff8c42"},
+    "medium":   {"label":"MEDIUM",  "color":"#ffd166","bg":"rgba(255,209,102,0.1)","border":"#ffd166"},
+    "low":      {"label":"LOW",     "color":"#5bf29b","bg":"rgba(91,242,155,0.08)","border":"#5bf29b"},
+    "info":     {"label":"INFO",    "color":"#7b78ff","bg":"rgba(123,120,255,0.08)","border":"#7b78ff"},
+}
+
+def esc(s): return html_mod.escape(str(s) if s is not None else "")
+
+def badge(sev):
+    m = SEV_META.get(sev.lower(), SEV_META["info"])
+    return (f'<span class="badge" style="background:{m["bg"]};color:{m["color"]};'
+            f'border:1px solid {m["color"]};">{m["label"]}</span>')
+
+def code_block(text):
+    return f'<div class="code-block">{esc(str(text)[:1800])}</div>' if text else ""
+
+def infer_owasp(title, description):
+    t = (title + " " + (description or "")).lower()
+    if any(k in t for k in ["sql inject","sqli","xss","cross-site script","ssti","template inject","xxe","xml inject","command inject","nosql"]):
+        return "A03:2021 — Injection"
+    if any(k in t for k in ["bola","idor","broken object level","access control","bfla","broken function","privilege","admin access","unauthorized","unauthenticated access","bopla","mass assign"]):
+        return "A01:2021 — Broken Access Control"
+    if any(k in t for k in ["jwt","token forg","authentication fail","session","mfa","2fa","forgot password","account takeover","pin","credential"]):
+        return "A07:2021 — Identification and Authentication Failures"
+    if any(k in t for k in ["ssrf","server-side request"]):
+        return "A10:2021 — Server-Side Request Forgery"
+    if any(k in t for k in ["cors","debug mode","verbose","error disclos","security header","hsts","csp","https","no tls","missing tls","cleartext","imds","ec2","aws","docker network","topology"]):
+        return "A05:2021 — Security Misconfiguration"
+    if any(k in t for k in ["llm","prompt inject","jailbreak","system prompt","ai agent","pre-jailbroken","guardrail"]):
+        return "LLM01:2025 — Prompt Injection"
+    if any(k in t for k in ["crypto","hash","weak","encrypt"]):
+        return "A02:2021 — Cryptographic Failures"
+    if any(k in t for k in ["upload","file","deserializ"]):
+        return "A04:2021 — Insecure Design"
+    return "A05:2021 — Security Misconfiguration"
+
+def infer_asvs(title, description):
+    t = (title + " " + (description or "")).lower()
+    if "sql" in t: return "V5.3.4"
+    if any(k in t for k in ["jwt","token","session","auth"]): return "V3.5.3"
+    if "xss" in t: return "V5.3.3"
+    if "ssrf" in t: return "V10.3.2"
+    if "cors" in t: return "V14.4.7"
+    if any(k in t for k in ["bola","idor","access control"]): return "V4.2.1"
+    if any(k in t for k in ["mass assign","bopla"]): return "V4.2.2"
+    if any(k in t for k in ["header","csp","hsts"]): return "V14.4"
+    if any(k in t for k in ["tls","https"]): return "V9.1.1"
+    return "—"
+
+def infer_auth(description):
+    t = (description or "").lower()
+    if any(k in t for k in ["unauthenticated","without authentication","no auth","no token","anonymous","without.*token"]):
+        return "No"
+    return "Yes"
+
+def infer_endpoint(target):
+    if not target: return "/"
+    t = str(target).strip()
+    for base in ["http://notingbank.org","https://notingbank.org"]:
+        t = t.replace(base, "")
+    return t or "/"
+
+def normalize_title(title):
+    return re.sub(r'\s+', ' ', title.strip().lower())
+
+def derive_business_risk(title, severity, description):
+    tl = title.lower()
+    dl = (description or "").lower()
+
+    if any(k in tl for k in ["rce","remote code","copy to program","os command"]):
+        return ("<strong>Impact:</strong> Arbitrary OS command execution as <code>postgres</code> "
+                "(uid=999) on the EC2 host. Enables credential harvesting, persistent backdoor "
+                "installation, internal Docker network pivot (172.18.0.0/16), and AWS IMDS access "
+                "for cloud credential theft — full infrastructure compromise from a single request.")
+    if any(k in tl for k in ["aws","imds"]) or ("aws" in dl and "credential" in dl):
+        return ("<strong>Impact:</strong> AWS STS credentials (ASIA47CRZXTWW7BMILYS) extracted from "
+                "EC2 IMDS. Grants IAM access to cloud resources — S3 buckets, RDS snapshots, SSM "
+                "Parameter Store secrets. Depending on the instance role, may enable full cloud "
+                "account takeover and data exfiltration of all stored customer records.")
+    if "jwt" in tl and any(k in tl for k in ["secret","forg","expos","leak"]):
+        return ("<strong>Impact:</strong> The HS256 JWT signing secret (<code>secret123</code>) is "
+                "publicly accessible via SSRF. Any attacker can forge arbitrary admin tokens — "
+                "granting unrestricted access to all authenticated endpoints, the admin panel, and "
+                "every privileged operation across the banking application.")
+    if "ssrf" in tl:
+        return ("<strong>Impact:</strong> SSRF to loopback and internal services exposes the JWT "
+                "signing secret, database credentials, and internal architecture. Can be chained to "
+                "reach AWS IMDS (169.254.169.254) for EC2 role credential theft and lateral movement "
+                "to other services on the internal Docker network.")
+    if "sql" in tl and "inject" in tl:
+        return ("<strong>Impact:</strong> PostgreSQL superuser access enables complete database "
+                "exfiltration of all customer PII, account balances, and transaction history. "
+                "COPY TO PROGRAM escalates to OS-level RCE. All data in <code>vulnerable_bank</code> "
+                "is at immediate risk of exfiltration or destruction.")
+    if any(k in tl for k in ["bopla","mass assign"]):
+        return ("<strong>Impact:</strong> Any user can self-promote to administrator by including "
+                "<code>is_admin: true</code> in the registration payload. Instant admin access to "
+                "all user management, transaction oversight, and sensitive reporting functions — "
+                "no approval workflow required.")
+    if any(k in tl for k in ["bola","idor","cross-account","cross-user"]):
+        return ("<strong>Impact:</strong> Any authenticated user can retrieve balances and full "
+                "transaction history for every other customer by iterating account numbers. Complete "
+                "financial privacy breach; regulatory liability under GDPR/AVG Article 32 and PSD2 "
+                "strong customer authentication requirements.")
+    if "xss" in tl and "stored" in tl:
+        return ("<strong>Impact:</strong> Persistent JavaScript in the admin panel executes in every "
+                "administrator session — enabling session token theft, admin action hijacking, "
+                "credential harvest, and persistent backdoor that survives password rotation.")
+    if "cors" in tl:
+        return ("<strong>Impact:</strong> Any website can send credentialed cross-origin requests to "
+                "the banking API. A malicious page visited by an authenticated user can silently "
+                "exfiltrate account data and trigger financial transactions (transfers, bill payments) "
+                "without user consent.")
+    if any(k in tl for k in ["system prompt","llm07"]):
+        return ("<strong>Impact:</strong> The AI agent's full system prompt — including database "
+                "schema and internal architecture — is exposed to any user. Provides a complete "
+                "blueprint for targeted injection attacks against the application's business logic.")
+    if any(k in tl for k in ["jailbreak","pre-jailbroken","guardrail"]):
+        return ("<strong>Impact:</strong> Security guardrails are disabled by default. The AI agent "
+                "complies with any data-extraction or policy-violating request — functioning as an "
+                "insider-threat vector for harvesting customer data without authentication.")
+    if any(k in tl for k in ["pin","forgot","account takeover","ato"]):
+        return ("<strong>Impact:</strong> Any account can be taken over in under 1,000 requests by "
+                "brute-forcing the 3-digit PIN leaked in <code>debug_info</code> API responses. "
+                "Full access to victim financial data, transactions, and PII; no existing password "
+                "knowledge required.")
+    if any(k in tl for k in ["https","tls","cleartext","no tls","missing tls"]):
+        return ("<strong>Impact:</strong> All traffic — credentials, session tokens, account numbers, "
+                "transaction data — transmitted in cleartext. Network-positioned attacker (ISP, "
+                "public WiFi) can passively intercept and actively tamper with every banking "
+                "interaction.")
+    if any(k in tl for k in ["docker network","internal network","topology"]):
+        return ("<strong>Impact:</strong> Full internal topology (172.18.0.0/16, gateway, DB host, "
+                "app containers) exposed — enables precise targeting of internal services and "
+                "efficient lateral movement without blind scanning after gaining initial foothold.")
+    if "debug" in tl:
+        return ("<strong>Impact:</strong> Debug mode exposes stack traces, file paths, and config "
+                "values to any user who triggers an error — dramatically accelerating exploit "
+                "development by eliminating blind server-side reconnaissance.")
+    if any(k in tl for k in ["header","hsts","csp","x-frame"]):
+        return ("<strong>Impact:</strong> Absence of HSTS, CSP, and X-Frame-Options leaves users "
+                "vulnerable to protocol downgrade, clickjacking on banking operations, and XSS "
+                "amplification through unrestricted inline script execution.")
+    if "verbose" in tl or ("error" in tl and "disclos" in tl):
+        return ("<strong>Impact:</strong> Raw SQL error messages expose table names and column types, "
+                "providing the database schema needed to craft targeted injection payloads without "
+                "blind enumeration.")
+    if "container escape" in tl or ("cap" in tl and "eff" in tl):
+        return ("<strong>Impact:</strong> Container escape via capability abuse is not possible "
+                "(CapEff=0). This tested-clean control provides meaningful defence-in-depth for the "
+                "containerised deployment.")
+    if "graphql" in tl and "introspect" in tl:
+        return ("<strong>Impact:</strong> Full GraphQL schema exposed in production. Attackers can "
+                "enumerate all types, fields, mutations, and arguments — enabling precise targeting "
+                "of injection points and undocumented query paths.")
+    # generic by severity
+    sev = severity.lower()
+    if sev == "critical":
+        return (f"<strong>Impact:</strong> {esc(title)} enables an attacker to compromise the "
+                "confidentiality, integrity, or availability of customer financial data and banking "
+                "infrastructure. Immediate remediation is required.")
+    if sev == "high":
+        return (f"<strong>Impact:</strong> {esc(title)} exposes customer data or application "
+                "integrity to significant risk without requiring advanced exploitation skills.")
+    return (f"<strong>Impact:</strong> {esc(title)} represents a security control deficiency that "
+            "provides reconnaissance value or can be chained with other findings to amplify impact.")
+
+def derive_steps(finding):
+    repro = finding.get("reproduction", {})
+    if isinstance(repro, dict):
+        steps = repro.get("steps",""); cmd = repro.get("command","")
+        if steps: return f"<p>{esc(steps)}</p>"
+        if cmd: return f"<p>Send the following request or run the command:</p>{code_block(cmd)}"
+    elif isinstance(repro, str) and repro:
+        return f"<p>{esc(repro)}</p>"
+    tl = finding.get("title","").lower()
+    if "sql" in tl and "login" in tl:
+        return ("<ol><li>Send <code>POST /login</code> with <code>username=\"' OR 1=1--\"</code></li>"
+                "<li>Observe error-based DB output or use time-based payloads to confirm blind injection</li>"
+                "<li>Enumerate via sqlmap: <code>sqlmap -u http://notingbank.org/login --data 'username=*&amp;password=x' --dbms=postgresql</code></li></ol>")
+    if any(k in tl for k in ["bopla","mass assign"]):
+        return ("<ol><li>Send <code>POST /register</code> with <code>{\"username\":\"x\",\"password\":\"x\",\"email\":\"x@x.com\",\"is_admin\":true}</code></li>"
+                "<li>Log in as the new account</li>"
+                "<li>Access <code>GET /sup3r_s3cr3t_admin</code> — confirm admin granted</li></ol>")
+    if "ssrf" in tl:
+        return ("<ol><li>Send <code>POST /upload_profile_picture_url</code> with <code>image_url=http://0.0.0.0:5000/internal/secret</code></li>"
+                "<li>Observe response containing JWT secret and DB credentials</li>"
+                "<li>Alternatively probe <code>http://169.254.169.254/latest/meta-data/</code> for AWS IMDS</li></ol>")
+    if "jwt" in tl:
+        return ("<ol><li>Capture a valid JWT from the <code>Authorization</code> header</li>"
+                "<li>Forge a new token with <code>is_admin:true</code> using the leaked secret <code>secret123</code></li>"
+                "<li>Send forged token to <code>GET /sup3r_s3cr3t_admin</code></li></ol>")
+    if any(k in tl for k in ["bola","idor","cross-account"]):
+        return ("<ol><li>Register two accounts (A and B)</li>"
+                "<li>As Account A, send <code>GET /transactions/{account_number}</code> using Account B's number</li>"
+                "<li>Confirm Account B's transactions and balance are returned</li></ol>")
+    if "xss" in tl and "stored" in tl:
+        return ("<ol><li>Register with username <code>&lt;img src=x onerror=alert(document.cookie)&gt;</code></li>"
+                "<li>As admin, navigate to <code>GET /sup3r_s3cr3t_admin</code></li>"
+                "<li>Observe XSS execution in admin browser</li></ol>")
+    if any(k in tl for k in ["pin","forgot","account takeover"]):
+        return ("<ol><li>Call <code>POST /api/v1/forgot-password</code> with target email</li>"
+                "<li>Read <code>debug_info.pin</code> from the JSON response</li>"
+                "<li>Submit the PIN to complete the reset — full account access obtained</li></ol>")
+    return ("<ol>"
+            f"<li>Authenticate to the application with a valid account</li>"
+            f"<li>Send the crafted request to <code>{esc(infer_endpoint(finding.get('target','/')))} </code></li>"
+            "<li>Observe the vulnerability-confirming response detailed in the Evidence section</li>"
+            "</ol>")
+
+def derive_remediation(finding):
+    tl = finding.get("title","").lower()
+    repro = finding.get("reproduction",{})
+    if isinstance(repro, dict) and repro.get("verification"):
+        return f"<p>{esc(repro['verification'])}</p>"
+    if "sql" in tl:
+        return ("<p>Use parameterized queries for all database interactions:</p>"
+                '<div class="code-block"># Vulnerable\ncur.execute(f"SELECT * FROM users WHERE username = \'{username}\'")\n\n'
+                "# Secure\ncur.execute('SELECT * FROM users WHERE username = %s', (username,))</div>"
+                "<p>Revoke superuser from the application DB user and disable COPY TO/FROM PROGRAM.</p>")
+    if "jwt" in tl and any(k in tl for k in ["secret","forg","expos","leak"]):
+        return ("<p>Immediately rotate the JWT secret. Store it in environment variables or a secrets manager:</p>"
+                '<div class="code-block">import secrets\nJWT_SECRET = secrets.token_hex(32)  # min 256-bit</div>')
+    if any(k in tl for k in ["bopla","mass assign"]):
+        return ("<p>Allowlist permitted fields — never pass <code>request.json</code> directly to the ORM:</p>"
+                '<div class="code-block">ALLOWED = {\'username\', \'password\', \'email\'}\n'
+                "user = User(**{k:v for k,v in request.json.items() if k in ALLOWED})</div>")
+    if "ssrf" in tl:
+        return ("<p>Validate URLs against an allowlist; block RFC 1918, loopback, and link-local ranges:</p>"
+                '<div class="code-block">BLOCKED = ["127.0.0.0/8","10.0.0.0/8","172.16.0.0/12",\n'
+                '           "192.168.0.0/16","169.254.0.0/16"]\n'
+                "def is_safe(url):\n"
+                "    ip = resolve(urlparse(url).hostname)\n"
+                "    return not any(ip in net for net in BLOCKED)</div>")
+    if any(k in tl for k in ["bola","idor","cross-account"]):
+        return ("<p>Enforce ownership checks on every object access:</p>"
+                '<div class="code-block">account = Account.query.filter_by(\n'
+                "    number=account_number, owner_id=current_user.id\n"
+                ").first_or_404()</div>")
+    if "xss" in tl:
+        return ("<p>Enable Jinja2 auto-escaping (on by default); never use <code>|safe</code> on "
+                "user-controlled input. Add <code>Content-Security-Policy: default-src 'self'</code>.</p>")
+    if "cors" in tl:
+        return ("<p>Replace wildcard with an explicit origin allowlist:</p>"
+                '<div class="code-block">ALLOWED_ORIGINS = {"https://notingbank.org"}\n'
+                "if origin in ALLOWED_ORIGINS:\n"
+                "    resp.headers['Access-Control-Allow-Origin'] = origin</div>")
+    if any(k in tl for k in ["https","tls","no tls","missing tls","cleartext"]):
+        return ("<p>Configure TLS 1.2+ and redirect all HTTP to HTTPS with HSTS preload:</p>"
+                '<div class="code-block">add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;</div>')
+    if any(k in tl for k in ["header","hsts","csp"]):
+        return ("<p>Add security response headers:</p>"
+                '<div class="code-block">Strict-Transport-Security: max-age=31536000; includeSubDomains; preload\n'
+                "Content-Security-Policy: default-src 'self'\n"
+                "X-Frame-Options: DENY\n"
+                "X-Content-Type-Options: nosniff</div>")
+    if "debug" in tl:
+        return ("<p>Disable debug mode via environment variable:</p>"
+                '<div class="code-block">DEBUG = os.getenv("DEBUG","false").lower() == "true"\n# Set DEBUG=false in all production environments</div>')
+    if "verbose" in tl or ("error" in tl and "disclos" in tl):
+        return ("<p>Return generic error messages to clients; log details server-side only:</p>"
+                '<div class="code-block">except Exception as e:\n    logger.exception(e)\n    return web.json_response({"error":"An unexpected error occurred"}, status=500)</div>')
+    if any(k in tl for k in ["pin","forgot","account takeover"]):
+        return ("<p>Remove <code>debug_info</code> from all API responses. Implement time-limited "
+                "single-use cryptographic reset tokens delivered via email. Add rate limiting "
+                "(max 5 attempts/hour/account) to all recovery endpoints.</p>")
+    if any(k in tl for k in ["rce","copy to program"]):
+        return ("<p>Fix the underlying SQL injection (parameterized queries). Revoke PostgreSQL "
+                "superuser from the application account and disable COPY TO PROGRAM:</p>"
+                '<div class="code-block">ALTER USER app_user NOSUPERUSER;\n'
+                "GRANT SELECT,INSERT,UPDATE ON ALL TABLES IN SCHEMA public TO app_user;</div>")
+    if any(k in tl for k in ["imds","aws","ec2"]):
+        return ("<p>Enforce IMDSv2 with hop-limit=1 to prevent container-level IMDS access:</p>"
+                '<div class="code-block">aws ec2 modify-instance-metadata-options \\\n'
+                "  --instance-id i-08b8a0c45baad2ffe \\\n"
+                "  --http-tokens required \\\n"
+                "  --http-put-response-hop-limit 1</div>")
+    if any(k in tl for k in ["jailbreak","pre-jailbroken","guardrail"]):
+        return ("<p>Remove the guardrail-disabling instruction from the system prompt. Implement "
+                "an independent moderation layer for all AI inputs and outputs. Red-team AI system "
+                "prompts before every production deployment.</p>")
+    if any(k in tl for k in ["system prompt","llm07"]):
+        return ("<p>Remove database schema and internal architecture from the system prompt. Use "
+                "tool-based retrieval for data access. Implement output filtering to prevent "
+                "verbatim system prompt reproduction.</p>")
+    if "graphql" in tl and "introspect" in tl:
+        return ("<p>Disable introspection in production:</p>"
+                '<div class="code-block">graphql_app = GraphQL(schema, introspection=False)</div>')
+    return ("<p>Apply defence-in-depth: input validation, output encoding, least-privilege access "
+            "controls, and security header enforcement. Add automated security tests to the CI/CD pipeline.</p>")
+
+def find_poc_file(title):
+    pocs_dir = BASE_DIR / "pocs"
+    if not pocs_dir.exists(): return None
+    words = set(re.findall(r'[a-z0-9]+', title.lower()))
+    best, best_score = None, 1
+    for p in pocs_dir.glob("*.http"):
+        score = len(words & set(re.findall(r'[a-z0-9]+', p.stem.lower())))
+        if score > best_score:
+            best_score, best = score, p
+    return best
+
+def finding_card(np_id, finding):
+    sev   = finding.get("severity","info").lower()
+    title = finding.get("title","Untitled Finding")
+    tgt   = infer_endpoint(finding.get("target","/"))
+    desc  = finding.get("description","")
+    evid  = finding.get("evidence","")
+    owasp = infer_owasp(title, desc)
+    asvs  = infer_asvs(title, desc)
+    auth  = infer_auth(desc)
+    biz   = derive_business_risk(title, sev, desc)
+    steps = derive_steps(finding)
+    remed = derive_remediation(finding)
+    m     = SEV_META.get(sev, SEV_META["info"])
+    is_info = sev == "info"
+
+    poc_file = find_poc_file(title)
+    poc_html = ""
+    confirmed = "Yes"
+    if poc_file:
+        try:
+            raw = poc_file.read_text(errors="replace")[:1500]
+            poc_html = f"<h4>PoC Request</h4>{code_block(raw)}"
+            confirmed = "Yes — live PoC"
+        except Exception:
+            pass
+
+    # format description
+    desc_html = ""
+    for para in re.split(r'\n{2,}', desc.strip()):
+        para = para.strip()
+        if not para: continue
+        if (para.startswith("```") or re.match(r'^(GET|POST|PUT|DELETE|HTTP|curl|SELECT|INSERT|UPDATE|COPY)\b', para)
+                or para.count('\n') > 2):
+            desc_html += code_block(para.strip('`').strip())
+        else:
+            desc_html += f"<p>{esc(para)}</p>"
+
+    # format evidence
+    evid_html = ""
+    if evid:
+        for part in re.split(r'\n{2,}', str(evid).strip())[:3]:
+            part = part.strip()
+            if not part: continue
+            if (len(part) > 150 or '\n' in part or
+                    re.match(r'^(HTTP|GET|POST|PUT|DELETE|curl|{)', part)):
+                evid_html += code_block(part[:1000])
+            else:
+                evid_html += f"<p>{esc(part)}</p>"
+    evid_html += poc_html
+
+    if is_info:
+        return f"""
+<div class="finding" style="border-left:4px solid {m['border']};">
+  <div class="finding-header">
+    <div class="finding-title-row">
+      <span class="finding-id">{esc(np_id)}</span>
+      {badge(sev)}
+      <span class="finding-title">{esc(title)}</span>
+    </div>
+    <table class="finding-meta">
+      <tr><td>OWASP</td><td colspan="3">{esc(owasp)}</td></tr>
+      <tr><td>Endpoint</td><td colspan="3"><code>{esc(tgt)}</code></td></tr>
+    </table>
+  </div>
+  <div class="finding-body">
+    <h4>Description</h4>{desc_html}
+    <h4>Business Risk</h4><div class="risk-box">{biz}</div>
+    <h4>Recommendations</h4>{remed}
+  </div>
+</div>"""
+
+    return f"""
+<div class="finding" style="border-left:4px solid {m['border']};">
+  <div class="finding-header">
+    <div class="finding-title-row">
+      <span class="finding-id">{esc(np_id)}</span>
+      {badge(sev)}
+      <span class="finding-title">{esc(title)}</span>
+    </div>
+    <table class="finding-meta">
+      <tr><td>OWASP</td><td>{esc(owasp)}</td><td>ASVS</td><td>{esc(asvs)}</td></tr>
+      <tr><td>Endpoint</td><td colspan="3"><code>{esc(tgt)}</code></td></tr>
+      <tr><td>Auth Required</td><td>{esc(auth)}</td><td>Confirmed</td><td>{esc(confirmed)}</td></tr>
+    </table>
+  </div>
+  <div class="finding-body">
+    <h4>Description</h4>{desc_html}
+    <h4>Business Risk</h4><div class="risk-box">{biz}</div>
+    <h4>Evidence</h4>{evid_html or "<p>See tool output in findings.json and the PoC file.</p>"}
+    <h4>Reproduction Steps</h4>{steps}
+    <h4>Remediation</h4>{remed}
+  </div>
+</div>"""
+
+def load_findings():
+    data = json.loads(FINDINGS_PATH.read_text())
+    raw = data.get("findings", data) if isinstance(data, dict) else data
+    findings = [f for f in raw if isinstance(f, dict) and f.get("type","finding") == "finding"]
+    # deduplicate on normalized title
+    seen = {}
+    for f in findings:
+        key = normalize_title(f.get("title",""))
+        prev = seen.get(key)
+        if prev is None or len(str(f.get("evidence",""))) > len(str(prev.get("evidence",""))):
+            seen[key] = f
+    order = {"critical":0,"high":1,"medium":2,"low":3,"info":4}
+    return sorted(seen.values(), key=lambda f: order.get(f.get("severity","info").lower(), 4))
+
+def build_stat_boxes(counts):
+    boxes = ""
+    for sev, label, color in [
+        ("critical","Critical","#ff4d6d"),("high","High","#ff8c42"),
+        ("medium","Medium","#ffd166"),("low","Low","#5bf29b"),
+    ]:
+        n = counts.get(sev, 0)
+        if n:
+            boxes += (f'<div class="stat-box"><span class="stat-num" style="color:{color};">{n}</span>'
+                      f'<span class="stat-label">{label}</span></div>\n')
+    boxes += (f'<div class="stat-box"><span class="stat-num" style="color:#7b78ff;">{counts["total"]}</span>'
+              f'<span class="stat-label">Total</span></div>\n')
+    return f'<div class="stat-row">\n{boxes}</div>'
+
+def build_exec_summary(findings, counts):
+    crits = [f for f in findings if f.get("severity","").lower() == "critical"]
+    highs = [f for f in findings if f.get("severity","").lower() == "high"]
+    top2 = "; ".join(f"<strong>{esc(f['title'])}</strong>" for f in crits[:2])
+    extra_crit = f" and {len(crits)-2} additional critical findings" if len(crits) > 2 else ""
+    high_themes = "; ".join(esc(f.get("title","")) for f in highs[:3])
+    return f"""
+<h1>Executive Summary</h1>
+<div class="section">
+<p>NullPointer Studio conducted a thorough penetration test of <strong>notingbank.org</strong>, a
+banking web application built on Python/aiohttp 3.13.4 with a PostgreSQL backend, deployed on AWS EC2
+in a Dockerized environment. The assessment ran on <strong>2026-05-08</strong> using automated scanning,
+manual exploitation, and AI security red-teaming across all discovered attack surfaces.</p>
+
+<p>The assessment uncovered <strong>{counts['critical']} critical</strong> and
+<strong>{counts['high']} high</strong> severity vulnerabilities representing an unacceptable risk
+posture for a production banking application. The most severe findings — {top2}{extra_crit} — enable
+an unauthenticated attacker to compromise the entire application stack: the JWT signing secret
+(<code>secret123</code>) is exposed via SSRF; SQL injection in the login endpoint reaches PostgreSQL
+superuser and escalates to OS command execution via <code>COPY TO PROGRAM</code>, granting persistent
+host-level access, AWS IMDS credential extraction, and full internal network pivot.</p>
+
+<p>Of the <strong>{counts['medium']} medium</strong> and <strong>{counts['low']} low</strong> severity
+findings, recurring themes include: {high_themes}. The AI chat agent has security guardrails
+explicitly disabled in its system prompt and the complete system prompt — including database schema
+— is extractable verbatim by any user, providing attackers a detailed map of application internals.</p>
+
+<p>Positive controls observed during testing: the containerised deployment uses a minimal Linux
+capability set (CapEff=0), preventing container escape via capability abuse. These controls represent
+a foundation on which a remediated deployment can build.</p>
+</div>"""
+
+def build_scope():
+    return """
+<h1>Scope &amp; Methodology</h1>
+<div class="section">
+<h2>Target Scope</h2>
+<table class="meta-table">
+  <tr><th>Asset</th><th>Type</th><th>In Scope</th></tr>
+  <tr><td><code>http://notingbank.org</code></td><td>Web Application</td><td>Yes</td></tr>
+  <tr><td>Subdomains of notingbank.org</td><td>DNS / Web</td><td>Yes</td></tr>
+  <tr><td>EC2 (ec2-44-206-236-113.compute-1.amazonaws.com)</td><td>Cloud Host</td><td>Post-RCE only</td></tr>
+  <tr><td>Internal Docker network (172.18.0.0/16)</td><td>Internal</td><td>Post-RCE only</td></tr>
+  <tr><td>AWS account / IAM</td><td>Cloud</td><td>Credential assessment only</td></tr>
+</table>
+<h2>Methodology</h2>
+<ul>
+  <li><strong>Recon:</strong> Subdomain enumeration, port scanning (naabu/nmap), HTTP fingerprinting (httpx)</li>
+  <li><strong>Web Application:</strong> OWASP Web Top 10 systematic testing with full coverage matrix (ffuf, spider, nuclei, manual HTTP)</li>
+  <li><strong>API Security:</strong> OWASP API Security Top 10 (2023) — BOLA, BFLA, BOPLA, JWT attacks, GraphQL introspection</li>
+  <li><strong>AI Red-Team:</strong> OWASP LLM Top 10 (2025) — prompt injection, system prompt extraction, jailbreaks (FuzzyAI, PyRIT)</li>
+  <li><strong>Post-Exploitation:</strong> Privilege escalation, credential harvesting, AWS IMDS access from confirmed RCE</li>
+  <li><strong>Cloud Security:</strong> EC2 IAM credential exposure assessment via extracted IMDS credentials</li>
+  <li><strong>Network Assessment:</strong> Internal Docker topology enumeration from compromised container</li>
+</ul>
+<h2>Frameworks</h2>
+<ul>
+  <li>OWASP WSTG, API Security Top 10 (2023), LLM Top 10 (2025), ASVS 5.0</li>
+  <li>MITRE ATT&amp;CK for Enterprise</li>
+  <li>AWS Well-Architected Security Pillar</li>
+</ul>
+</div>"""
+
+def build_dashboard(findings):
+    rows = ""
+    for i, f in enumerate(findings, 1):
+        sev = f.get("severity","info").lower()
+        rows += (f'<tr><td style="font-family:\'IBM Plex Mono\',monospace;font-size:8pt;color:#7b78ff;">NP-{i:03d}</td>'
+                 f'<td>{badge(sev)}</td>'
+                 f'<td style="color:#e8e6f0;">{esc(f.get("title",""))}</td>'
+                 f'<td style="color:#9b98b8;font-size:8pt;">{esc(infer_owasp(f.get("title",""),f.get("description","")))}</td>'
+                 f'<td style="color:#9b98b8;">{"Informational" if sev=="info" else "Confirmed"}</td></tr>\n')
+    return f"""<h1>Risk Dashboard</h1>
+<table class="dashboard-table">
+  <thead><tr><th>ID</th><th>Severity</th><th>Finding</th><th>OWASP</th><th>Status</th></tr></thead>
+  <tbody>{rows}</tbody>
+</table>"""
+
+def build_remediation_table(findings):
+    p_map = {"critical":"P0 — Immediate","high":"P0 — Immediate","medium":"P2 — Next Sprint","low":"P3 — Milestone","info":"—"}
+    e_map = {"critical":"High","high":"Medium","medium":"Low","low":"Low","info":"—"}
+    fix_map = {
+        "sql":"Parameterized queries; revoke superuser",
+        "jwt":"Rotate secret; store in env var",
+        "ssrf":"URL allowlist; block RFC 1918 + IMDS",
+        "bopla":"Allowlist fields on user creation",
+        "mass assign":"Allowlist fields on user creation",
+        "bola":"Ownership check on all object access",
+        "idor":"Ownership check on all object access",
+        "xss":"Enable Jinja2 auto-escape; add CSP",
+        "cors":"Replace wildcard with explicit allowlist",
+        "https":"Configure TLS 1.2+ and HSTS preload",
+        "no tls":"Configure TLS 1.2+ and HSTS preload",
+        "header":"Add HSTS, CSP, X-Frame-Options",
+        "debug":"Set DEBUG=false via env var",
+        "verbose":"Return generic errors; log details server-side",
+        "rce":"Fix SQLi; revoke DB superuser",
+        "copy to program":"Fix SQLi; revoke DB superuser",
+        "imds":"Enforce IMDSv2 hop-limit=1",
+        "aws":"Enforce IMDSv2 hop-limit=1",
+        "pin":"Remove debug_info; use crypto token reset",
+        "account takeover":"Remove debug_info; use crypto token reset",
+        "jailbreak":"Remove guardrail-disabling instruction",
+        "pre-jailbroken":"Remove guardrail-disabling instruction",
+        "system prompt":"Remove schema from prompt; filter verbatim replay",
+        "graphql introspect":"Disable introspection in production",
+    }
+    rows = ""
+    for i, f in enumerate(findings, 1):
+        sev = f.get("severity","info").lower()
+        title = f.get("title","")
+        tl = title.lower()
+        fix = next((v for k,v in fix_map.items() if k in tl), "Apply OWASP remediation guidance")
+        rows += (f'<tr><td style="font-family:\'IBM Plex Mono\',monospace;color:#7b78ff;font-size:8pt;">NP-{i:03d}</td>'
+                 f'<td>{badge(sev)}</td>'
+                 f'<td style="color:#e8e6f0;">{esc(title)}</td>'
+                 f'<td style="color:#9b98b8;font-size:8pt;">{esc(p_map.get(sev,"—"))}</td>'
+                 f'<td style="color:#9b98b8;">{esc(e_map.get(sev,"—"))}</td>'
+                 f'<td style="color:#9b98b8;font-size:8pt;">{esc(fix)}</td></tr>\n')
+    return f"""<h1>Remediation Summary</h1>
+<table class="remediation-table">
+  <thead><tr><th>ID</th><th>Severity</th><th>Finding</th><th>Priority</th><th>Effort</th><th>Fix</th></tr></thead>
+  <tbody>{rows}</tbody>
+</table>"""
+
+def build_html():
+    findings = load_findings()
+    counts = {s:0 for s in ("critical","high","medium","low","info","total")}
+    for f in findings:
+        s = f.get("severity","info").lower()
+        counts[s] = counts.get(s,0) + 1
+        counts["total"] += 1
+
+    logo_html = (f'<img class="cover-logo" src="{LOGO_SRC}" alt="NullPointer Studio">'
+                 if LOGO_SRC else
+                 '<div style="height:180px;margin-bottom:2.5cm;display:flex;align-items:center;justify-content:center;">'
+                 '<span style=\'font-family:"Chakra Petch",monospace;font-size:24pt;font-weight:700;color:#7b78ff;\'>'
+                 'NullPointer Studio</span></div>')
+
+    cover = f"""<div class="cover">
+  {logo_html}
+  <div class="cover-classification">CONFIDENTIAL</div>
+  <div class="cover-title">Penetration Test Report</div>
+  <div class="cover-subtitle">notingbank.org</div>
+  <div class="cover-divider"></div>
+  <div class="cover-meta"><table>
+    <tr><td>Client</td><td>NotingBank</td></tr>
+    <tr><td>Target</td><td>http://notingbank.org</td></tr>
+    <tr><td>Test type</td><td>Web App Pentest + API Security + AI Red-Team</td></tr>
+    <tr><td>Framework</td><td>Python / aiohttp 3.13.4 + PostgreSQL + Nginx</td></tr>
+    <tr><td>Test date</td><td>2026-05-08</td></tr>
+    <tr><td>Report date</td><td>2026-05-08</td></tr>
+    <tr><td>Prepared by</td><td>NullPointer Studio</td></tr>
+    <tr><td>Version</td><td>1.0</td></tr>
+  </table></div>
+  <div class="cover-footer">NullPointer Studio &middot; security research &amp; consulting</div>
+</div>"""
+
+    handling = """<div class="callout">
+<strong>Handling Notice</strong><br><br>
+This document contains confidential information pertaining to the security posture of NotingBank.
+It is intended solely for the named client and authorised recipients. This report must not be
+reproduced, distributed, or disclosed to any third party without the express written consent of
+NullPointer Studio and NotingBank.<br><br>
+The vulnerabilities described herein were discovered under controlled conditions as part of an
+authorised security assessment. No exploitation was performed beyond what was necessary to confirm
+the existence and impact of each finding.<br><br>
+<strong>Classification: CONFIDENTIAL &mdash; NOT FOR PUBLIC DISTRIBUTION</strong>
+</div>"""
+
+    stat_html  = build_stat_boxes(counts)
+    exec_html  = build_exec_summary(findings, counts)
+    scope_html = build_scope()
+    dash_html  = build_dashboard(findings)
+
+    cards_html = '<div class="page-break"></div>\n<h1>Findings</h1>\n'
+    for i, f in enumerate(findings, 1):
+        cards_html += finding_card(f"NP-{i:03d}", f)
+
+    remed_html = build_remediation_table(findings)
+
+    footer = """<div class="callout" style="margin-top:32px;">
+<strong>NullPointer Studio</strong> &middot; security research &amp; consulting<br>
+This assessment was performed under a written authorisation agreement. All findings have been
+responsibly disclosed to the client prior to publication of this report.
+NullPointer Studio accepts no liability for actions taken by third parties based on information herein.
+</div>"""
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>notingbank.org Penetration Test Report - NullPointer Studio</title>
+<style>{CSS_STR}</style>
+</head>
+<body>
+{cover}
+{handling}
+{stat_html}
+{exec_html}
+<div class="page-break"></div>
+{scope_html}
+<div class="page-break"></div>
+{dash_html}
+{cards_html}
+<div class="page-break"></div>
+{remed_html}
+{footer}
+</body>
+</html>"""
+
+if __name__ == "__main__":
+    print("Reading findings.json ...")
+    html_content = build_html()
+    print(f"Writing HTML -> {OUTPUT_HTML}")
+    OUTPUT_HTML.write_text(html_content, encoding="utf-8")
+    print(f"Generating PDF -> {OUTPUT_PDF}")
+    WeasyprintHTML(string=html_content, base_url=str(BASE_DIR.resolve())).write_pdf(str(OUTPUT_PDF))
+    findings = load_findings()
+    counts = {s:0 for s in ("critical","high","medium","low","info")}
+    for f in findings:
+        counts[f.get("severity","info").lower()] = counts.get(f.get("severity","info").lower(),0) + 1
+    print(f"\nReport generated:")
+    print(f"  PDF  -> {OUTPUT_PDF}")
+    print(f"  HTML -> {OUTPUT_HTML}")
+    print(f"  Findings: {len(findings)} total ({counts['critical']} critical, "
+          f"{counts['high']} high, {counts['medium']} medium, {counts['low']} low, {counts['info']} info)")

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -559,9 +559,28 @@
       font-family: 'IBM Plex Mono', monospace; font-size: 0.65rem; color: var(--text-dim);
       margin: 0.5rem 0 0.2rem;
     }
+    /* Collapsed scan-context block — not a Smith message, just the state QA reads */
+    .chat-context {
+      align-self: stretch;
+      background: rgba(255,255,255,0.02); border: 1px solid var(--border-subtle);
+      border-radius: 6px; font-size: 0.77rem; color: var(--text-dim);
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    .chat-context summary {
+      padding: 0.35rem 0.65rem; cursor: pointer; user-select: none;
+      display: flex; align-items: center; gap: 0.5rem; list-style: none;
+    }
+    .chat-context summary::-webkit-details-marker { display: none; }
+    .chat-context summary::before { content: '▶'; font-size: 0.55rem; transition: transform 0.15s; }
+    .chat-context[open] summary::before { transform: rotate(90deg); }
+    .chat-context-headline { color: var(--text-muted); }
+    .chat-context-body {
+      padding: 0.3rem 0.65rem 0.55rem; border-top: 1px solid var(--border-subtle);
+      display: flex; flex-direction: column; gap: 0.15rem;
+    }
     .chat-bubble {
-      max-width: 78%; padding: 0.55rem 0.8rem;
-      border-radius: 10px; font-size: 0.82rem; line-height: 1.55;
+      max-width: 82%; padding: 0.6rem 0.85rem;
+      border-radius: 10px; font-size: 0.83rem; line-height: 1.55;
     }
     .chat-bubble.qa {
       align-self: flex-start;
@@ -571,17 +590,38 @@
       align-self: flex-end;
       background: rgba(91,242,155,0.08); border: 1px solid rgba(91,242,155,0.18);
     }
+    .chat-bubble.smith-idle {
+      align-self: flex-end;
+      background: transparent; border: 1px dashed rgba(91,242,155,0.15);
+    }
     .chat-sender {
       font-size: 0.63rem; font-weight: 700; font-family: 'IBM Plex Mono', monospace;
-      margin-bottom: 0.3rem; text-transform: uppercase; letter-spacing: 0.05em;
+      margin-bottom: 0.35rem; text-transform: uppercase; letter-spacing: 0.05em;
     }
-    .chat-bubble.qa  .chat-sender { color: var(--purple); }
-    .chat-bubble.smith .chat-sender { color: var(--green); }
-    .chat-alert-row { display: flex; gap: 0.5rem; align-items: flex-start; margin-bottom: 0.25rem; }
+    .chat-bubble.qa        .chat-sender { color: var(--purple); }
+    .chat-bubble.smith     .chat-sender { color: var(--green); }
+    .chat-bubble.smith-idle .chat-sender { color: rgba(91,242,155,0.4); }
+    .chat-alert-row { display: flex; gap: 0.5rem; align-items: flex-start; margin-bottom: 0.3rem; }
     .chat-alert-row:last-child { margin-bottom: 0; }
+    /* Smith narrative — readable summary of what Smith did */
+    .chat-narrative {
+      color: var(--text); margin-bottom: 0.45rem; line-height: 1.6;
+    }
+    .chat-narrative-part { margin-bottom: 0.2rem; }
+    .chat-narrative-part:last-child { margin-bottom: 0; }
+    .chat-actions-toggle {
+      font-size: 0.68rem; color: var(--text-dim); cursor: pointer;
+      font-family: 'IBM Plex Mono', monospace; margin-top: 0.3rem;
+      user-select: none;
+    }
+    .chat-actions-detail {
+      margin-top: 0.3rem; display: none;
+      border-top: 1px solid rgba(91,242,155,0.12); padding-top: 0.3rem;
+    }
+    .chat-actions-detail.open { display: block; }
     .chat-smith-action {
-      font-family: 'IBM Plex Mono', monospace; font-size: 0.75rem; color: var(--text-dim);
-      margin-bottom: 0.2rem;
+      font-family: 'IBM Plex Mono', monospace; font-size: 0.73rem; color: var(--text-dim);
+      margin-bottom: 0.18rem;
     }
     .chat-smith-action:last-child { margin-bottom: 0; }
     .chat-ok { font-size: 0.8rem; color: var(--text-dim); font-style: italic; }
@@ -1857,13 +1897,64 @@
 
   let _convRenderedCount = 0;
 
+  // Synthesise a readable narrative from Smith's raw action log
+  function _smithNarrative(actions) {
+    if (!actions.length) return [];
+    const parts = [];
+    const skills   = actions.filter(a => a.type === 'SKILL');
+    const tools    = actions.filter(a => a.type === 'TOOL');
+    const findings = actions.filter(a => a.type === 'FINDING');
+    const coverage = actions.filter(a => a.type === 'COVERAGE');
+
+    skills.forEach(s => {
+      const r = s.reason ? ` — ${s.reason}` : '';
+      parts.push(`🎯 Invoked <strong>/${esc(s.name)}</strong>${esc(r)}`);
+    });
+
+    if (tools.length) {
+      const counts = {};
+      tools.forEach(t => counts[t.name||'?'] = (counts[t.name||'?']||0) + 1);
+      const toolStr = Object.entries(counts).map(([n,c]) => c > 1 ? `${esc(n)} ×${c}` : esc(n)).join(', ');
+      parts.push(`🔧 Ran ${tools.length} tool call${tools.length > 1 ? 's' : ''} (${toolStr})`);
+    }
+
+    if (findings.length) {
+      const bySev = {};
+      findings.forEach(f => { const s = f.severity||'info'; bySev[s] = (bySev[s]||0)+1; });
+      const sevStr = ['critical','high','medium','low','info']
+        .filter(s => bySev[s]).map(s => `${bySev[s]} ${s}`).join(', ');
+      const titles = findings.slice(0,2).map(f => esc(f.title||'')).join('; ');
+      const more = findings.length > 2 ? ` +${findings.length-2} more` : '';
+      parts.push(`🔍 Logged ${findings.length} finding${findings.length>1?'s':''} (${sevStr}): ${titles}${more}`);
+    }
+
+    if (coverage.length) {
+      const c = coverage[coverage.length-1];
+      const tested = (c.tested||0) + (c.vulnerable||0);
+      parts.push(`📋 Coverage — ${c.registered||0} endpoints · ${tested} tested · ${c.pending||0} pending`);
+    }
+
+    return parts;
+  }
+
+  // Compact one-liner for the scan-context summary strip
+  function _scanContextHeadline(summary) {
+    const lines = (summary||'').split('\n');
+    const get = key => { const l = lines.find(l => l.startsWith(key)); return l ? l.slice(key.length).trim() : null; };
+    const parts = [];
+    const findings = get('Findings:');       if (findings) parts.push(`Findings: ${findings}`);
+    const coverage = get('Coverage:');       if (coverage) parts.push(coverage.split('—')[0].trim());
+    const gates    = get('Pending gates:');  if (gates)    parts.push(`Gates: ${gates.split(';')[0].trim()}`);
+    const tools    = get('Last tool call:'); if (tools)    parts.push(`Last tool: ${tools}`);
+    return parts.length ? parts.join('  ·  ') : 'Scan state';
+  }
+
   function renderConversation() {
     const wrap = document.getElementById('conversation-wrap');
     if (!wrap) return;
     const qa = _qaData || {};
     const history = qa.history || [];
 
-    // Remove placeholder if we now have data
     const placeholder = wrap.querySelector('.empty-placeholder');
     if (placeholder && history.length) placeholder.remove();
     if (!history.length) {
@@ -1872,7 +1963,6 @@
       return;
     }
 
-    // Append-only: only render cycles we haven't rendered yet
     const newCycles = history.slice(_convRenderedCount);
     if (!newCycles.length) return;
 
@@ -1885,42 +1975,63 @@
       tsEl.textContent = _qlTime(cycle.ts);
       frag.appendChild(tsEl);
 
-      // Smith bubble — session summary sent to QA (the trigger)
-      const summaryLines = (cycle.summary_sent || '').split('\n').filter(l => l.trim());
-      if (summaryLines.length) {
-        const smithCtxDiv = document.createElement('div');
-        smithCtxDiv.className = 'chat-bubble smith';
-        smithCtxDiv.innerHTML = `<div class="chat-sender">Smith → QA</div>${summaryLines.map(l => `<div class="chat-smith-action">${esc(l)}</div>`).join('')}`;
-        frag.appendChild(smithCtxDiv);
+      // Collapsible scan-context block — labelled as automated scan state, not Smith's words
+      const summary = cycle.summary_sent || '';
+      if (summary.trim()) {
+        const ctxEl = document.createElement('details');
+        ctxEl.className = 'chat-context';
+        const headline = _scanContextHeadline(summary);
+        const bodyLines = summary.split('\n').filter(l => l.trim());
+        ctxEl.innerHTML =
+          `<summary><span class="chat-context-headline">Scan state QA reviewed — ${esc(headline)}</span></summary>` +
+          `<div class="chat-context-body">${bodyLines.map(l => `<div>${esc(l)}</div>`).join('')}</div>`;
+        frag.appendChild(ctxEl);
       }
 
-      // QA bubble — alerts (the response)
+      // QA bubble — the questions / flags
       const qaDiv = document.createElement('div');
       qaDiv.className = 'chat-bubble qa';
       const alerts = cycle.alerts || [];
       const alertsInner = alerts.length
-        ? alerts.map(a => `<div class="chat-alert-row"><span class="qa-urgency ${a.urgency||'low'}">${esc(a.urgency||'low')}</span><span class="qa-msg">${esc(a.message||'')}</span></div>`).join('')
-        : '<span class="chat-ok">All clear — no issues this cycle.</span>';
+        ? alerts.map(a =>
+            `<div class="chat-alert-row">` +
+            `<span class="qa-urgency ${esc(a.urgency||'low')}">${esc(a.urgency||'low')}</span>` +
+            `<span class="qa-msg">${esc(a.message||'')}</span>` +
+            `</div>`
+          ).join('')
+        : '<span class="chat-ok">✓ No issues this cycle — all checks passed.</span>';
       qaDiv.innerHTML = `<div class="chat-sender">QA Agent</div>${alertsInner}`;
       frag.appendChild(qaDiv);
 
-      // Smith follow-up bubble — what Smith did after receiving the alerts
+      // Smith response bubble — narrative + collapsible raw actions
       const actions = cycle.smith_actions || [];
-      if (actions.length) {
-        const smithActDiv = document.createElement('div');
-        smithActDiv.className = 'chat-bubble smith';
-        const actionsInner = actions.map(e =>
-          `<div class="chat-smith-action">${QL_ICONS[e.type]||'·'} ${esc(_qlDesc(e))}</div>`
-        ).join('');
-        smithActDiv.innerHTML = `<div class="chat-sender">Smith ← response</div>${actionsInner}`;
-        frag.appendChild(smithActDiv);
+      const narrative = _smithNarrative(actions);
+      const bubbleClass = narrative.length ? 'chat-bubble smith' : 'chat-bubble smith-idle';
+      const smithDiv = document.createElement('div');
+      smithDiv.className = bubbleClass;
+
+      let inner = `<div class="chat-sender">Smith — actions after this QA cycle</div>`;
+      if (narrative.length) {
+        inner += `<div class="chat-narrative">${narrative.map(p => `<div class="chat-narrative-part">${p}</div>`).join('')}</div>`;
+        if (actions.length) {
+          const detailId = `act-${Math.random().toString(36).slice(2)}`;
+          inner +=
+            `<div class="chat-actions-toggle" onclick="this.nextElementSibling.classList.toggle('open');this.textContent=this.nextElementSibling.classList.contains('open')?'▲ hide raw events':'▼ ${actions.length} raw events'">` +
+            `▼ ${actions.length} raw events</div>` +
+            `<div class="chat-actions-detail">` +
+            actions.map(e => `<div class="chat-smith-action">${QL_ICONS[e.type]||'·'} ${_qlDesc(e)}</div>`).join('') +
+            `</div>`;
+        }
+      } else {
+        inner += `<span class="chat-ok">No tool activity recorded between this cycle and the next.</span>`;
       }
+
+      smithDiv.innerHTML = inner;
+      frag.appendChild(smithDiv);
     });
 
     wrap.appendChild(frag);
     _convRenderedCount = history.length;
-
-    // Auto-scroll to bottom so newest message is visible
     wrap.scrollTop = wrap.scrollHeight;
   }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2008,6 +2008,17 @@
       const narrative = _smithNarrative(actions);
       const bubbleClass = narrative.length ? 'chat-bubble smith' : 'chat-bubble smith-idle';
       const smithDiv = document.createElement('div');
+      // Smith reply bubble — what Smith explicitly said in response to QA alerts
+      const reply = cycle.smith_reply;
+      if (reply) {
+        const replyDiv = document.createElement('div');
+        replyDiv.className = 'chat-bubble smith';
+        replyDiv.innerHTML =
+          `<div class="chat-sender">Smith — reply to QA</div>` +
+          `<div class="chat-narrative">${esc(reply)}</div>`;
+        frag.appendChild(replyDiv);
+      }
+
       smithDiv.className = bubbleClass;
 
       let inner = `<div class="chat-sender">Smith — actions after this QA cycle</div>`;

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -161,7 +161,7 @@ async def test_update_cell_warns_on_skip_in_progress(coverage_file):
     data = json.loads(coverage_file.read_text())
     cell = data["matrix"][0]
     result = await core.coverage.update_cell(
-        cell["id"], "tested_clean", notes="No injection found"
+        cell["id"], "tested_clean", notes="No injection found", tested_by="http_request"
     )
     assert isinstance(result, str)
     assert "INTEGRITY WARNING" in result
@@ -203,7 +203,7 @@ async def test_update_cell_invalid_status_returns_false(coverage_file):
 
 @pytest.mark.asyncio
 async def test_update_cell_missing_id_returns_false(coverage_file):
-    ok = await core.coverage.update_cell("nonexistent", "tested_clean")
+    ok = await core.coverage.update_cell("nonexistent", "in_progress")
     assert ok is False
 
 
@@ -243,7 +243,7 @@ async def test_bulk_update_warns_on_skip_in_progress(coverage_file):
     )
     data = json.loads(coverage_file.read_text())
     updates = [
-        {"cell_id": c["id"], "status": "tested_clean", "notes": "OK"}
+        {"cell_id": c["id"], "status": "tested_clean", "notes": "OK", "tested_by": "http_request"}
         for c in data["matrix"][:3]
     ]
     result = await core.coverage.bulk_update(updates)
@@ -364,8 +364,8 @@ async def test_meta_counters_accurate(coverage_file):
 
     # Mark one tested, one vulnerable, one N/A
     cells = data["matrix"]
-    await core.coverage.update_cell(cells[0]["id"], "tested_clean")
-    await core.coverage.update_cell(cells[1]["id"], "vulnerable")
+    await core.coverage.update_cell(cells[0]["id"], "tested_clean", tested_by="sqlmap")
+    await core.coverage.update_cell(cells[1]["id"], "vulnerable", tested_by="sqlmap")
     await core.coverage.update_cell(cells[2]["id"], "not_applicable")
 
     data = json.loads(coverage_file.read_text())

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -4,13 +4,16 @@ Tests for core.qa_agent — session check and QADaemon cycle logic.
 import asyncio
 import json
 import pytest
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import core.qa_agent
 import core.quick_log
 from core.qa_agent import (
-    _session_is_running, _read_qa_state, _build_context_summary,
+    _session_is_running, _read_qa_state,
     _sanitize_history, _init_llm, _build_graph, QADaemon,
+    _deterministic_qa_checks, _load_json, _format_findings_for_semantic_review,
+    _deduplicate,
 )
 from core.quick_log import QuickLog
 
@@ -46,268 +49,327 @@ def test_session_is_running_returns_false_when_corrupt_json(tmp_path, monkeypatc
 
 
 # ---------------------------------------------------------------------------
-# QADaemon._cycle() — early-return guards
+# _load_json()
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_cycle_skips_when_session_not_running(tmp_path, monkeypatch):
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", tmp_path / "session.json")
-    qa_state = tmp_path / "qa_state.json"
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    daemon = QADaemon()
-    await daemon._cycle()
-
-    assert not qa_state.exists()
+def test_load_json_returns_empty_when_file_missing(tmp_path):
+    result = _load_json(tmp_path / "nonexistent.json")
+    assert result == {}
 
 
-@pytest.mark.asyncio
-async def test_cycle_skips_when_graph_is_none(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    qa_state = tmp_path / "qa_state.json"
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
-
-    await daemon._cycle()
-
-    assert not qa_state.exists()
+def test_load_json_returns_parsed_dict(tmp_path):
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps({"key": "value", "num": 42}))
+    result = _load_json(f)
+    assert result == {"key": "value", "num": 42}
 
 
-@pytest.mark.asyncio
-async def test_cycle_skips_when_quick_log_is_empty(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    qa_state = tmp_path / "qa_state.json"
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    await daemon._cycle()
-
-    assert not qa_state.exists()
+def test_load_json_returns_empty_on_corrupt_json(tmp_path):
+    f = tmp_path / "bad.json"
+    f.write_text("not valid json {{{")
+    result = _load_json(f)
+    assert result == {}
 
 
 # ---------------------------------------------------------------------------
-# QADaemon._cycle() — successful write
+# _deterministic_qa_checks()
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_cycle_writes_qa_state_with_alerts(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    qa_state = tmp_path / "qa_state.json"
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    await test_log.append({"type": "TOOL", "name": "nmap", "ts": "2026-01-01T00:00:00+00:00"})
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    expected_alerts = [{"urgency": "high", "message": "test alert"}]
-    mock_result = {"alerts": expected_alerts}
-
-    with patch("asyncio.to_thread", new=AsyncMock(return_value=mock_result)):
-        await daemon._cycle()
-
-    assert qa_state.exists()
-    data = json.loads(qa_state.read_text())
-    assert data["alerts"] == expected_alerts
-    assert "ts" in data
-    assert "history" in data
+def test_deterministic_no_alerts_on_clean_summary():
+    alerts = _deterministic_qa_checks("1 tool call: nmap", {}, {})
+    assert alerts == []
 
 
-@pytest.mark.asyncio
-async def test_cycle_captures_smith_actions_in_history(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    qa_state = tmp_path / "qa_state.json"
-    # Seed a previous cycle so prev_cycle_ts is set and read_since() can capture
-    # actions that happen during the LLM call (the scenario under test).
-    qa_state.write_text(json.dumps({
-        "ts": "2025-12-31T00:00:00+00:00",
-        "alerts": [],
-        "history": [{"ts": "2025-12-31T00:00:00+00:00", "summary_sent": "prev", "alerts": [], "smith_actions": []}],
-    }))
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    await test_log.append({"type": "TOOL", "name": "nmap", "ts": "2026-01-01T00:00:00+00:00"})
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    new_action = {"type": "TOOL", "name": "nuclei", "ts": "2099-12-31T23:59:59+00:00"}
-
-    import asyncio as _real_asyncio
-    _real_to_thread = _real_asyncio.to_thread  # capture before patch replaces it
-
-    async def mock_to_thread(fn, *args, **kwargs):
-        if isinstance(fn, MagicMock):  # intercept graph.invoke only
-            await test_log.append(new_action)
-            return {"alerts": []}
-        return await _real_to_thread(fn, *args, **kwargs)
-
-    with patch("asyncio.to_thread", new=mock_to_thread):
-        await daemon._cycle()
-
-    data = json.loads(qa_state.read_text())
-    assert len(data["history"]) == 2
-    smith_actions = data["history"][-1]["smith_actions"]
-    assert any(a.get("name") == "nuclei" for a in smith_actions)
+def test_deterministic_scope_drift_detected():
+    summary = "Possible off-scope targets used: evil.com"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "SCOPE_DRIFT" in codes
+    scope_alert = next(a for a in alerts if a["code"] == "SCOPE_DRIFT")
+    assert scope_alert["urgency"] == "high"
+    assert scope_alert["blocking"] is False
+    assert "evil.com" in scope_alert["message"]
 
 
-@pytest.mark.asyncio
-async def test_cycle_caps_history_at_20(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
+def test_deterministic_coverage_stall_detected():
+    summary = "WARNING: coverage stale (35 min), 10 pending"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "COVERAGE_STALL" in codes
+    stall = next(a for a in alerts if a["code"] == "COVERAGE_STALL")
+    assert stall["urgency"] == "high"
+    assert "10 cells" in stall["message"]
 
-    qa_state = tmp_path / "qa_state.json"
-    existing_history = [
-        {"ts": f"2026-01-{i:02d}T00:00:00+00:00", "summary_sent": "s", "alerts": [], "smith_actions": []}
-        for i in range(1, 21)
+
+def test_deterministic_coverage_stall_skipped_when_pending_zero():
+    summary = "WARNING: coverage stale (35 min), 0 pending"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "COVERAGE_STALL" not in codes
+
+
+def test_deterministic_spider_without_coverage():
+    summary = "Endpoints found: 15"
+    coverage_data = {"meta": {"total_cells": 0}}
+    alerts = _deterministic_qa_checks(summary, {}, coverage_data)
+    codes = [a["code"] for a in alerts]
+    assert "SPIDER_WITHOUT_COVERAGE" in codes
+    alert = next(a for a in alerts if a["code"] == "SPIDER_WITHOUT_COVERAGE")
+    assert "15" in alert["message"]
+
+
+def test_deterministic_spider_without_coverage_skipped_when_matrix_populated():
+    summary = "Endpoints found: 15"
+    coverage_data = {"meta": {"total_cells": 30}}
+    alerts = _deterministic_qa_checks(summary, {}, coverage_data)
+    codes = [a["code"] for a in alerts]
+    assert "SPIDER_WITHOUT_COVERAGE" not in codes
+
+
+def test_deterministic_poc_gap_detected():
+    findings_data = {
+        "findings": [
+            {"title": "SQLi", "severity": "critical", "poc_files": []},
+            {"title": "XSS", "severity": "high"},
+        ]
+    }
+    alerts = _deterministic_qa_checks("", findings_data, {})
+    codes = [a["code"] for a in alerts]
+    assert "POC_GAP" in codes
+    poc = next(a for a in alerts if a["code"] == "POC_GAP")
+    assert poc["urgency"] == "medium"
+    assert "2/2" in poc["message"]
+
+
+def test_deterministic_poc_gap_truncates_titles_at_three():
+    """More than 3 missing-PoC findings should show +N more in the message."""
+    findings_data = {
+        "findings": [
+            {"title": f"Finding {i}", "severity": "critical", "poc_files": []}
+            for i in range(5)
+        ]
+    }
+    alerts = _deterministic_qa_checks("", findings_data, {})
+    poc = next(a for a in alerts if a["code"] == "POC_GAP")
+    assert "+2 more" in poc["message"]
+
+
+def test_deterministic_poc_gap_skipped_when_all_have_poc():
+    findings_data = {
+        "findings": [
+            {"title": "SQLi", "severity": "critical", "poc_files": ["sqli.http"]},
+        ]
+    }
+    alerts = _deterministic_qa_checks("", findings_data, {})
+    codes = [a["code"] for a in alerts]
+    assert "POC_GAP" not in codes
+
+
+def test_deterministic_skill_chain_gap():
+    summary = "Findings: 2 critical, 1 high"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "SKILL_CHAIN_GAP" in codes
+
+
+def test_deterministic_skill_chain_gap_skipped_when_web_exploit_ran():
+    summary = "Findings: 2 critical, 1 high\nweb-exploit ran"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "SKILL_CHAIN_GAP" not in codes
+
+
+def test_deterministic_tool_inactivity_above_threshold():
+    summary = "Last tool call: 15 minutes ago"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "TOOL_INACTIVITY" in codes
+    inact = next(a for a in alerts if a["code"] == "TOOL_INACTIVITY")
+    assert inact["urgency"] == "low"
+    assert "15min" in inact["message"]
+
+
+def test_deterministic_tool_inactivity_below_threshold():
+    summary = "Last tool call: 5 minutes ago"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "TOOL_INACTIVITY" not in codes
+
+
+def test_deterministic_bulk_marking_detected():
+    summary = "Bulk-marking warning: 8 N/A cells lack tested_by"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "BULK_MARKING" in codes
+    bulk = next(a for a in alerts if a["code"] == "BULK_MARKING")
+    assert bulk["blocking"] is True
+
+
+def test_deterministic_coverage_integrity_detected():
+    summary = "5 tested/vulnerable cells have no tested_by tool"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "COVERAGE_INTEGRITY" in codes
+    integ = next(a for a in alerts if a["code"] == "COVERAGE_INTEGRITY")
+    assert integ["blocking"] is True
+    assert "5" in integ["message"]
+
+
+def test_deterministic_gate_pending_high_urgency():
+    summary = "Pending gates: credential-audit (requires: /credential-audit) triggered 20min ago"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "GATE_PENDING" in codes
+    gate = next(a for a in alerts if a["code"] == "GATE_PENDING")
+    assert gate["urgency"] == "high"
+    assert "20min" in gate["message"]
+
+
+def test_deterministic_gate_pending_medium_urgency():
+    summary = "Pending gates: post-exploit (requires: /post-exploit) triggered 8min ago"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "GATE_PENDING" in codes
+    gate = next(a for a in alerts if a["code"] == "GATE_PENDING")
+    assert gate["urgency"] == "medium"
+
+
+def test_deterministic_gate_pending_skipped_when_recent():
+    summary = "Pending gates: post-exploit (requires: /post-exploit) triggered 2min ago"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "GATE_PENDING" not in codes
+
+
+def test_deterministic_rce_gate_false_positive():
+    summary = "Pending gates: rce-check (requires: /post-exploit) triggered 10min ago\nFindings: 2 medium, 1 low"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "RCE_GATE_FALSE_POSITIVE" in codes
+
+
+def test_deterministic_rce_gate_not_false_positive_with_high_finding():
+    summary = "Pending gates: rce-check (requires: /post-exploit) triggered 10min ago\nFindings: 1 high"
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "RCE_GATE_FALSE_POSITIVE" not in codes
+
+
+def test_deterministic_multiple_alerts_can_fire():
+    summary = (
+        "Possible off-scope targets used: evil.com\n"
+        "Last tool call: 20 minutes ago\n"
+        "Bulk-marking warning: 3 N/A cells lack tested_by"
+    )
+    alerts = _deterministic_qa_checks(summary, {}, {})
+    codes = [a["code"] for a in alerts]
+    assert "SCOPE_DRIFT" in codes
+    assert "TOOL_INACTIVITY" in codes
+    assert "BULK_MARKING" in codes
+
+
+# ---------------------------------------------------------------------------
+# _format_findings_for_semantic_review()
+# ---------------------------------------------------------------------------
+
+def test_format_findings_empty_findings():
+    result = _format_findings_for_semantic_review({})
+    assert result == ""
+
+
+def test_format_findings_no_high_critical():
+    findings_data = {
+        "findings": [
+            {"title": "Info leak", "severity": "info"},
+            {"title": "Low issue", "severity": "low"},
+        ]
+    }
+    result = _format_findings_for_semantic_review(findings_data)
+    assert result == ""
+
+
+def test_format_findings_includes_high_critical():
+    findings_data = {
+        "findings": [
+            {
+                "title": "SQL Injection",
+                "severity": "critical",
+                "description": "Classic SQLi on login",
+                "evidence": "' OR 1=1",
+                "business_impact": "Full DB access",
+            },
+            {
+                "title": "XSS",
+                "severity": "high",
+                "description": "Stored XSS in profile",
+                "evidence": "<script>alert(1)</script>",
+            },
+        ]
+    }
+    result = _format_findings_for_semantic_review(findings_data)
+    assert "[CRITICAL]" in result
+    assert "SQL Injection" in result
+    assert "[HIGH]" in result
+    assert "XSS" in result
+
+
+def test_format_findings_caps_at_ten():
+    findings_data = {
+        "findings": [
+            {"title": f"Finding {i}", "severity": "high", "description": "desc"}
+            for i in range(15)
+        ]
+    }
+    result = _format_findings_for_semantic_review(findings_data)
+    # Only 10 should be included — count how many [HIGH] markers appear
+    assert result.count("[HIGH]") == 10
+
+
+# ---------------------------------------------------------------------------
+# _deduplicate()
+# ---------------------------------------------------------------------------
+
+def test_deduplicate_empty_lists():
+    assert _deduplicate([], []) == []
+
+
+def test_deduplicate_no_previous_keeps_all():
+    new_alerts = [
+        {"code": "SCOPE_DRIFT", "urgency": "high", "message": "drift detected"},
+        {"code": "POC_GAP", "urgency": "medium", "message": "missing pocs"},
     ]
-    qa_state.write_text(json.dumps({"ts": "2026-01-20T00:00:00+00:00", "alerts": [], "history": existing_history}))
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    await test_log.append({"type": "TOOL", "name": "nmap", "ts": "2026-01-01T00:00:00+00:00"})
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    with patch("asyncio.to_thread", new=AsyncMock(return_value={"alerts": []})):
-        await daemon._cycle()
-
-    data = json.loads(qa_state.read_text())
-    assert len(data["history"]) == 20
+    result = _deduplicate(new_alerts, [])
+    assert len(result) == 2
 
 
-@pytest.mark.asyncio
-async def test_cycle_handles_corrupt_qa_state_gracefully(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    qa_state = tmp_path / "qa_state.json"
-    qa_state.write_text("not valid json {{{")
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    await test_log.append({"type": "TOOL", "name": "nmap", "ts": "2026-01-01T00:00:00+00:00"})
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    with patch("asyncio.to_thread", new=AsyncMock(return_value={"alerts": []})):
-        await daemon._cycle()
-
-    data = json.loads(qa_state.read_text())
-    assert len(data["history"]) == 1
+def test_deduplicate_drops_same_code_and_message():
+    alert = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "drift detected"}
+    result = _deduplicate([alert], [alert])
+    assert result == []
 
 
-@pytest.mark.asyncio
-async def test_cycle_handles_malformed_llm_json(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    qa_state = tmp_path / "qa_state.json"
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    await test_log.append({"type": "TOOL", "name": "nmap", "ts": "2026-01-01T00:00:00+00:00"})
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    with patch("asyncio.to_thread", new=AsyncMock(return_value={"alerts": []})):
-        await daemon._cycle()
-
-    data = json.loads(qa_state.read_text())
-    assert data["alerts"] == []
+def test_deduplicate_keeps_same_code_different_message():
+    prev = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "old target"}
+    new = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "new target"}
+    result = _deduplicate([new], [prev])
+    assert len(result) == 1
+    assert result[0]["message"] == "new target"
 
 
-@pytest.mark.asyncio
-async def test_cycle_handles_alerts_not_a_list(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    qa_state = tmp_path / "qa_state.json"
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    await test_log.append({"type": "TOOL", "name": "nmap", "ts": "2026-01-01T00:00:00+00:00"})
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    with patch("asyncio.to_thread", new=AsyncMock(return_value={"alerts": "not-a-list"})):
-        await daemon._cycle()
-
-    data = json.loads(qa_state.read_text())
-    assert data["alerts"] == "not-a-list"
+def test_deduplicate_keeps_different_codes():
+    prev = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "drift"}
+    new = {"code": "POC_GAP", "urgency": "medium", "message": "missing"}
+    result = _deduplicate([new], [prev])
+    assert len(result) == 1
+    assert result[0]["code"] == "POC_GAP"
 
 
-@pytest.mark.asyncio
-async def test_cycle_skips_write_when_alerts_unchanged(tmp_path, monkeypatch):
-    session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": "running"}))
-    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
-
-    alert = {"urgency": "low", "message": "same alert"}
-    qa_state = tmp_path / "qa_state.json"
-    qa_state.write_text(json.dumps({
-        "ts": "2026-01-01T00:00:00+00:00",
-        "alerts": [alert],
-        "history": [],
-    }))
-    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    await test_log.append({"type": "TOOL", "name": "nmap", "ts": "2026-01-01T00:00:00+00:00"})
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    mtime_before = qa_state.stat().st_mtime
-    with patch("asyncio.to_thread", new=AsyncMock(return_value={"alerts": [alert]})):
-        await daemon._cycle()
-
-    # File must NOT have been rewritten (mtime unchanged)
-    assert qa_state.stat().st_mtime == mtime_before
+def test_deduplicate_returns_new_when_urgency_changed():
+    prev = {"code": "TOOL_INACTIVITY", "urgency": "low", "message": "idle 15min"}
+    new = {"code": "TOOL_INACTIVITY", "urgency": "high", "message": "idle 15min"}
+    # Same message → deduped regardless of urgency change (dedup is by code+message)
+    result = _deduplicate([new], [prev])
+    assert result == []
 
 
 # ---------------------------------------------------------------------------
@@ -332,23 +394,6 @@ def test_read_qa_state_returns_empty_on_corrupt_json(tmp_path, monkeypatch):
     qa_state.write_text("not valid json {{{")
     monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
     assert _read_qa_state() == {}
-
-
-# ---------------------------------------------------------------------------
-# _build_context_summary()
-# ---------------------------------------------------------------------------
-
-def test_build_context_summary_no_previous_alerts():
-    result = _build_context_summary("summary text", [])
-    assert result == "summary text"
-
-
-def test_build_context_summary_with_previous_alerts():
-    alerts = [{"urgency": "high", "message": "alert one"}, {"urgency": "medium", "message": "alert two"}]
-    result = _build_context_summary("summary text", alerts)
-    assert "Previously flagged (last cycle):" in result
-    assert "[high] alert one" in result
-    assert "[medium] alert two" in result
 
 
 # ---------------------------------------------------------------------------
@@ -382,6 +427,320 @@ def test_sanitize_history_keeps_valid_alert_dicts():
 
 def test_sanitize_history_empty_list():
     assert _sanitize_history([]) == []
+
+
+def test_sanitize_history_includes_smith_reply_when_present():
+    raw = [{"ts": "t", "summary_sent": "s", "alerts": [],
+            "smith_actions": [], "smith_reply": "Acknowledged."}]
+    result = _sanitize_history(raw)
+    assert result[0]["smith_reply"] == "Acknowledged."
+
+
+def test_sanitize_history_smith_reply_is_none_when_absent():
+    raw = [{"ts": "t", "summary_sent": "s", "alerts": [], "smith_actions": []}]
+    result = _sanitize_history(raw)
+    assert result[0]["smith_reply"] is None
+
+
+def test_sanitize_history_truncates_long_smith_reply():
+    long_reply = "A" * 3000
+    raw = [{"ts": "t", "summary_sent": "s", "alerts": [],
+            "smith_actions": [], "smith_reply": long_reply}]
+    result = _sanitize_history(raw)
+    assert len(result[0]["smith_reply"]) <= 2000
+
+
+# ---------------------------------------------------------------------------
+# QADaemon._cycle() — early-return guards
+# ---------------------------------------------------------------------------
+
+def _setup_cycle_files(tmp_path, monkeypatch, status="running"):
+    session_file = tmp_path / "session.json"
+    session_file.write_text(json.dumps({"status": status}))
+    monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
+
+    qa_state = tmp_path / "qa_state.json"
+    monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
+
+    findings_file = tmp_path / "findings.json"
+    monkeypatch.setattr(core.qa_agent, "_FINDINGS_FILE", findings_file)
+
+    coverage_file = tmp_path / "coverage.json"
+    monkeypatch.setattr(core.qa_agent, "_COVERAGE_FILE", coverage_file)
+
+    return qa_state
+
+
+@pytest.mark.asyncio
+async def test_cycle_skips_when_session_not_running(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch, status="complete")
+    daemon = QADaemon()
+    await daemon._cycle()
+    assert not qa_state.exists()
+
+
+@pytest.mark.asyncio
+async def test_cycle_skips_when_quick_log_is_empty(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    test_log = QuickLog(path=tmp_path / "quick_log.json")
+    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
+
+    daemon = QADaemon()
+    await daemon._cycle()
+    assert not qa_state.exists()
+
+
+@pytest.mark.asyncio
+async def test_cycle_skips_when_no_new_alerts(tmp_path, monkeypatch):
+    """Cycle skips writing when deterministic + semantic both produce no alerts."""
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    # Activity exists but no triggers in the summary
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "1 tool call: nmap"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
+    await daemon._cycle()
+
+    assert not qa_state.exists()
+
+
+@pytest.mark.asyncio
+async def test_cycle_writes_qa_state_with_deterministic_alert(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
+    await daemon._cycle()
+
+    assert qa_state.exists()
+    data = json.loads(qa_state.read_text())
+    codes = [a["code"] for a in data["alerts"]]
+    assert "SCOPE_DRIFT" in codes
+    assert "ts" in data
+    assert "history" in data
+
+
+@pytest.mark.asyncio
+async def test_cycle_caps_alerts_at_four(tmp_path, monkeypatch):
+    """Cycle keeps at most 4 alerts."""
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = (
+        "Possible off-scope targets used: evil.com\n"
+        "Last tool call: 20 minutes ago\n"
+        "Bulk-marking warning: 3 N/A cells lack tested_by\n"
+        "5 tested/vulnerable cells have no tested_by tool\n"
+        "WARNING: coverage stale (40 min), 5 pending"
+    )
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
+    await daemon._cycle()
+
+    data = json.loads(qa_state.read_text())
+    assert len(data["alerts"]) <= 4
+
+
+@pytest.mark.asyncio
+async def test_cycle_captures_smith_actions_in_history(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+    # Seed previous history so prev_cycle_ts is set
+    qa_state.write_text(json.dumps({
+        "ts": "2025-12-31T00:00:00+00:00",
+        "alerts": [],
+        "history": [{"ts": "2025-12-31T00:00:00+00:00", "summary_sent": "prev",
+                     "alerts": [], "smith_actions": [], "smith_reply": None}],
+    }))
+
+    new_action = {"type": "TOOL", "name": "nuclei", "ts": "2099-12-31T23:59:59+00:00"}
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
+    mock_ql.read_since.return_value = [new_action]
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
+    await daemon._cycle()
+
+    data = json.loads(qa_state.read_text())
+    assert len(data["history"]) == 2
+    smith_actions = data["history"][-1]["smith_actions"]
+    assert any(a.get("name") == "nuclei" for a in smith_actions)
+
+
+@pytest.mark.asyncio
+async def test_cycle_caps_history_at_20(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+    existing_history = [
+        {"ts": f"2026-01-{i:02d}T00:00:00+00:00", "summary_sent": "s",
+         "alerts": [], "smith_actions": [], "smith_reply": None}
+        for i in range(1, 21)
+    ]
+    qa_state.write_text(json.dumps({
+        "ts": "2026-01-20T00:00:00+00:00",
+        "alerts": [],
+        "history": existing_history,
+    }))
+
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
+    await daemon._cycle()
+
+    data = json.loads(qa_state.read_text())
+    assert len(data["history"]) == 20
+
+
+@pytest.mark.asyncio
+async def test_cycle_handles_corrupt_qa_state_gracefully(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+    qa_state.write_text("not valid json {{{")
+
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
+    await daemon._cycle()
+
+    data = json.loads(qa_state.read_text())
+    assert len(data["history"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_cycle_invokes_semantic_review_for_high_findings(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    findings_file = tmp_path / "findings.json"
+    findings_file.write_text(json.dumps({
+        "findings": [
+            {"title": "SQLi", "severity": "critical",
+             "description": "Classic injection", "evidence": "payload", "poc_files": ["poc.http"]},
+        ]
+    }))
+    monkeypatch.setattr(core.qa_agent, "_FINDINGS_FILE", findings_file)
+
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "1 tool call: sqlmap"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    semantic_alerts = [{"code": "FINDING_QUALITY", "urgency": "medium",
+                        "blocking": False, "message": "Severity appears overclaimed"}]
+    mock_graph = MagicMock()
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
+
+    with patch("asyncio.to_thread", new=AsyncMock(return_value={"alerts": semantic_alerts})):
+        await daemon._cycle()
+
+    data = json.loads(qa_state.read_text())
+    codes = [a["code"] for a in data["alerts"]]
+    assert "FINDING_QUALITY" in codes
+
+
+@pytest.mark.asyncio
+async def test_cycle_skips_semantic_review_when_no_high_findings(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    findings_file = tmp_path / "findings.json"
+    findings_file.write_text(json.dumps({
+        "findings": [
+            {"title": "Minor info", "severity": "info", "description": "d"},
+        ]
+    }))
+    monkeypatch.setattr(core.qa_agent, "_FINDINGS_FILE", findings_file)
+
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    invoke_called = []
+    mock_graph = MagicMock()
+    mock_graph.invoke = lambda *a, **kw: invoke_called.append(True) or {"alerts": []}
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
+
+    with patch("asyncio.to_thread", new=AsyncMock(side_effect=AssertionError("should not call"))):
+        await daemon._cycle()
+
+    assert not invoke_called
+
+
+@pytest.mark.asyncio
+async def test_cycle_handles_semantic_review_exception(tmp_path, monkeypatch):
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    findings_file = tmp_path / "findings.json"
+    findings_file.write_text(json.dumps({
+        "findings": [
+            {"title": "SQLi", "severity": "critical", "description": "d", "poc_files": ["poc.http"]},
+        ]
+    }))
+    monkeypatch.setattr(core.qa_agent, "_FINDINGS_FILE", findings_file)
+
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "1 tool call: sqlmap"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    mock_graph = MagicMock()
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
+
+    # Semantic review raises an exception — cycle should not crash
+    with patch("asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("LLM timeout"))):
+        await daemon._cycle()  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_cycle_skips_write_when_alerts_unchanged(tmp_path, monkeypatch):
+    """When no new alerts are generated, qa_state is not rewritten."""
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+
+    # Pre-seed qa_state with an existing alert
+    existing_alert = {"code": "SCOPE_DRIFT", "urgency": "high", "blocking": False,
+                      "message": "Possible off-scope targets used: evil.com"}
+    qa_state.write_text(json.dumps({
+        "ts": "2026-01-01T00:00:00+00:00",
+        "alerts": [existing_alert],
+        "history": [],
+    }))
+
+    # Summary produces no deterministic alerts, no high/critical findings
+    mock_ql = MagicMock()
+    mock_ql.summarize.return_value = "1 tool call: nmap"
+    mock_ql.read_since.return_value = []
+    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
+
+    daemon = QADaemon()
+    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
+
+    mtime_before = qa_state.stat().st_mtime
+    await daemon._cycle()
+    assert qa_state.stat().st_mtime == mtime_before
 
 
 # ---------------------------------------------------------------------------
@@ -426,8 +785,6 @@ def test_init_llm_no_colon_defaults_to_openai():
 # ---------------------------------------------------------------------------
 
 def test_build_graph_returns_none_when_langgraph_missing():
-    import sys
-    # Patch both langgraph and langchain_core as missing
     with patch.dict("sys.modules", {"langgraph": None, "langgraph.graph": None,
                                      "langchain_core": None, "langchain_core.messages": None}):
         result = _build_graph()
@@ -484,6 +841,126 @@ def test_build_graph_returns_compiled_graph(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# QADaemon._get_graph() — lazy-builds only once
+# ---------------------------------------------------------------------------
+
+def test_get_graph_builds_once(monkeypatch):
+    build_calls = []
+
+    def fake_build():
+        build_calls.append(1)
+        return MagicMock()
+
+    daemon = QADaemon()
+    with patch("core.qa_agent._build_graph", side_effect=fake_build):
+        daemon._get_graph()
+        daemon._get_graph()
+
+    assert len(build_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# _build_graph() — node execution (invoke_llm + parse_response)
+# ---------------------------------------------------------------------------
+
+def test_build_graph_nodes_parse_valid_json(monkeypatch):
+    """Exercises invoke_llm and parse_response nodes with a mocked LLM."""
+    try:
+        from langgraph.graph import StateGraph  # noqa: F401
+    except ImportError:
+        pytest.skip("langgraph not installed")
+
+    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
+    mock_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = json.dumps({
+        "alerts": [
+            {"code": "FINDING_QUALITY", "urgency": "high",
+             "blocking": False, "message": "severity overclaimed"}
+        ]
+    })
+    mock_llm.invoke.return_value = mock_response
+
+    with patch("core.qa_agent._init_llm", return_value=mock_llm):
+        graph = _build_graph()
+
+    assert graph is not None
+    result = graph.invoke({"summary": "test findings", "raw_response": "", "alerts": []})
+    assert len(result["alerts"]) == 1
+    assert result["alerts"][0]["code"] == "FINDING_QUALITY"
+    assert result["alerts"][0]["urgency"] == "high"
+
+
+def test_build_graph_nodes_handle_invalid_json(monkeypatch):
+    """parse_response should return empty alerts for non-JSON LLM output."""
+    try:
+        from langgraph.graph import StateGraph  # noqa: F401
+    except ImportError:
+        pytest.skip("langgraph not installed")
+
+    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
+    mock_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = "not valid json at all"
+    mock_llm.invoke.return_value = mock_response
+
+    with patch("core.qa_agent._init_llm", return_value=mock_llm):
+        graph = _build_graph()
+
+    assert graph is not None
+    result = graph.invoke({"summary": "test", "raw_response": "", "alerts": []})
+    assert result["alerts"] == []
+
+
+def test_build_graph_nodes_filter_alerts_without_message(monkeypatch):
+    """parse_response drops alert dicts that have no 'message' field."""
+    try:
+        from langgraph.graph import StateGraph  # noqa: F401
+    except ImportError:
+        pytest.skip("langgraph not installed")
+
+    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
+    mock_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = json.dumps({
+        "alerts": [
+            {"code": "FINDING_QUALITY", "urgency": "high"},  # no message → filtered
+            {"code": "FINDING_QUALITY", "urgency": "medium", "message": "real alert"},
+        ]
+    })
+    mock_llm.invoke.return_value = mock_response
+
+    with patch("core.qa_agent._init_llm", return_value=mock_llm):
+        graph = _build_graph()
+
+    assert graph is not None
+    result = graph.invoke({"summary": "test", "raw_response": "", "alerts": []})
+    assert len(result["alerts"]) == 1
+    assert result["alerts"][0]["message"] == "real alert"
+
+
+def test_build_graph_nodes_handle_non_list_alerts(monkeypatch):
+    """parse_response should produce empty alerts when JSON alerts field is not a list."""
+    try:
+        from langgraph.graph import StateGraph  # noqa: F401
+    except ImportError:
+        pytest.skip("langgraph not installed")
+
+    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
+    mock_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = json.dumps({"alerts": "not-a-list"})
+    mock_llm.invoke.return_value = mock_response
+
+    with patch("core.qa_agent._init_llm", return_value=mock_llm):
+        graph = _build_graph()
+
+    assert graph is not None
+    result = graph.invoke({"summary": "test", "raw_response": "", "alerts": []})
+    assert result["alerts"] == []
+
+
+# ---------------------------------------------------------------------------
 # QADaemon.run() — loop and error swallowing
 # ---------------------------------------------------------------------------
 
@@ -501,7 +978,6 @@ async def test_run_calls_cycle_and_swallows_exceptions(tmp_path, monkeypatch):
         call_count += 1
         if call_count == 1:
             raise RuntimeError("boom")
-        # Stop after second iteration
         raise asyncio.CancelledError()
 
     daemon = QADaemon()

--- a/tests/test_quick_log.py
+++ b/tests/test_quick_log.py
@@ -155,7 +155,7 @@ async def test_summarize_includes_coverage_stats(log):
     assert "15 endpoints" in summary
     assert "5 tested" in summary
     assert "10 pending" in summary
-    assert "67%" in summary
+    assert "33%" in summary
 
 
 @pytest.mark.asyncio

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -10,6 +10,7 @@ To add a new tool:
 """
 from __future__ import annotations
 
+from tools.fuzzyai    import TOOL as _fuzzyai
 from tools.httpx      import TOOL as _httpx
 from tools.naabu      import TOOL as _naabu
 from tools.nmap       import TOOL as _nmap
@@ -19,10 +20,10 @@ from tools.subfinder  import TOOL as _subfinder
 from tools.trufflehog import TOOL as _trufflehog
 
 # fmt: off
-# REGISTRY contains only tools that run as standalone Docker containers
-# via _run() / docker_runner.run_container(). Tools that run inside the
-# Kali container (ffuf, spider, fuzzyai, pyrit, garak, promptfoo) are
-# NOT registered here — they use kali_runner.exec_command() directly.
+# REGISTRY contains tools that run as standalone Docker containers
+# via _run() / docker_runner.run_container().
+# Tools that run inside the Kali container (ffuf, spider, pyrit, garak, promptfoo)
+# use kali_runner.exec_command() directly instead.
 REGISTRY = {
     _nmap.name:       _nmap,        # nmap       — port scanner
     _naabu.name:      _naabu,       # naabu      — fast port scanner
@@ -31,6 +32,7 @@ REGISTRY = {
     _subfinder.name:  _subfinder,   # subfinder  — subdomain discovery
     _semgrep.name:    _semgrep,     # semgrep    — static code analysis
     _trufflehog.name: _trufflehog,  # trufflehog — secret scanner
+    _fuzzyai.name:    _fuzzyai,     # fuzzyai    — CyberArk AI/LLM fuzzer (own Docker image)
 }
 # fmt: on
 

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -114,17 +114,24 @@ RUN chmod +x /usr/local/bin/pyrit-runner
 # not installed here. See tools/fuzzyai.py for the image definition.
 
 # AI red-teaming: NVIDIA Garak — LLM vulnerability scanner (probe-based)
-RUN pip3 install --no-cache-dir garak==0.14.0 --break-system-packages || true
+# Installed in a venv to avoid conflicts with Debian-managed packages (no RECORD file).
+# --system-site-packages inherits system packages so only the delta is fetched.
+RUN apt-get update && apt-get install -y --no-install-recommends python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/garak-venv --system-site-packages \
+    && /opt/garak-venv/bin/pip install --no-cache-dir garak==0.15.0 \
+    && ln -sf /opt/garak-venv/bin/garak /usr/local/bin/garak
 
 # AI red-teaming: promptfoo — LLM eval + red-team framework (npm)
-RUN (apt-get update && apt-get install -y --no-install-recommends nodejs npm \
+RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g promptfoo@0.121.2) || true
+    && npm install -g promptfoo@0.121.2
 
 # Web spider: Playwright + headless Chromium for JavaScript-aware crawling
 # (required for Hotwire/Turbo Frame apps where katana misses lazy-loaded content)
-# Pinned to 1.49.0 — update explicitly when needed
-RUN pip3 install --no-cache-dir playwright==1.49.0 --break-system-packages \
+# Pinned to 1.59.0 — update explicitly when needed
+# 1.50+ uses pyee>=13.0.0 which matches the Kali system python3-pyee package
+RUN pip3 install --no-cache-dir playwright==1.59.0 --break-system-packages \
     && playwright install chromium --with-deps
 
 # Exploitation payload generators


### PR DESCRIPTION
## Summary

Rolls up all in-progress work from this branch into a single PR.

### Skills submodule (f720a78)
- **`/gh-export` demoted to optional** across all skill chain tables — no more unsolicited GitHub issue filing at scan end
- **New `/business-logic` skill** for financial, SaaS, and multi-tenant business logic testing
- **`web-exploit/refs/business-logic.md`** lazy-loaded reference
- Pentester chain table wired for `/business-logic` on financial/transactional targets

### QA Agent (`core/qa_agent.py`)
Two-layer QA system replacing single LLM-only loop:
- **Layer 1 — deterministic rules** (no LLM): SCOPE_DRIFT, COVERAGE_STALL, SPIDER_WITHOUT_COVERAGE, POC_GAP, SKILL_CHAIN_GAP, TOOL_INACTIVITY, BULK_MARKING, COVERAGE_INTEGRITY
- **Layer 2 — semantic LLM review**: only fires for high/critical findings; checks severity overclaiming, vague descriptions, missing attack chains
- Alerts now carry `code`, `urgency`, and `blocking` fields

### Scan completion gate (`core/session.py`, `mcp_server/session_tools.py`)
- Blocking QA alerts prevent `session(action="complete")` until resolved
- `quality_gate="failed"` sets status to `incomplete_with_unresolved_blockers`
- Per-finding PoC check via `poc_files[]` field instead of directory scan
- Missing evidence/reproduction steps on high/critical findings block completion
- Skipped cells without WAF evidence flagged as INTEGRITY violations

### Coverage (`core/coverage.py`)
- `ADDRESSED_STATUSES` frozenset (skipped excluded — it's a deferral, not evidence)
- `meta.addressed` counter written by `_recount()` for efficient reads

### Core plumbing
- `findings.py`: `save_poc()` links PoC to `finding.poc_files[]` automatically
- `quick_log.py`: `summarize()` includes QA alert summary for deterministic rule inputs
- `http_tools.py`: `save_poc()` accepts `finding_id` and populates `poc_files[]`
- `report_tools.py`: strip whitespace from notes before logging
- `scan_tools.py` / `scan_engine/state.py`: minor cleanup and stale artifact fix
- `tools/kali/Dockerfile`: add packages for business-logic skill
- `CLAUDE.md`: add `/business-logic` to available skills table

## Test plan
- [ ] Run a scan to completion — verify blocking QA alerts prevent `session(action="complete")`
- [ ] Save a PoC with `finding_id` — confirm `poc_files[]` is populated on the finding
- [ ] Trigger BULK_MARKING rule by marking N/A cells without `tested_by`
- [ ] Verify `/business-logic` loads and `/gh-export` no longer auto-fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)