### PR TITLE
feat: add metrics, steering queue, and recovery improvements to scan …

### DIFF
--- a/.github/workflows/bump-skills.yml
+++ b/.github/workflows/bump-skills.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
@@ -27,14 +28,25 @@ jobs:
           git submodule update --remote --merge skills
           echo "sha=$(git -C skills rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Commit if changed
+      - name: Open PR if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if git diff --quiet; then
             echo "skills already up to date"
-          else
-            git add skills
-            git commit -m "chore: bump skills submodule to ${{ steps.update.outputs.sha }}"
-            git push
+            exit 0
           fi
+          BRANCH="ci/auto-bump-skills"
+          git checkout -B "$BRANCH"
+          git add skills
+          git commit -m "chore: bump skills submodule to ${{ steps.update.outputs.sha }}"
+          git push --force-with-lease origin "$BRANCH"
+          gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' \
+            | grep -q '[0-9]' && echo "PR already open" && exit 0
+          gh pr create \
+            --title "chore: bump skills submodule to ${{ steps.update.outputs.sha }}" \
+            --body "Automated skills submodule bump triggered by workflow." \
+            --base main \
+            --head "$BRANCH"

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ report_generator.py
 *.swp
 *.swo
 *~
+steering_queue.json
+recovery_latest.json
+pentest_metrics.jsonl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,8 @@ Skills are slash commands that contain full structured workflows. In Claude Code
 |---------|---------|-------------|
 | `/pentester` | Full pentest orchestrator — recon → exploitation → report | General web/network pentest request |
 | `/web-exploit` | Deep injection, auth, logic, and business-logic exploitation | Web app confirmed; systematic endpoint testing needed |
-| `/business-logic` | Understanding-first BL testing: BOLA, BFLA, workflow bypass, financial logic, trust boundary, multi-tenant isolation | Financial/SaaS/transactional app; systematic BL coverage needed |
+| `/param-fuzz` | Auth stripping, type confusion, boundary values, mass assignment discovery, entropy/predictability analysis of generated IDs and tokens | After /web-exploit on any app with structured parameters or generated values (tokens, IDs, PINs, reference numbers) |
+| `/business-logic` | Understanding-first BL testing: value/quantity logic abuse, workflow bypass, state machine abuse, BOLA/BFLA, replay/idempotency, quota bypass, time manipulation, multi-tenant isolation — domain-agnostic | Any multi-user app with stateful workflows, numeric fields, or role-based access |
 | `/codebase` | OWASP ASVS 5.0 white-box source code review | Local codebase path provided |
 | `/ai-redteam` | OWASP LLM Top 10 red-team — prompt injection, jailbreaks, data extraction | AI/chatbot/LLM target |
 | `/cloud-security` | AWS/Azure/GCP IAM, storage, serverless posture assessment | Cloud account target |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Log findings, diagrams, notes, and coverage matrix updates.
 - `action="finding"` — data: `{title, severity, target, description, evidence, tool_used, cve}`
 - `action="diagram"` — data: `{title, mermaid}`
 - `action="note"` — data: `{message}`
-- `action="dashboard"` — data: `{port: 5000}`
+- `action="dashboard"` — data: `{port: 8888}`
 - `action="coverage"` — data: `{type, ...}` — manage the coverage matrix:
   - `type="endpoint"` — register endpoint + auto-generate cells: `{path, method, params=[{name, type, value_hint}], discovered_by, auth_context}`
   - `type="tested"` — mark cell tested: `{cell_id, status (tested_clean|vulnerable|not_applicable|skipped), notes, finding_id}`

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -1,7 +1,7 @@
 """
 FastAPI web server
 ==================
-Serves the dashboard UI and REST API on the same port (default 8888).
+Serves the dashboard UI and REST API on the same port (default 7777).
 
 Routes
 ------
@@ -14,8 +14,8 @@ Routes
 Usage
 -----
   from core.api_server import serve
-  url = await serve(port=8888)
-  # → "http://localhost:8888"
+  url = await serve(port=7777)
+  # → "http://localhost:7777"
 """
 from __future__ import annotations
 
@@ -438,12 +438,16 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _port_healthy(port: int) -> bool:
-    import socket
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(("localhost", port)) == 0
+    """Return True only if our FastAPI dashboard is responding on this port."""
+    import urllib.request
+    try:
+        with urllib.request.urlopen(f"http://localhost:{port}/api/session", timeout=2) as r:
+            return r.status == 200
+    except Exception:
+        return False
 
 
-async def serve(port: int = 8888) -> str:
+async def serve(port: int = 7777) -> str:
     """
     Start the dashboard server as an independent background process.
     Survives MCP server restarts — uses a PID file to detect and reuse

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -291,8 +291,6 @@ async def api_clear() -> JSONResponse:
     except Exception:
         pass
 
-    # session.json, coverage_matrix.json, quick_log.json, qa_state.json, session_cost.json,
-    # steering_queue.json, recovery_latest.json
     _RECOVERY_SNAP = _REPO_ROOT / "recovery_latest.json"
     for path in (_SESSION_FILE, _COVERAGE_FILE, _QUICK_LOG_FILE, _QA_STATE_FILE,
                  _COST_FILE, _STEERING_FILE, _RECOVERY_SNAP):

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -1,7 +1,7 @@
 """
 FastAPI web server
 ==================
-Serves the dashboard UI and REST API on the same port (default 5000).
+Serves the dashboard UI and REST API on the same port (default 8888).
 
 Routes
 ------
@@ -14,8 +14,8 @@ Routes
 Usage
 -----
   from core.api_server import serve
-  url = await serve(port=5000)
-  # → "http://localhost:5000"
+  url = await serve(port=8888)
+  # → "http://localhost:8888"
 """
 from __future__ import annotations
 
@@ -34,7 +34,9 @@ _SESSION_FILE      = _REPO_ROOT / "session.json"
 _COST_FILE         = _REPO_ROOT / "session_cost.json"
 _COVERAGE_FILE     = _REPO_ROOT / "coverage_matrix.json"
 _QA_STATE_FILE     = _REPO_ROOT / "qa_state.json"
+_STEERING_FILE     = _REPO_ROOT / "steering_queue.json"
 _QUICK_LOG_FILE    = _REPO_ROOT / "quick_log.json"
+_METRICS_FILE      = _REPO_ROOT / "pentest_metrics.jsonl"
 _TEMPLATES_DIR     = _REPO_ROOT / "templates"
 _THREAT_MODEL_DIR  = _REPO_ROOT / "threat-model"
 
@@ -289,8 +291,11 @@ async def api_clear() -> JSONResponse:
     except Exception:
         pass
 
-    # session.json, coverage_matrix.json, quick_log.json, qa_state.json, session_cost.json
-    for path in (_SESSION_FILE, _COVERAGE_FILE, _QUICK_LOG_FILE, _QA_STATE_FILE, _COST_FILE):
+    # session.json, coverage_matrix.json, quick_log.json, qa_state.json, session_cost.json,
+    # steering_queue.json, recovery_latest.json
+    _RECOVERY_SNAP = _REPO_ROOT / "recovery_latest.json"
+    for path in (_SESSION_FILE, _COVERAGE_FILE, _QUICK_LOG_FILE, _QA_STATE_FILE,
+                 _COST_FILE, _STEERING_FILE, _RECOVERY_SNAP):
         _safe_unlink(path)
 
     # log files in logs/
@@ -365,6 +370,17 @@ async def api_qa() -> JSONResponse:
     return JSONResponse(_read_json(_QA_STATE_FILE))
 
 
+@app.get("/api/steering")
+async def api_steering() -> JSONResponse:
+    return JSONResponse(_read_json(_STEERING_FILE))
+
+
+@app.get("/api/metrics")
+async def api_metrics() -> JSONResponse:
+    import core.metrics as metrics_mod
+    return JSONResponse(metrics_mod.load_all())
+
+
 @app.get("/api/quicklog")
 async def api_quicklog() -> JSONResponse:
     if not _QUICK_LOG_FILE.exists():
@@ -427,7 +443,7 @@ def _port_healthy(port: int) -> bool:
         return s.connect_ex(("localhost", port)) == 0
 
 
-async def serve(port: int = 5000) -> str:
+async def serve(port: int = 8888) -> str:
     """
     Start the dashboard server as an independent background process.
     Survives MCP server restarts — uses a PID file to detect and reuse

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,301 @@
+"""
+Pentest run metrics
+===================
+Computes and appends one record to pentest_metrics.jsonl at scan completion.
+Each record is a self-contained snapshot — never mutated after writing.
+
+Called from mcp_server/session_tools.py :: _do_complete() after a clean or
+force-completed scan.
+
+Schema (all fields always present; None for unavailable):
+  run_id            str       session UUID
+  ts                str       ISO completion timestamp
+  target            str       declared target
+  depth             str       recon|standard|thorough
+  status            str       complete|incomplete_with_unresolved_blockers|limit_reached
+  force_completed   bool
+
+  # Duration
+  duration_minutes  float
+
+  # Cost
+  total_cost_usd        float
+  tool_calls_total      int
+  context_chars_total   int
+  cost_per_finding      float | None
+  tool_calls_per_finding float | None
+
+  # Coverage
+  endpoint_count        int
+  total_cells           int
+  coverage_rate_pct     float   (addressed/total * 100)
+  injection_types_tested list[str]
+  injection_breadth     int     (unique injection types tested)
+
+  # Findings
+  findings_total        int
+  findings_critical     int
+  findings_high         int
+  findings_medium       int
+  findings_low          int
+  findings_info         int
+  poc_coverage_rate_pct float | None   (findings_with_poc / (crit+high) * 100)
+  false_positive_count  int
+  escalation_completion_rate_pct float | None
+
+  # Context health
+  resume_events         int     (RESUME DETECTED in tool_invocations)
+  duplicate_tool_calls  int     (DUPLICATE_TOOL_CALL warnings in tool_invocations)
+  steering_interventions  int   (total directives in steering_queue history)
+  steering_auto_satisfied int   (auto_satisfied directives)
+
+  # Skill chain
+  skills_invoked        list[str]
+  skill_chain_depth     int
+  unsatisfied_gate_count int
+  completion_blockers   list[str]
+
+  # Speed
+  time_per_skill_minutes dict[str, float]
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent
+_METRICS_FILE = _REPO_ROOT / "pentest_metrics.jsonl"
+
+
+def record(
+    session: dict,
+    cost_summary: dict,
+    findings_data: dict,
+    coverage: dict,
+    force_completed: bool,
+    completion_blockers: list[str],
+    quick_log_entries: list[dict],
+    steering_history: list[dict],
+) -> dict:
+    """Compute metrics and append to pentest_metrics.jsonl. Returns the record."""
+    m = _compute(
+        session, cost_summary, findings_data, coverage,
+        force_completed, completion_blockers, quick_log_entries, steering_history,
+    )
+    _append(m)
+    return m
+
+
+def load_all() -> list[dict]:
+    """Return all historical metric records, oldest first."""
+    if not _METRICS_FILE.exists():
+        return []
+    records = []
+    for line in _METRICS_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                pass
+    return records
+
+
+# ── Computation ───────────────────────────────────────────────────────────────
+
+def _compute(
+    session: dict,
+    cost_summary: dict,
+    findings_data: dict,
+    coverage: dict,
+    force_completed: bool,
+    completion_blockers: list[str],
+    quick_log_entries: list[dict],
+    steering_history: list[dict],
+) -> dict:
+    findings = findings_data.get("findings", [])
+    meta = coverage.get("meta", {})
+    matrix = coverage.get("matrix", [])
+    endpoints = coverage.get("endpoints", [])
+
+    # ── Duration ─────────────────────────────────────────────────────────────
+    duration_min = _duration_minutes(session)
+
+    # ── Cost ─────────────────────────────────────────────────────────────────
+    total_cost = round(cost_summary.get("est_cost_usd", 0.0), 6)
+    tool_calls = cost_summary.get("tool_calls_done", 0)
+    context_chars = session.get("context_chars_sent", 0)
+
+    findings_count = len(findings)
+    cost_per_finding = round(total_cost / findings_count, 6) if findings_count else None
+    calls_per_finding = round(tool_calls / findings_count, 2) if findings_count else None
+
+    # ── Coverage ─────────────────────────────────────────────────────────────
+    total_cells = meta.get("total_cells", 0)
+    addressed = meta.get("addressed", meta.get("tested", 0) + meta.get("not_applicable", 0))
+    coverage_rate = round(addressed / total_cells * 100, 1) if total_cells else 0.0
+
+    tested_statuses = {"tested_clean", "vulnerable"}
+    tested_injection_types = sorted({
+        c["injection_type"]
+        for c in matrix
+        if c.get("status") in tested_statuses and c.get("injection_type")
+    })
+
+    # ── Findings ─────────────────────────────────────────────────────────────
+    sev_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
+    for f in findings:
+        s = f.get("severity", "").lower()
+        if s in sev_counts:
+            sev_counts[s] += 1
+
+    high_crit_count = sev_counts["critical"] + sev_counts["high"]
+    findings_with_poc = sum(1 for f in findings if f.get("poc_files"))
+    poc_rate = round(findings_with_poc / high_crit_count * 100, 1) if high_crit_count else None
+
+    false_positives = sum(1 for f in findings if f.get("status") == "false_positive")
+
+    total_leads = sum(len(f.get("escalation_leads", [])) for f in findings)
+    done_leads = sum(
+        1 for f in findings
+        for lead in f.get("escalation_leads", [])
+        if lead.get("status") == "done"
+    )
+    esc_rate = round(done_leads / total_leads * 100, 1) if total_leads else None
+
+    # ── Context health ────────────────────────────────────────────────────────
+    invocations = session.get("tool_invocations", [])
+    resume_events = sum(
+        1 for i in invocations
+        if "RESUME DETECTED" in i.get("summary", "")
+    )
+    duplicate_calls = sum(
+        1 for i in invocations
+        if "DUPLICATE_TOOL_CALL" in i.get("summary", "")
+    )
+    # Also check quick_log for QA_REPLY/duplicate markers
+    for e in quick_log_entries:
+        if e.get("type") == "TOOL" and "DUPLICATE" in e.get("name", ""):
+            duplicate_calls += 1
+
+    steering_total = len(steering_history)
+    steering_auto = sum(1 for d in steering_history if d.get("status") == "auto_satisfied")
+
+    # ── Skill chain ───────────────────────────────────────────────────────────
+    skill_history = session.get("skill_history", [])
+    skills_invoked = [
+        (e["skill"] if isinstance(e, dict) else e)
+        for e in skill_history
+    ]
+
+    gates = session.get("gates", [])
+    unsatisfied_gates = sum(1 for g in gates if g.get("status") != "satisfied")
+
+    # ── Time per skill (from quick_log SKILL events) ──────────────────────────
+    time_per_skill = _compute_time_per_skill(quick_log_entries, duration_min)
+
+    return {
+        # Identity
+        "run_id":   session.get("id", ""),
+        "ts":       session.get("finished") or datetime.now(timezone.utc).isoformat(),
+        "target":   session.get("target", ""),
+        "depth":    session.get("depth", ""),
+        "status":   session.get("status", "complete"),
+        "force_completed": force_completed,
+
+        # Duration
+        "duration_minutes": duration_min,
+
+        # Cost
+        "total_cost_usd":          total_cost,
+        "tool_calls_total":        tool_calls,
+        "context_chars_total":     context_chars,
+        "cost_per_finding":        cost_per_finding,
+        "tool_calls_per_finding":  calls_per_finding,
+
+        # Coverage
+        "endpoint_count":          len(endpoints),
+        "total_cells":             total_cells,
+        "coverage_rate_pct":       coverage_rate,
+        "injection_types_tested":  tested_injection_types,
+        "injection_breadth":       len(tested_injection_types),
+
+        # Findings
+        "findings_total":          findings_count,
+        "findings_critical":       sev_counts["critical"],
+        "findings_high":           sev_counts["high"],
+        "findings_medium":         sev_counts["medium"],
+        "findings_low":            sev_counts["low"],
+        "findings_info":           sev_counts["info"],
+        "poc_coverage_rate_pct":   poc_rate,
+        "false_positive_count":    false_positives,
+        "escalation_completion_rate_pct": esc_rate,
+
+        # Context health
+        "resume_events":            resume_events,
+        "duplicate_tool_calls":     duplicate_calls,
+        "steering_interventions":   steering_total,
+        "steering_auto_satisfied":  steering_auto,
+
+        # Skill chain
+        "skills_invoked":          skills_invoked,
+        "skill_chain_depth":       len(set(skills_invoked)),
+        "unsatisfied_gate_count":  unsatisfied_gates,
+        "completion_blockers":     completion_blockers,
+
+        # Speed
+        "time_per_skill_minutes":  time_per_skill,
+    }
+
+
+def _duration_minutes(session: dict) -> float:
+    try:
+        started  = datetime.fromisoformat(session["started"])
+        finished = datetime.fromisoformat(session["finished"])
+        return round((finished - started).total_seconds() / 60, 1)
+    except Exception:
+        return 0.0
+
+
+def _compute_time_per_skill(entries: list[dict], total_minutes: float) -> dict[str, float]:
+    """Compute minutes spent in each skill by bucketing TOOL events between SKILL events."""
+    skill_events = [(e["ts"], e.get("name", "")) for e in entries if e.get("type") == "SKILL"]
+    tool_events  = [(e["ts"],) for e in entries if e.get("type") in ("TOOL", "SPIDER")]
+
+    if not skill_events:
+        return {}
+
+    result: dict[str, float] = {}
+    # Build time windows: skill_name → (start_ts, end_ts)
+    windows: list[tuple[str, str, str]] = []
+    for i, (ts, name) in enumerate(skill_events):
+        end_ts = skill_events[i + 1][0] if i + 1 < len(skill_events) else ""
+        windows.append((name, ts, end_ts))
+
+    for name, start_ts, end_ts in windows:
+        # Count tool events in this window
+        in_window = [
+            t[0] for t in tool_events
+            if t[0] >= start_ts and (not end_ts or t[0] < end_ts)
+        ]
+        if not in_window:
+            continue
+        try:
+            start_dt = datetime.fromisoformat(start_ts)
+            end_dt   = datetime.fromisoformat(in_window[-1])
+            mins = round((end_dt - start_dt).total_seconds() / 60, 1)
+            result[name] = result.get(name, 0.0) + mins
+        except Exception:
+            pass
+
+    return result
+
+
+def _append(record: dict) -> None:
+    try:
+        line = json.dumps(record, separators=(",", ":")) + "\n"
+        with _METRICS_FILE.open("a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception:
+        pass

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -193,7 +193,7 @@ def _compute(
     unsatisfied_gates = sum(1 for g in gates if g.get("status") != "satisfied")
 
     # ── Time per skill (from quick_log SKILL events) ──────────────────────────
-    time_per_skill = _compute_time_per_skill(quick_log_entries, duration_min)
+    time_per_skill = _compute_time_per_skill(quick_log_entries)
 
     return {
         # Identity
@@ -258,7 +258,7 @@ def _duration_minutes(session: dict) -> float:
         return 0.0
 
 
-def _compute_time_per_skill(entries: list[dict], total_minutes: float) -> dict[str, float]:
+def _compute_time_per_skill(entries: list[dict]) -> dict[str, float]:
     """Compute minutes spent in each skill by bucketing TOOL events between SKILL events."""
     skill_events = [(e["ts"], e.get("name", "")) for e in entries if e.get("type") == "SKILL"]
     tool_events  = [(e["ts"],) for e in entries if e.get("type") in ("TOOL", "SPIDER")]

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -453,11 +453,12 @@ class QADaemon:
         while True:
             await asyncio.sleep(interval_s)
             try:
-                self._cycle()
+                await self._cycle()
             except Exception as exc:
                 _log.warning("QA Daemon cycle error: %s", exc)
 
-    def _cycle(self) -> None:
+    async def _cycle(self) -> None:
+        await asyncio.sleep(0)
         if not _session_is_running():
             return
 

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -1,20 +1,18 @@
 """
 QA Agent
 ========
-Two-layer QA reviewer that runs every 2 minutes during an active scan.
+Deterministic QA reviewer + active steering daemon.
 
-Layer 1 — Deterministic Python rules
-  Reads quick_log.summarize(), findings.json, and coverage_matrix.json.
-  Produces coded, typed alerts without any LLM call.
+Runs every 2 minutes during an active scan. Two responsibilities:
 
-Layer 2 — Semantic LLM review
-  Only invoked when there are high/critical findings to review.
-  Checks: overclaimed severity, vague descriptions, missing attack chains.
-  Provider-agnostic via QA_MODEL env var:
+1. Alert generation — coded alerts written to qa_state.json and injected into
+   tool envelopes (via envelope P5.5). Purely observational — no blocking on
+   most codes, completeness blocking only on BULK_MARKING and COVERAGE_INTEGRITY.
 
-    QA_MODEL=openai:gpt-4o-mini               (default)
-    QA_MODEL=anthropic:claude-haiku-4-5-20251001
-    QA_MODEL=ollama:qwen2.5:7b
+2. Steering directives — when Smith stalls, misses a skill chain, or leaves a gate
+   open too long, the QA daemon writes a SteeringDirective to steering_queue.json.
+   The envelope P5.7 injects pending directives directly into Smith's next tool
+   response. No model action needed — Smith sees it automatically.
 
 Alert schema
   {
@@ -23,17 +21,17 @@ Alert schema
     "blocking": bool,  — true = this alert blocks scan completion
     "message":  str,   — human-readable description
   }
+
+All checks operate on structured data (session.json, coverage_matrix.json,
+findings.json, quick_log entries). No regex parsing of summary text.
 """
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
-import os
-import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TypedDict
 
 _log = logging.getLogger(__name__)
 _REPO_ROOT      = Path(__file__).parent.parent
@@ -42,38 +40,72 @@ _SESSION_FILE   = _REPO_ROOT / "session.json"
 _FINDINGS_FILE  = _REPO_ROOT / "findings.json"
 _COVERAGE_FILE  = _REPO_ROOT / "coverage_matrix.json"
 
+_DOCKER_ALIASES = {"host.docker.internal", "172.17.0.1", "172.18.0.1"}  # NOSONAR
 
-# ── Deterministic checks ──────────────────────────────────────────────────────
 
-def _check_scope_drift(summary: str) -> dict | None:
-    if "Possible off-scope targets used:" not in summary:
+def _norm_target(t: str) -> str:
+    for alias in _DOCKER_ALIASES:
+        t = t.replace(alias, "localhost")
+    return t
+
+
+# ── Deterministic checks — structured data only ───────────────────────────────
+
+def _check_scope_drift(entries: list[dict], session_data: dict) -> dict | None:
+    declared = _norm_target(session_data.get("target", ""))
+    if not declared:
         return None
-    m = re.search(r"Possible off-scope targets used: (.+)", summary)
-    targets = m.group(1).strip() if m else "unknown"
+    off_scope: set[str] = set()
+    for e in entries:
+        if e.get("type") != "TOOL":
+            continue
+        tgt = _norm_target(e.get("target", ""))
+        if tgt and declared not in tgt and tgt not in declared:
+            off_scope.add(e.get("target", ""))
+    if not off_scope:
+        return None
+    targets = ", ".join(list(off_scope)[:5])
     return {"code": "SCOPE_DRIFT", "urgency": "high", "blocking": False,
             "message": f"Scope drift: tools ran against {targets}"}
 
 
-def _check_coverage_stall(summary: str) -> dict | None:
-    stall_m   = re.search(r"WARNING: coverage stale \((\d+) min", summary)
-    pending_m = re.search(r",\s*(\d+) pending", summary)
-    if not stall_m or not pending_m:
+def _check_coverage_stall(coverage_data: dict, entries: list[dict]) -> dict | None:
+    cov_entries = [e for e in entries if e.get("type") == "COVERAGE"]
+    if not cov_entries:
         return None
-    pending = int(pending_m.group(1))
+    last = cov_entries[-1]
+    pending = last.get("pending", 0)
     if pending == 0:
         return None
-    mins = int(stall_m.group(1))
+    try:
+        last_ts = datetime.fromisoformat(last["ts"])
+        mins = int((datetime.now(timezone.utc) - last_ts).total_seconds() / 60)
+    except Exception:
+        return None
+    if mins < 15:
+        return None
+    from core.steering import steering_queue, RESUME_TESTING
+    steering_queue.add_directive(
+        code=RESUME_TESTING,
+        message=(
+            f"Coverage stalled {mins}min — {pending} cells pending. "
+            "EXECUTE: session(action='recovery') then resume systematic testing from EXECUTE_NOW."
+        ),
+        priority="high",
+        skill=None,
+        trigger="COVERAGE_STALL",
+    )
     return {"code": "COVERAGE_STALL", "urgency": "high", "blocking": False,
             "message": f"Coverage stall — {pending} cells untested, last update {mins}min ago"}
 
 
-def _check_spider_without_coverage(summary: str, coverage_data: dict) -> dict | None:
-    if "Endpoints found:" not in summary:
+def _check_spider_without_coverage(entries: list[dict], coverage_data: dict) -> dict | None:
+    spiders = [e for e in entries if e.get("type") == "SPIDER"]
+    if not spiders:
         return None
     if coverage_data.get("meta", {}).get("total_cells", 0) != 0:
         return None
-    m = re.search(r"Endpoints found: (\S+)", summary)
-    count = m.group(1) if m else "?"
+    count = spiders[-1].get("endpoints_found", "?")
     return {"code": "SPIDER_WITHOUT_COVERAGE", "urgency": "high", "blocking": False,
             "message": f"Spider found {count} endpoint(s) but coverage matrix is empty — register endpoints"}
 
@@ -87,59 +119,95 @@ def _check_poc_gap(findings_data: dict) -> dict | None:
     titles = ", ".join(f["title"] for f in missing_poc[:3])
     if len(missing_poc) > 3:
         titles += f" +{len(missing_poc) - 3} more"
-    return {"code": "POC_GAP", "urgency": "medium", "blocking": False,
+    from core.steering import steering_queue, POC_REQUIRED
+    steering_queue.add_directive(
+        code=POC_REQUIRED,
+        message=(
+            f"PoC required for {len(missing_poc)} high/critical finding(s): {titles}. "
+            "Call http(action='save_poc', options={title: '...', finding_id: '<id>'}) for each."
+        ),
+        priority="high",
+        skill=None,
+        trigger="POC_GAP",
+    )
+    return {"code": "POC_GAP", "urgency": "high", "blocking": False,
             "message": f"PoC gap: {len(missing_poc)}/{len(high_crit)} high/critical findings have no saved PoC: {titles}"}
 
 
-def _check_skill_chain_gap(summary: str) -> dict | None:
-    if "Findings:" not in summary or "web-exploit" in summary:
+def _check_tool_inactivity(entries: list[dict]) -> dict | None:
+    tools = [e for e in entries if e.get("type") in ("TOOL", "SPIDER")]
+    if not tools:
         return None
-    sev_m = re.search(r"Findings: (.+)", summary)
-    if not sev_m:
+    try:
+        last_ts = datetime.fromisoformat(tools[-1]["ts"])
+        mins = int((datetime.now(timezone.utc) - last_ts).total_seconds() / 60)
+    except Exception:
         return None
-    sev_str = sev_m.group(1)
-    if "critical" not in sev_str and " high" not in sev_str:
-        return None
-    return {"code": "SKILL_CHAIN_GAP", "urgency": "medium", "blocking": False,
-            "message": "High/critical findings but web-exploit not yet chained — run /web-exploit"}
-
-
-def _check_tool_inactivity(summary: str) -> dict | None:
-    inact_m = re.search(r"Last tool call: (\d+) minutes ago", summary)
-    if not inact_m:
-        return None
-    mins = int(inact_m.group(1))
     if mins <= 10:
         return None
-    return {"code": "TOOL_INACTIVITY", "urgency": "low", "blocking": False,
-            "message": f"No tool activity in {mins}min — is Smith stuck?"}
+    urgency = "high" if mins > 15 else "medium"
+    alert = {"code": "TOOL_INACTIVITY", "urgency": urgency, "blocking": False,
+             "message": f"No tool activity for {mins}min — Smith may have stalled or quit."}
+    if mins > 15:
+        from core.steering import steering_queue, RESUME_REQUIRED
+        steering_queue.add_directive(
+            code=RESUME_REQUIRED,
+            message=(
+                f"Smith stalled for {mins}min. "
+                "EXECUTE: session(action='recovery') — then continue from EXECUTE_NOW field."
+            ),
+            priority="high",
+            skill=None,
+            trigger="TOOL_INACTIVITY",
+        )
+    return alert
 
 
-def _check_bulk_marking(summary: str) -> dict | None:
-    if "Bulk-marking warning:" not in summary:
+def _check_bulk_marking(entries: list[dict]) -> dict | None:
+    cov_entries = [e for e in entries if e.get("type") == "COVERAGE"]
+    if not cov_entries:
         return None
-    m = re.search(r"Bulk-marking warning: (.+)(?:\n|$)", summary)
-    detail = m.group(1).strip() if m else "N/A cells have no tested_by tool"
+    na_untooled = cov_entries[-1].get("na_untooled", 0)
+    if na_untooled <= 10:
+        return None
     return {"code": "BULK_MARKING", "urgency": "high", "blocking": True,
-            "message": f"Bulk-marking detected: {detail}"}
+            "message": f"Bulk-marking detected: {na_untooled} N/A cells have no tested_by tool"}
 
 
-def _check_coverage_integrity(summary: str) -> dict | None:
-    integ_m = re.search(r"(\d+) tested/vulnerable cells have no tested_by tool", summary)
-    if not integ_m:
+def _check_coverage_integrity(entries: list[dict]) -> dict | None:
+    cov_entries = [e for e in entries if e.get("type") == "COVERAGE"]
+    if not cov_entries:
         return None
-    count = integ_m.group(1)
+    untooled = cov_entries[-1].get("untooled", 0)
+    if untooled == 0:
+        return None
     return {"code": "COVERAGE_INTEGRITY", "urgency": "high", "blocking": True,
-            "message": f"Coverage integrity: {count} tested/vulnerable cells lack tested_by tool"}
+            "message": f"Coverage integrity: {untooled} tested/vulnerable cells lack tested_by tool"}
+
+
+def _check_missing_diagram(findings_data: dict) -> dict | None:
+    """Warn early when findings exist but no architecture diagram has been logged."""
+    if not findings_data.get("findings"):
+        return None
+    if findings_data.get("diagrams"):
+        return None
+    return {"code": "NO_DIAGRAM", "urgency": "medium", "blocking": False,
+            "message": "No architecture diagram yet — required before completion. Call report(action='diagram')."}
+
+
+def _check_no_spider_after_httpx(entries: list[dict]) -> dict | None:
+    """Warn if httpx confirmed web targets but spider was never run."""
+    tool_names = {e.get("name") for e in entries if e.get("type") == "TOOL"}
+    if "httpx" not in tool_names:
+        return None
+    if any(e.get("type") == "SPIDER" for e in entries):
+        return None
+    return {"code": "NO_SPIDER", "urgency": "medium", "blocking": False,
+            "message": "httpx confirmed web targets but spider never ran — run scan(tool='spider') to crawl the application"}
 
 
 def _check_endpoint_trigger_gaps(session_data: dict) -> list[dict]:
-    """Fire targeted alerts for every pending trigger gate in the session.
-
-    Unlike _check_gate_alerts (which parses the quick_log summary string),
-    this reads session.json's structured `gates` array directly so it catches
-    gates that were opened mid-scan and never escalated to a summary line.
-    """
+    """Fire targeted alerts for every pending trigger gate in the session."""
     alerts: list[dict] = []
     gates = session_data.get("gates", [])
     satisfied_skills = {e["skill"] for e in session_data.get("skill_history", [])}
@@ -167,19 +235,26 @@ def _check_endpoint_trigger_gaps(session_data: dict) -> list[dict]:
                 f"Required skills not yet run: {', '.join(f'/{s}' for s in missing)}"
             ),
         })
+        if elapsed >= 15:
+            for skill in missing:
+                from core.steering import steering_queue, CHAIN_REQUIRED
+                steering_queue.add_directive(
+                    code=CHAIN_REQUIRED,
+                    message=(
+                        f"Gate '{gate['id']}' open {elapsed}min — "
+                        f"invoke /{skill} to satisfy it. "
+                        "Use Skill tool: skill='" + skill + "'."
+                    ),
+                    priority="high",
+                    skill=skill,
+                    trigger="ENDPOINT_TRIGGER_GAP",
+                )
     return alerts
 
 
 def _check_coverage_gap(coverage_data: dict, session_data: dict) -> list[dict]:
-    """Detect high-value endpoint types that appear in the coverage matrix but
-    have no corresponding skill in skill_history.
-
-    Catches cases where an endpoint was registered + classified (so the trigger
-    gate exists) but the gate check didn't fire because session_data['gates']
-    wasn't populated yet (e.g. first scan cycle).
-    """
+    """Detect high-value endpoint types that appear in coverage but have no skill in history."""
     from core.session import _TRIGGER_MAP
-    # Invert trigger map: endpoint_type -> required_skill
     _TYPE_TO_SKILL: dict[str, str] = {
         ep_type: entry["required_skills"][0]
         for ep_type, entry in _TRIGGER_MAP.items()
@@ -223,15 +298,7 @@ def _check_coverage_gap(coverage_data: dict, session_data: dict) -> list[dict]:
 
 
 def _check_injection_breadth(coverage_data: dict) -> dict | None:
-    """Fire when a text parameter has sqli cells but is missing xss/ssti/ssrf/cmdi cells.
-
-    This catches two failure modes:
-    1. Endpoint registered with wrong param_type (e.g. body_json before the applicability fix).
-    2. Agent bulk-marked non-sqli injection types as N/A without testing them.
-
-    Only fires when sqli cells exist AND at least one of the four breadth types is entirely
-    absent (no cell of any status) for the same endpoint+param combination.
-    """
+    """Fire when a text parameter has sqli cells but is missing xss/ssti/ssrf/cmdi cells."""
     _BREADTH_REQUIRED = {"xss", "ssti", "ssrf", "cmdi"}
     _TEXT_PARAM_TYPES = {"query", "body_form", "body_json", "path", "header", "cookie"}
 
@@ -239,7 +306,6 @@ def _check_injection_breadth(coverage_data: dict) -> dict | None:
     if not matrix:
         return None
 
-    # Group cells by (endpoint_id, param) for text-type params
     from collections import defaultdict
     by_param: dict[tuple, dict[str, list]] = defaultdict(lambda: defaultdict(list))
     for cell in matrix:
@@ -250,7 +316,7 @@ def _check_injection_breadth(coverage_data: dict) -> dict | None:
     gap_params: list[str] = []
     for (ep_id, param), inj_map in by_param.items():
         if "sqli" not in inj_map:
-            continue  # no sqli cell — not a text param we care about
+            continue
         missing = _BREADTH_REQUIRED - set(inj_map.keys())
         if missing:
             gap_params.append(f"{param} (missing: {', '.join(sorted(missing))})")
@@ -271,183 +337,31 @@ def _check_injection_breadth(coverage_data: dict) -> dict | None:
             f"{sample}{more}"
         ),
     }
-def _check_rce_gate_alert(gate_info: str, summary: str) -> dict | None:
-    if "rce" not in gate_info.lower():
-        return None
-    sev_m = re.search(r"Findings: (.+)", summary)
-    if not sev_m:
-        return None
-    sev_str = sev_m.group(1)
-    if "critical" not in sev_str and " high" not in sev_str:
-        return {"code": "RCE_GATE_FALSE_POSITIVE", "urgency": "medium", "blocking": False,
-                "message": "RCE gate may be a false positive — verify finding severity"}
-    return None
-
-
-def _check_gate_alerts(summary: str) -> list[dict]:
-    alerts: list[dict] = []
-    gate_m = re.search(r"Pending gates: (.+)(?:\n|$)", summary)
-    if not gate_m:
-        return alerts
-    gate_info = gate_m.group(1)
-    time_m  = re.search(r"triggered (\d+)min ago", gate_info)
-    elapsed = int(time_m.group(1)) if time_m else 0
-    if elapsed >= 5:
-        urgency  = "high" if elapsed >= 15 else "medium"
-        gid_m    = re.search(r"^(\S+) \(", gate_info)
-        gate_id  = gid_m.group(1) if gid_m else "unknown"
-        req_m    = re.search(r"requires: (.+?)\)", gate_info)
-        requires = req_m.group(1) if req_m else "required skill"
-        alerts.append({"code": "GATE_PENDING", "urgency": urgency, "blocking": False,
-                       "message": f"Gate {gate_id} pending {elapsed}min — chain {requires} or dismiss"})
-    rce_alert = _check_rce_gate_alert(gate_info, summary)
-    if rce_alert:
-        alerts.append(rce_alert)
-    return alerts
 
 
 def _deterministic_qa_checks(
-    summary: str,
+    entries: list[dict],
     findings_data: dict,
     coverage_data: dict,
-    session_data: dict | None = None,
+    session_data: dict,
 ) -> list[dict]:
-    """Rule-based checks over the summary text and structured state.
-
-    Returns a list of alert dicts: {code, urgency, blocking, message}.
-    """
-    sd = session_data or {}
+    """Rule-based checks over structured state — no text parsing."""
     checks = [
-        _check_scope_drift(summary),
-        _check_coverage_stall(summary),
-        _check_spider_without_coverage(summary, coverage_data),
+        _check_scope_drift(entries, session_data),
+        _check_coverage_stall(coverage_data, entries),
+        _check_spider_without_coverage(entries, coverage_data),
         _check_poc_gap(findings_data),
-        _check_skill_chain_gap(summary),
-        _check_tool_inactivity(summary),
-        _check_bulk_marking(summary),
-        _check_coverage_integrity(summary),
+        _check_tool_inactivity(entries),
+        _check_bulk_marking(entries),
+        _check_coverage_integrity(entries),
+        _check_missing_diagram(findings_data),
+        _check_no_spider_after_httpx(entries),
         _check_injection_breadth(coverage_data),
     ]
     alerts = [c for c in checks if c is not None]
-    alerts.extend(_check_gate_alerts(summary))
-    alerts.extend(_check_endpoint_trigger_gaps(sd))
-    alerts.extend(_check_coverage_gap(coverage_data, sd))
+    alerts.extend(_check_endpoint_trigger_gaps(session_data))
+    alerts.extend(_check_coverage_gap(coverage_data, session_data))
     return alerts
-
-
-# ── Semantic LLM review ───────────────────────────────────────────────────────
-
-# Prompt focuses only on what a Python rule cannot assess: semantic quality.
-QA_SYSTEM_PROMPT = """\
-You are a QA reviewer for a penetration test. Review the finding quality below.
-
-For each high or critical finding, check:
-1. Is the severity plausibly overclaimed? (e.g. an info-disclosure marked critical)
-2. Is the description so vague it is not actionable by a developer?
-3. Is business impact absent or generic for a high/critical finding?
-4. Is an obvious next attack path missing? (e.g. auth bypass + IDOR suggests priv-esc path)
-
-Only flag issues you can justify from the finding text. Do NOT flag missing PoCs or coverage
-gaps — those are handled by deterministic checks and will appear separately.
-
-Output ONLY valid JSON — no markdown, no explanation:
-{"alerts": [{"code": "FINDING_QUALITY", "urgency": "high|medium", "blocking": false, "message": "..."}]}
-Max 2 alerts. If no semantic issues, return {"alerts": []}.
-"""
-
-
-# ── LangGraph wiring ──────────────────────────────────────────────────────────
-
-class QAState(TypedDict):
-    summary: str
-    raw_response: str
-    alerts: list[dict]
-
-
-def _init_llm(model_name: str, max_tokens: int = 512):
-    provider, _, model = model_name.partition(":")
-    if not model:
-        provider, model = "openai", model_name
-    if provider == "openai":
-        from langchain_openai import ChatOpenAI
-        return ChatOpenAI(model=model, max_tokens=max_tokens)
-    if provider == "anthropic":
-        from langchain_anthropic import ChatAnthropic
-        return ChatAnthropic(model=model, max_tokens=max_tokens)
-    if provider == "ollama":
-        from langchain_ollama import ChatOllama
-        return ChatOllama(model=model, num_predict=max_tokens)
-    raise ValueError(f"Unknown QA_MODEL provider {provider!r}. Use openai:MODEL, anthropic:MODEL, or ollama:MODEL")
-
-
-def _build_graph():
-    """Build and return the LangGraph semantic QA graph, or None if deps are missing."""
-    try:
-        from langgraph.graph import StateGraph, END
-    except ImportError as exc:
-        _log.warning("QA Agent: langgraph / langchain-core not installed (%s). Semantic review disabled.", exc)
-        return None
-
-    model_name = os.getenv("QA_MODEL", "openai:gpt-4o-mini")
-    try:
-        llm = _init_llm(model_name)
-    except Exception as exc:
-        _log.warning("QA Agent: could not initialise model %s — %s", model_name, exc)
-        return None
-
-    def invoke_llm(state: QAState) -> QAState:
-        from langchain_core.messages import SystemMessage, HumanMessage
-        response = llm.invoke([
-            SystemMessage(content=QA_SYSTEM_PROMPT),
-            HumanMessage(content=state["summary"]),
-        ])
-        return {**state, "raw_response": response.content}
-
-    def parse_response(state: QAState) -> QAState:
-        try:
-            alerts = json.loads(state["raw_response"]).get("alerts", [])
-            if not isinstance(alerts, list):
-                alerts = []
-        except (json.JSONDecodeError, AttributeError):
-            alerts = []
-        # Ensure every alert has the required schema fields
-        cleaned = []
-        for a in alerts:
-            if isinstance(a, dict) and a.get("message"):
-                cleaned.append({
-                    "code":     str(a.get("code", "FINDING_QUALITY")),
-                    "urgency":  str(a.get("urgency", "medium")),
-                    "blocking": bool(a.get("blocking", False)),
-                    "message":  str(a["message"]),
-                })
-        return {**state, "alerts": cleaned}
-
-    graph = StateGraph(QAState)
-    graph.add_node("invoke_llm", invoke_llm)
-    graph.add_node("parse_response", parse_response)
-    graph.set_entry_point("invoke_llm")
-    graph.add_edge("invoke_llm", "parse_response")
-    graph.add_edge("parse_response", END)
-    return graph.compile()
-
-
-def _format_findings_for_semantic_review(findings_data: dict) -> str:
-    """Format high/critical findings as compact text for the LLM."""
-    high_crit = [
-        f for f in findings_data.get("findings", [])
-        if f.get("severity") in ("high", "critical")
-    ]
-    if not high_crit:
-        return ""
-    lines = []
-    for f in high_crit[:10]:
-        lines.append(
-            f"[{f['severity'].upper()}] {f['title']}\n"
-            f"  description: {(f.get('description') or '')[:300]}\n"
-            f"  evidence: {(f.get('evidence') or '')[:200]}\n"
-            f"  business_impact: {(f.get('business_impact') or 'not set')}"
-        )
-    return "\n\n".join(lines)
 
 
 # ── State helpers ─────────────────────────────────────────────────────────────
@@ -477,7 +391,7 @@ def _load_json(path: Path) -> dict:
 
 
 def _deduplicate(new_alerts: list[dict], previous_alerts: list[dict]) -> list[dict]:
-    """Drop alerts whose code+message were already raised at same/higher urgency last cycle."""
+    """Return alerts whose code+message changed since last cycle."""
     _URGENCY = {"high": 2, "medium": 1, "low": 0}
     prev_by_code: dict[str, dict] = {}
     for a in previous_alerts:
@@ -489,9 +403,31 @@ def _deduplicate(new_alerts: list[dict], previous_alerts: list[dict]) -> list[di
     for a in new_alerts:
         prev = prev_by_code.get(a.get("code", ""))
         if prev and prev.get("message") == a.get("message"):
-            continue  # unchanged — skip to avoid noise
+            continue  # unchanged — skip
         result.append(a)
     return result
+
+
+def _merge_alerts(unique_alerts: list[dict], all_alerts: list[dict], cap: int = 4) -> list[dict]:
+    """Merge changed alerts first, then fill with persistent unchanged ones.
+
+    Fixes the deduplication bug where persistent alerts disappeared whenever
+    any new alert fired. Changed alerts take priority; unchanged ones fill
+    remaining slots so they stay visible.
+    """
+    seen_codes: set[str] = set()
+    merged: list[dict] = []
+    for a in unique_alerts:
+        code = a.get("code", "")
+        if code not in seen_codes:
+            seen_codes.add(code)
+            merged.append(a)
+    for a in all_alerts:
+        code = a.get("code", "")
+        if code not in seen_codes:
+            seen_codes.add(code)
+            merged.append(a)
+    return merged[:cap]
 
 
 def _sanitize_history(raw: list) -> list[dict]:
@@ -502,7 +438,6 @@ def _sanitize_history(raw: list) -> list[dict]:
         reply = entry.get("smith_reply")
         result.append({
             "ts":            str(entry.get("ts", ""))[:50],
-            "summary_sent":  str(entry.get("summary_sent", "")),
             "alerts":        [a for a in entry.get("alerts", []) if isinstance(a, dict)][:10],
             "smith_reply":   str(reply)[:2000] if reply else None,
             "smith_actions": [a for a in entry.get("smith_actions", []) if isinstance(a, dict)][:50],
@@ -513,16 +448,6 @@ def _sanitize_history(raw: list) -> list[dict]:
 # ── Daemon ────────────────────────────────────────────────────────────────────
 
 class QADaemon:
-    def __init__(self):
-        self._graph = None
-        self._graph_built = False
-
-    def _get_graph(self):
-        if not self._graph_built:
-            self._graph = _build_graph()
-            self._graph_built = True
-        return self._graph
-
     async def run(self, interval_s: int = 120) -> None:
         _log.info("QA Daemon started (interval=%ds)", interval_s)
         while True:
@@ -532,56 +457,32 @@ class QADaemon:
             except Exception as exc:
                 _log.warning("QA Daemon cycle error: %s", exc)
 
-    async def _run_semantic_review(self, finding_text: str) -> list[dict]:
-        graph = self._get_graph()
-        if graph is None:
-            return []
-        try:
-            result = await asyncio.to_thread(
-                graph.invoke,
-                {"summary": finding_text, "raw_response": "", "alerts": []},
-            )
-            return result.get("alerts", [])
-        except Exception as exc:
-            _log.warning("QA Daemon: semantic review failed — %s", exc)
-            return []
-
     async def _cycle(self) -> None:
         if not _session_is_running():
             return
 
         from core.quick_log import quick_log
-        summary = quick_log.summarize()
-        if not summary.strip() or summary == "No activity logged yet.":
+        entries = quick_log.read_all()
+        if not any(e.get("type") in ("TOOL", "SPIDER", "SKILL", "FINDING", "COVERAGE") for e in entries):
             return
 
         findings_data = _load_json(_FINDINGS_FILE)
         coverage_data = _load_json(_COVERAGE_FILE)
         session_data  = _load_json(_SESSION_FILE)
 
-        # Layer 1: deterministic checks — always run, no LLM cost
-        determ_alerts = _deterministic_qa_checks(summary, findings_data, coverage_data, session_data)
+        determ_alerts = _deterministic_qa_checks(entries, findings_data, coverage_data, session_data)
 
-        # Layer 2: semantic LLM review — only when there are high/critical findings
-        finding_text    = _format_findings_for_semantic_review(findings_data)
-        semantic_alerts = await self._run_semantic_review(finding_text) if finding_text else []
+        existing        = _read_qa_state()
+        previous_alerts = existing.get("alerts", [])
 
-        all_alerts = determ_alerts + semantic_alerts
-
-        existing       = _read_qa_state()
-        previous_alerts: list[dict] = existing.get("alerts", [])
-
-        # Deduplicate against last cycle to reduce noise
-        unique_alerts = _deduplicate(all_alerts, previous_alerts)
-        if not unique_alerts and not all_alerts:
+        unique_alerts = _deduplicate(determ_alerts, previous_alerts)
+        if not unique_alerts and not determ_alerts:
             return
 
-        # Cap at 4 alerts (deterministic takes priority over semantic)
-        final_alerts = (all_alerts if not unique_alerts else unique_alerts)[:4]
+        final_alerts = _merge_alerts(unique_alerts, determ_alerts)
 
         ts_before = datetime.now(timezone.utc).isoformat()
 
-        # Re-read after async work so a Clear All during inference is respected
         post_existing = _read_qa_state()
         history       = _sanitize_history(post_existing.get("history", []))
         prev_cycle_ts = history[-1]["ts"] if history else ""
@@ -595,7 +496,6 @@ class QADaemon:
 
         history.append({
             "ts":            ts_before,
-            "summary_sent":  summary,
             "alerts":        final_alerts,
             "smith_reply":   smith_reply,
             "smith_actions": smith_actions,
@@ -607,8 +507,7 @@ class QADaemon:
             "history": history[-20:],
         }))
 
-        _log.info("QA Daemon: %d alert(s) written (%d determ, %d semantic)",
-                  len(final_alerts), len(determ_alerts), len(semantic_alerts))
+        _log.info("QA Daemon: %d alert(s) written", len(final_alerts))
 
 
 qa_daemon = QADaemon()

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -69,7 +69,7 @@ def _check_scope_drift(entries: list[dict], session_data: dict) -> dict | None:
             "message": f"Scope drift: tools ran against {targets}"}
 
 
-def _check_coverage_stall(coverage_data: dict, entries: list[dict]) -> dict | None:
+def _check_coverage_stall(entries: list[dict]) -> dict | None:
     cov_entries = [e for e in entries if e.get("type") == "COVERAGE"]
     if not cov_entries:
         return None
@@ -348,7 +348,7 @@ def _deterministic_qa_checks(
     """Rule-based checks over structured state — no text parsing."""
     checks = [
         _check_scope_drift(entries, session_data),
-        _check_coverage_stall(coverage_data, entries),
+        _check_coverage_stall(entries),
         _check_spider_without_coverage(entries, coverage_data),
         _check_poc_gap(findings_data),
         _check_tool_inactivity(entries),
@@ -453,11 +453,11 @@ class QADaemon:
         while True:
             await asyncio.sleep(interval_s)
             try:
-                await self._cycle()
+                self._cycle()
             except Exception as exc:
                 _log.warning("QA Daemon cycle error: %s", exc)
 
-    async def _cycle(self) -> None:
+    def _cycle(self) -> None:
         if not _session_is_running():
             return
 

--- a/core/steering.py
+++ b/core/steering.py
@@ -1,0 +1,195 @@
+"""
+Steering queue — QA-driven directives injected into Smith's tool envelopes.
+
+The steering queue is the active correction mechanism. When the QA daemon detects
+that Smith has stalled, missed a skill chain, or left a gate open too long, it writes
+a SteeringDirective here. The envelope pipeline (P5.7) reads pending directives and
+injects them directly into Smith's next tool response — no model action required.
+
+Directive lifecycle
+  pending      → created by QA daemon
+  injected     → envelope P5.7 pushed it into a tool response
+  acknowledged → Smith called session(action='qa_reply')
+  auto_satisfied → the required action actually happened (_do_set_skill chained the skill)
+
+File: steering_queue.json
+API:  GET /api/steering
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent
+_STEERING_FILE = _REPO_ROOT / "steering_queue.json"
+
+# Codes that can appear in a directive
+RESUME_REQUIRED  = "RESUME_REQUIRED"
+CHAIN_REQUIRED   = "CHAIN_REQUIRED"
+RESUME_TESTING   = "RESUME_TESTING"
+POC_REQUIRED     = "POC_REQUIRED"
+
+
+@dataclass
+class SteeringDirective:
+    id: str
+    ts: str
+    code: str
+    priority: str           # "high" | "medium"
+    message: str
+    skill: str | None       # for CHAIN_REQUIRED: the skill to invoke
+    trigger: str            # alert code that caused this directive
+    status: str             # pending | injected | acknowledged | auto_satisfied
+    injected_at: str | None = None
+    acknowledged_at: str | None = None
+    ack_message: str | None = None
+
+
+class SteeringQueue:
+    """Persistent steering directive queue backed by steering_queue.json."""
+
+    def _load(self) -> list[dict]:
+        try:
+            if _STEERING_FILE.exists():
+                return json.loads(_STEERING_FILE.read_text(encoding="utf-8")).get("directives", [])
+        except Exception:
+            pass
+        return []
+
+    def _save(self, directives: list[dict]) -> None:
+        try:
+            _STEERING_FILE.write_text(
+                json.dumps({"directives": directives}, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    # ── Write ──────────────────────────────────────────────────────────────────
+
+    def add_directive(
+        self,
+        code: str,
+        message: str,
+        priority: str = "high",
+        skill: str | None = None,
+        trigger: str = "",
+    ) -> str | None:
+        """Add a directive. Returns id if created, None if deduped.
+
+        Dedup rule: skip if same code+skill already has status pending or injected.
+        """
+        directives = self._load()
+        for d in directives:
+            if (
+                d.get("code") == code
+                and d.get("skill") == skill
+                and d.get("status") in ("pending", "injected")
+            ):
+                return None  # already active — don't duplicate
+
+        directive_id = f"steer-{uuid.uuid4().hex[:8]}"
+        directive = {
+            "id": directive_id,
+            "ts": self._now(),
+            "code": code,
+            "priority": priority,
+            "message": message,
+            "skill": skill,
+            "trigger": trigger,
+            "status": "pending",
+            "injected_at": None,
+            "acknowledged_at": None,
+            "ack_message": None,
+        }
+        directives.append(directive)
+        self._save(directives)
+        return directive_id
+
+    # ── Transitions ────────────────────────────────────────────────────────────
+
+    def mark_injected(self, directive_id: str) -> None:
+        directives = self._load()
+        for d in directives:
+            if d["id"] == directive_id and d["status"] == "pending":
+                d["status"] = "injected"
+                d["injected_at"] = self._now()
+                break
+        self._save(directives)
+
+    def acknowledge(self, directive_id: str, message: str | None = None) -> bool:
+        """Mark a directive acknowledged. Returns True if found."""
+        directives = self._load()
+        for d in directives:
+            if d["id"] == directive_id and d["status"] in ("pending", "injected"):
+                d["status"] = "acknowledged"
+                d["acknowledged_at"] = self._now()
+                d["ack_message"] = message
+                self._save(directives)
+                return True
+        return False
+
+    def auto_satisfy(self, skill: str) -> list[str]:
+        """Auto-satisfy all CHAIN_REQUIRED directives for a skill. Returns satisfied IDs."""
+        directives = self._load()
+        satisfied: list[str] = []
+        for d in directives:
+            if (
+                d.get("code") == CHAIN_REQUIRED
+                and d.get("skill") == skill
+                and d.get("status") in ("pending", "injected")
+            ):
+                d["status"] = "auto_satisfied"
+                d["acknowledged_at"] = self._now()
+                satisfied.append(d["id"])
+        if satisfied:
+            self._save(directives)
+        return satisfied
+
+    def acknowledge_latest_injected(self, message: str | None = None) -> str | None:
+        """Acknowledge the most recently injected directive. Returns its id or None."""
+        directives = self._load()
+        injected = [d for d in directives if d.get("status") == "injected"]
+        if not injected:
+            return None
+        latest = max(injected, key=lambda d: d.get("injected_at") or d["ts"])
+        self.acknowledge(latest["id"], message)
+        return latest["id"]
+
+    # ── Query ──────────────────────────────────────────────────────────────────
+
+    def get_pending(self) -> list[SteeringDirective]:
+        return [
+            SteeringDirective(**d)
+            for d in self._load()
+            if d.get("status") == "pending"
+        ]
+
+    def get_injected(self) -> list[SteeringDirective]:
+        return [
+            SteeringDirective(**d)
+            for d in self._load()
+            if d.get("status") == "injected"
+        ]
+
+    def get_active(self) -> list[SteeringDirective]:
+        """Pending + injected — the directives Smith should still act on."""
+        return [
+            SteeringDirective(**d)
+            for d in self._load()
+            if d.get("status") in ("pending", "injected")
+        ]
+
+    def get_history(self) -> list[dict]:
+        """All directives, newest first — for the dashboard audit trail."""
+        directives = self._load()
+        return list(reversed(directives))
+
+
+steering_queue = SteeringQueue()

--- a/mcp_server/report_tools.py
+++ b/mcp_server/report_tools.py
@@ -84,7 +84,7 @@ async def report(action: str, data: Any) -> str:
       message
 
     dashboard data:
-      port=5000
+      port=8888
 
     coverage data:
       type: endpoint | tested | bulk_tested | reset
@@ -292,7 +292,7 @@ def _auto_trigger_note_gates(message: str) -> list[str]:
 async def _do_dashboard(data):
     try:
         from core import api_server
-        port = data.get("port", 5000)
+        port = data.get("port", 8888)
         log.tool_call("dashboard", {"port": port})
         url = await api_server.serve(port)
         log.tool_result("dashboard", url)

--- a/mcp_server/report_tools.py
+++ b/mcp_server/report_tools.py
@@ -84,7 +84,7 @@ async def report(action: str, data: Any) -> str:
       message
 
     dashboard data:
-      port=8888
+      port=7777
 
     coverage data:
       type: endpoint | tested | bulk_tested | reset
@@ -292,7 +292,7 @@ def _auto_trigger_note_gates(message: str) -> list[str]:
 async def _do_dashboard(data):
     try:
         from core import api_server
-        port = data.get("port", 8888)
+        port = data.get("port", 7777)
         log.tool_call("dashboard", {"port": port})
         url = await api_server.serve(port)
         log.tool_result("dashboard", url)

--- a/mcp_server/scan_engine/budget.py
+++ b/mcp_server/scan_engine/budget.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
 
 MODEL_PROFILES: dict[str, dict] = {
     "full": {
-        "enforce_budget": False,     # No output limits — go full in
-        "budget_multiplier": 1.0,    # unused when enforce_budget=False
-        "context_budget_chars": None,  # no context tracking limit
+        "enforce_budget": False,       # No output limits — go full in
+        "budget_multiplier": 1.0,      # unused when enforce_budget=False
+        "context_budget_chars": 400_000,  # ~100K tokens; warn at 80% (320K) before compaction fires
         "recovery_cells_shown": None,  # show all cells in recovery
         "execute_next_in_summary": True,  # still useful, harmless for large models
     },

--- a/mcp_server/scan_engine/envelope.py
+++ b/mcp_server/scan_engine/envelope.py
@@ -7,7 +7,7 @@ Raw output lives in artifacts, referenced by artifact_id.
 from __future__ import annotations
 
 import json
-import os
+import pathlib
 from dataclasses import dataclass, field, asdict
 from typing import Any, TYPE_CHECKING
 
@@ -17,10 +17,10 @@ from mcp_server.scan_engine.planner import compute_next
 from mcp_server.scan_engine.state import get_state
 from mcp_server.scan_engine.summarizers import summarize
 
-_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-_QA_STATE_FILE      = os.path.join(_REPO_ROOT, "qa_state.json")
-_STEERING_FILE      = os.path.join(_REPO_ROOT, "steering_queue.json")
-_RECOVERY_SNAP_FILE = os.path.join(_REPO_ROOT, "recovery_latest.json")
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_QA_STATE_FILE      = _REPO_ROOT / "qa_state.json"
+_STEERING_FILE      = _REPO_ROOT / "steering_queue.json"
+_RECOVERY_SNAP_FILE = _REPO_ROOT / "recovery_latest.json"
 _last_qa_shown_ts: str = ""  # ISO timestamp of last alert batch shown to the model
 
 
@@ -251,7 +251,7 @@ def _maybe_write_recovery_snapshot(scan_session: Any) -> None:
         if seq > 0 and seq % 10 == 0:
             from mcp_server.session_tools import _do_recovery
             import pathlib
-            pathlib.Path(_RECOVERY_SNAP_FILE).write_text(_do_recovery(), encoding="utf-8")
+            _RECOVERY_SNAP_FILE.write_text(_do_recovery(), encoding="utf-8")
     except Exception:
         pass
 
@@ -320,9 +320,9 @@ def _inject_qa_alerts_into_envelope(env: Envelope) -> None:
     """
     global _last_qa_shown_ts
     try:
-        if not os.path.isfile(_QA_STATE_FILE):
+        if not _QA_STATE_FILE.is_file():
             return
-        state = json.loads(open(_QA_STATE_FILE).read())
+        state = json.loads(_QA_STATE_FILE.read_text(encoding="utf-8"))
         ts = state.get("ts", "")
         if not ts or ts <= _last_qa_shown_ts:
             return

--- a/mcp_server/scan_engine/envelope.py
+++ b/mcp_server/scan_engine/envelope.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass, field, asdict
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from mcp_server.scan_engine.artifacts import store_artifact
 from mcp_server.scan_engine.budget import enforce_budget, get_tool_budget, get_profile
@@ -17,9 +17,10 @@ from mcp_server.scan_engine.planner import compute_next
 from mcp_server.scan_engine.state import get_state
 from mcp_server.scan_engine.summarizers import summarize
 
-_QA_STATE_FILE = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "qa_state.json"
-)
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+_QA_STATE_FILE      = os.path.join(_REPO_ROOT, "qa_state.json")
+_STEERING_FILE      = os.path.join(_REPO_ROOT, "steering_queue.json")
+_RECOVERY_SNAP_FILE = os.path.join(_REPO_ROOT, "recovery_latest.json")
 _last_qa_shown_ts: str = ""  # ISO timestamp of last alert batch shown to the model
 
 
@@ -58,7 +59,7 @@ def wrap(tool: str, raw_output: str, context: dict | None = None) -> str:
     result = summarize(tool, raw_output, ctx)
 
     # 2a. Record tool invocation with summary (P1 — dedup + recovery)
-    _record_invocation(tool, ctx, result.summary)
+    is_duplicate = _record_invocation(tool, ctx, result.summary)
 
     # 2b. Extract and persist known assets (P2 — auto-accumulation)
     _extract_and_persist_assets(tool, result, ctx)
@@ -100,10 +101,17 @@ def wrap(tool: str, raw_output: str, context: dict | None = None) -> str:
     # 5.5. QA alerts — inject into warnings (high urgency also prepended to summary)
     _inject_qa_alerts_into_envelope(enforced)
 
-    # 5.6. Quick log — fire-and-forget, does not block
+    # 5.6. Steering directives — inject pending QA steering directives
+    _inject_steering_directives(enforced)
+
+    # 5.7. Duplicate tool call warning
+    if is_duplicate:
+        _inject_duplicate_warning(enforced, tool)
+
+    # 5.8. Quick log — fire-and-forget, does not block
     _quick_log_tool(tool, ctx, result.summary)
 
-    # 6. Context tracking (P4) — charge and check pressure
+    # 6. Context tracking (P4) — charge, check pressure tiers, periodic snapshot
     json_str = enforced.to_json()
     json_str = _check_context_pressure(enforced, json_str)
 
@@ -114,14 +122,21 @@ def wrap(tool: str, raw_output: str, context: dict | None = None) -> str:
 # P1 — Tool invocation recording
 # ---------------------------------------------------------------------------
 
-def _record_invocation(tool: str, ctx: dict, summary: str) -> None:
-    """Record tool invocation with summary for dedup and recovery."""
+def _record_invocation(tool: str, ctx: dict, summary: str) -> bool:
+    """Record tool invocation with summary for dedup and recovery.
+
+    Returns True if this invocation was a duplicate (same tool+target+options already seen).
+    """
     import hashlib
     from core import session as scan_session
     target = ctx.get("url", ctx.get("host", ctx.get("domain", ctx.get("path", ""))))
     hash_input = f"{tool}:{target}:{sorted(ctx.items())}"
     options_hash = hashlib.sha256(hash_input.encode()).hexdigest()[:8]
+    current = scan_session.get() or {}
+    invocations = current.get("tool_invocations", [])
+    is_duplicate = bool(options_hash and any(i.get("options_hash") == options_hash for i in invocations))
     scan_session.add_tool_invocation(tool, target, summary, options_hash)
+    return is_duplicate
 
 
 # ---------------------------------------------------------------------------
@@ -173,23 +188,119 @@ def _extract_and_persist_assets(tool: str, result: Any, ctx: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# P4 — Context pressure tracking
+# P4 — Context pressure tracking (tiered)
 # ---------------------------------------------------------------------------
 
 def _check_context_pressure(env: Envelope, json_str: str) -> str:
-    """Track context usage and inject warning if pressure exceeds 80%."""
+    """Track context usage and inject tiered warnings as pressure grows.
+
+    Tier 1 (>70%): advisory — good time to call recovery.
+    Tier 2 (>80%): urgent — EXECUTE NOW directive with exact call.
+    Tier 3 (>90%): auto-inject full recovery brief into session_state; no model action needed.
+    Also writes a periodic snapshot to recovery_latest.json every 10 tool calls.
+    """
     from core import session as scan_session
     scan_session.charge_context(len(json_str))
     profile = get_profile()
     pressure = scan_session.get_context_pressure(profile)
+
+    _maybe_write_recovery_snapshot(scan_session)
+
+    if pressure > 0.9:
+        pct = int(pressure * 100)
+        env.warnings.append(
+            f"CONTEXT_WARNING: ~{pct}% of context budget used — compaction imminent. "
+            f"Recovery brief auto-injected into session_state.recovery_brief. "
+            f"EXECUTE NOW: session(action='recovery') for a fresh copy."
+        )
+        try:
+            from mcp_server.session_tools import _do_recovery
+            import json as _json
+            env.session_state["recovery_brief"] = _json.loads(_do_recovery())
+        except Exception:
+            pass
+        return env.to_json()
+
     if pressure > 0.8:
         pct = int(pressure * 100)
         env.warnings.append(
             f"CONTEXT_WARNING: ~{pct}% of context budget used. "
-            f"Consider calling session(action='recovery') to compact."
+            f"EXECUTE NOW: session(action='recovery') — all state is safe on disk. "
+            f"After reading the brief, continue from its EXECUTE_NOW field."
         )
         return env.to_json()
+
+    if pressure > 0.7:
+        pct = int(pressure * 100)
+        env.warnings.append(
+            f"CONTEXT_WARNING: ~{pct}% of context budget used. "
+            f"Good time to call session(action='recovery') to get a compact state snapshot."
+        )
+        return env.to_json()
+
     return json_str
+
+
+def _maybe_write_recovery_snapshot(scan_session: Any) -> None:
+    """Write recovery_latest.json every 10 tool invocations as a passive fallback."""
+    try:
+        current = scan_session.get() or {}
+        if current.get("status") != "running":
+            return
+        seq = len(current.get("tool_invocations", []))
+        if seq > 0 and seq % 10 == 0:
+            from mcp_server.session_tools import _do_recovery
+            import pathlib
+            pathlib.Path(_RECOVERY_SNAP_FILE).write_text(_do_recovery(), encoding="utf-8")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# P5.6 — Steering directive injection
+# ---------------------------------------------------------------------------
+
+def _inject_steering_directives(env: Envelope) -> None:
+    """Inject pending QA steering directives into the envelope.
+
+    Pending directives are injected into warnings. High-priority directives are
+    also prepended to the summary so the model sees them immediately.
+    Each directive is marked injected after surfacing so the audit trail is accurate.
+    """
+    try:
+        from core.steering import steering_queue
+        pending = steering_queue.get_pending()
+        if not pending:
+            return
+        for directive in pending:
+            env.warnings.append(f"[QA STEER {directive.priority.upper()}] {directive.message}")
+            if directive.priority == "high":
+                env.summary = (
+                    f"⚠ QA STEERING: {directive.message}\n"
+                    f"(Act on this before continuing.)\n\n"
+                    + env.summary
+                )
+            steering_queue.mark_injected(directive.id)
+    except Exception:
+        pass  # steering failures must never break tool dispatch
+
+
+def _inject_duplicate_warning(env: Envelope, tool: str) -> None:
+    """Inject a recovery reminder when the same tool+params were already run."""
+    from core import session as scan_session
+    try:
+        invocations = (scan_session.get() or {}).get("tool_invocations", [])
+        seq = next(
+            (i.get("seq") for i in reversed(invocations) if i.get("tool") == tool),
+            "?",
+        )
+        env.warnings.append(
+            f"DUPLICATE_TOOL_CALL: {tool} was already run with these exact parameters "
+            f"(invocation #{seq}). You may be post-compaction. "
+            "Call session(action='recovery') to verify where you left off."
+        )
+    except Exception:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_server/scan_engine/envelope.py
+++ b/mcp_server/scan_engine/envelope.py
@@ -250,8 +250,9 @@ def _maybe_write_recovery_snapshot(scan_session: Any) -> None:
         seq = len(current.get("tool_invocations", []))
         if seq > 0 and seq % 10 == 0:
             from mcp_server.session_tools import _do_recovery
-            import pathlib
-            _RECOVERY_SNAP_FILE.write_text(_do_recovery(), encoding="utf-8")
+            snap = _RECOVERY_SNAP_FILE.resolve()
+            if _REPO_ROOT.resolve() in snap.parents:
+                snap.write_text(_do_recovery(), encoding="utf-8")
     except Exception:
         pass
 

--- a/mcp_server/scan_engine/state.py
+++ b/mcp_server/scan_engine/state.py
@@ -23,7 +23,9 @@ _TESTING_TOOLS = {"kali", "nuclei"}
 def get_state() -> dict:
     """Compute current scan state from session.json + coverage_matrix.json.
 
-    Returns a compact dict suitable for embedding in every tool response envelope.
+    Returns a compact dict embedded in every tool response envelope.
+    Includes recovery-oriented fields so a post-compaction model can orient
+    from any tool response without calling session(action='recovery').
     """
     current = scan_session.get()
     if not current or current.get("status") != "running":
@@ -46,16 +48,46 @@ def get_state() -> dict:
     summary = cost_tracker.get_summary()
     remaining = scan_session.remaining(summary)
 
-    return {
-        "target": current.get("target", ""),
-        "phase": phase,
-        "tools_run": sorted(tools_run),
-        "endpoints": endpoints,
-        "coverage": f"{tested}/{total_cells}" if total_cells else "no endpoints registered",
-        "findings": vulnerable,
-        "calls_used": summary.get("tool_calls_total", 0),
-        "time_pct": remaining.get("time_pct", 0),
+    # In-progress cells — post-compaction orientation (capped at 3 to limit envelope size)
+    ep_map = {ep["id"]: ep.get("path", "?") for ep in cov.get("endpoints", [])}
+    in_progress = [
+        {
+            "cell_id":   c["id"],
+            "endpoint":  ep_map.get(c["endpoint_id"], "?"),
+            "param":     c["param"],
+            "injection": c["injection_type"],
+            "notes":     c.get("notes", "")[:100],
+        }
+        for c in cov.get("matrix", []) if c["status"] == "in_progress"
+    ][:3]
+
+    # Pending escalation leads count
+    try:
+        from core.findings import findings_store
+        findings_data = findings_store._load()
+        pending_escalations = sum(
+            1 for f in findings_data.get("findings", [])
+            for lead in f.get("escalation_leads", [])
+            if lead.get("status") == "pending"
+        )
+    except Exception:
+        pending_escalations = 0
+
+    state: dict = {
+        "target":               current.get("target", ""),
+        "phase":                phase,
+        "active_skill":         current.get("skill", ""),
+        "tools_run":            sorted(tools_run),
+        "endpoints":            endpoints,
+        "coverage":             f"{tested}/{total_cells}" if total_cells else "no endpoints registered",
+        "findings":             vulnerable,
+        "calls_used":           summary.get("tool_calls_total", 0),
+        "time_pct":             remaining.get("time_pct", 0),
+        "pending_escalations":  pending_escalations,
     }
+    if in_progress:
+        state["in_progress_cells"] = in_progress
+    return state
 
 
 def _compute_phase(tools_run: set, endpoints: int, total_cells: int, tested: int) -> str:

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -238,7 +238,7 @@ def _do_start(opts):
 
     lines += [
         "EXECUTE NOW (do not ask questions, do not output text):",
-        "  report(action='dashboard', data={'port': 8888})",
+        "  report(action='dashboard', data={'port': 7777})",
         f"  scan(tool='httpx', target='{target}')" if not is_resume else "  Continue from recovery state above — follow EXECUTE_NOW field.",
         "",
         "Then in order (skip steps in tools_already_run if this is a resume):",

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -200,6 +200,7 @@ def _do_start(opts):
             "matrix": [],
         })
     # Same target with existing data — keep matrix as-is (resume or view results)
+    is_resume = bool(prev_target and prev_target == target and has_data)
     depth = opts.get("depth", "standard")
     cfg = scan_session.start(
         target=target, depth=depth,
@@ -223,11 +224,24 @@ def _do_start(opts):
         "Scan started.",
         f"  Target: {target} | Depth: {cfg['depth_label']} | Limits: {cost_str}/{time_str}/{call_limit_str}",
         "",
+    ]
+
+    if is_resume:
+        recovery_brief = _do_recovery()
+        lines += [
+            "RESUME DETECTED: existing scan state found for this target.",
+            "Recovery state follows — read it before issuing any tool calls:",
+            "",
+            recovery_brief,
+            "",
+        ]
+
+    lines += [
         "EXECUTE NOW (do not ask questions, do not output text):",
-        "  report(action='dashboard', data={'port': 5000})",
-        f"  scan(tool='httpx', target='{target}')",
+        "  report(action='dashboard', data={'port': 8888})",
+        f"  scan(tool='httpx', target='{target}')" if not is_resume else "  Continue from recovery state above — follow EXECUTE_NOW field.",
         "",
-        "Then in order:",
+        "Then in order (skip steps in tools_already_run if this is a resume):",
         f"  scan(tool='naabu', target='{target}')",
         f"  scan(tool='spider', target='{target}')",
         "  Register endpoints with report(action='coverage', data=...)",
@@ -556,6 +570,7 @@ def _do_complete(opts):
             log.note(f"Force-completing after {attempts} blocked attempts. Remaining blockers: {'; '.join(blockers)}")
             scan_session.complete(notes, stop_reason=force_reason, quality_gate="failed")
             _complete_attempts = 0
+            _record_metrics(data, blockers, force_completed=True)
             return (
                 f"Scan FORCE-COMPLETED (exceeded {attempts} attempt limit). "
                 f"status=incomplete_with_unresolved_blockers quality_gate=failed. "
@@ -571,17 +586,65 @@ def _do_complete(opts):
     status = cfg.get("status", "complete")
     log.note(f"Scan complete — {notes}")
     _complete_attempts = 0
+    _record_metrics(data, [], force_completed=False)
+    # Clean up old artifacts (older than 24h) to prevent unbounded disk growth
+    try:
+        from mcp_server.scan_engine.artifacts import cleanup_artifacts
+        cleanup_artifacts(max_age_hours=24)
+    except Exception:
+        pass
     return f"Scan marked {status}. session.json updated. STOP — do not call any more tools. The scan is done."
 
 
+def _record_metrics(findings_data: dict, completion_blockers: list[str], force_completed: bool) -> None:
+    try:
+        import core.metrics as metrics_mod
+        from core.quick_log import quick_log
+        from core.steering import steering_queue
+        from core.coverage import get_matrix
+        metrics_mod.record(
+            session=scan_session.get() or {},
+            cost_summary=cost_tracker.get_summary(),
+            findings_data=findings_data,
+            coverage=get_matrix(),
+            force_completed=force_completed,
+            completion_blockers=completion_blockers,
+            quick_log_entries=quick_log.read_all(),
+            steering_history=steering_queue.get_history(),
+        )
+    except Exception:
+        pass
+
+
 async def _do_qa_reply(opts):
-    """Log Smith's textual response to QA alerts so the conversation record is complete."""
+    """Log Smith's response to a QA steering directive and acknowledge it.
+
+    Optionally references a specific directive_id to acknowledge. If omitted,
+    the most recently injected directive is acknowledged automatically.
+    """
     from core.quick_log import quick_log
+    from core.steering import steering_queue
     message = str(opts.get("message", "")).strip()
+    directive_id = str(opts.get("directive_id", "")).strip()
     if not message:
         return "qa_reply requires a non-empty message= option."
-    await quick_log.append({"type": "QA_REPLY", "message": message})
-    return "QA reply logged."
+
+    ack_id: str | None = None
+    if directive_id:
+        if steering_queue.acknowledge(directive_id, message):
+            ack_id = directive_id
+    else:
+        ack_id = steering_queue.acknowledge_latest_injected(message)
+
+    await quick_log.append({
+        "type":         "QA_REPLY",
+        "message":      message,
+        "directive_id": ack_id,
+    })
+
+    if ack_id:
+        return f"QA reply logged. Directive {ack_id} acknowledged."
+    return "QA reply logged. (No active directive to acknowledge — reply recorded for audit trail.)"
 
 
 def _do_status():
@@ -701,7 +764,7 @@ def _add_status_work_queue(result: dict, cov: dict) -> None:
 
 
 def _add_status_qa_alerts(result: dict) -> None:
-    """Append QA alerts from qa_state.json to the status result dict (in-place)."""
+    """Append QA alerts and active steering directives to the status result dict."""
     import os as _os
     _qa_path = _os.path.join(_os.path.dirname(_os.path.dirname(__file__)), _QA_STATE_FILENAME)
     try:
@@ -711,15 +774,27 @@ def _add_status_qa_alerts(result: dict) -> None:
             _alerts = _qa.get("alerts", [])
             result["qa_alerts"] = _alerts
             result["qa_last_check"] = _qa.get("ts", "")
-            if _alerts:
-                result["qa_instruction"] = (
-                    "REQUIRED: call session(action='qa_reply', options={'message': '<your response>'}) "
-                    "NOW — acknowledge each alert and state what you will do. Do this before any other tool call."
-                )
         else:
             result["qa_alerts"] = []
     except Exception:
         result["qa_alerts"] = []
+
+    # Include active steering directives so status gives a complete picture
+    try:
+        from core.steering import steering_queue
+        active = steering_queue.get_active()
+        if active:
+            result["steering_directives"] = [
+                {"id": d.id, "code": d.code, "priority": d.priority,
+                 "message": d.message, "status": d.status}
+                for d in active
+            ]
+            result["qa_note"] = (
+                "Steering directives above are already injected into tool responses. "
+                "To acknowledge: session(action='qa_reply', options={message: '...', directive_id: '<id>'})"
+            )
+    except Exception:
+        pass
 
 
 _INJECTION_TOOL_MAP = {
@@ -1034,6 +1109,14 @@ def _do_set_skill(opts):
     chained_from = opts.get("chained_from", "")
     if not skill_name:
         return "Error: 'skill' option is required"
+
+    # Check for resume BEFORE set_skill appends (set_skill deduplicates silently)
+    prior = scan_session.get() or {}
+    is_resume = skill_name in [
+        (e["skill"] if isinstance(e, dict) else e)
+        for e in prior.get("skill_history", [])
+    ]
+
     result = scan_session.set_skill(skill_name, reason=reason, chained_from=chained_from)
     if result is None:
         return "No active running session — cannot set skill."
@@ -1060,6 +1143,24 @@ def _do_set_skill(opts):
         _t.add_done_callback(_background_tasks.discard)
     except Exception:
         pass
+
+    # Auto-satisfy any CHAIN_REQUIRED steering directives for this skill
+    try:
+        from core.steering import steering_queue
+        steering_queue.auto_satisfy(skill_name)
+    except Exception:
+        pass
+
+    # Detect post-compaction resume: skill was already in history before this call
+    if is_resume:
+        recovery_brief = _do_recovery()
+        msg = (
+            f"RESUME DETECTED: '{skill_name}' was already in skill history — "
+            f"post-compaction context likely. Full recovery state follows:\n\n{recovery_brief}"
+        )
+        if satisfied_gates:
+            msg += f"\n\n(satisfied gate(s): {', '.join(satisfied_gates)})"
+        return msg
 
     msg = f"Skill '{skill_name}' logged"
     if satisfied_gates:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -503,6 +503,19 @@
     .qa-label {
       font-family: 'Chakra Petch', monospace; font-size: 0.88rem; font-weight: 600; color: #fff;
     }
+    .metrics-table {
+      width: 100%; border-collapse: collapse; font-size: 0.78rem;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    .metrics-table th {
+      text-align: left; padding: 0.3rem 0.6rem; color: var(--text-dim);
+      border-bottom: 1px solid var(--border); white-space: nowrap;
+    }
+    .metrics-table td {
+      padding: 0.35rem 0.6rem; border-bottom: 1px solid rgba(255,255,255,0.04);
+      white-space: nowrap;
+    }
+    .metrics-table tr:hover td { background: rgba(255,255,255,0.03); }
     .qa-last-check {
       font-family: 'IBM Plex Mono', monospace; font-size: 0.7rem; color: var(--text-dim);
     }
@@ -548,35 +561,15 @@
     .ql-type.FINDING  { color: #ff4d6d; }
     .ql-type.COVERAGE { color: #ffd166; }
 
-    /* ── Conversation tab ── */
-    #conversation-wrap {
+    /* ── QA cycle history (embedded in QA tab) ── */
+    #cycle-history-wrap {
       display: flex; flex-direction: column; gap: 0.5rem;
       padding-bottom: 1rem;
-      max-height: calc(100vh - 180px); overflow-y: auto;
     }
     .chat-ts-chip {
       text-align: center;
       font-family: 'IBM Plex Mono', monospace; font-size: 0.65rem; color: var(--text-dim);
       margin: 0.5rem 0 0.2rem;
-    }
-    /* Collapsed scan-context block — not a Smith message, just the state QA reads */
-    .chat-context {
-      align-self: stretch;
-      background: rgba(255,255,255,0.02); border: 1px solid var(--border-subtle);
-      border-radius: 6px; font-size: 0.77rem; color: var(--text-dim);
-      font-family: 'IBM Plex Mono', monospace;
-    }
-    .chat-context summary {
-      padding: 0.35rem 0.65rem; cursor: pointer; user-select: none;
-      display: flex; align-items: center; gap: 0.5rem; list-style: none;
-    }
-    .chat-context summary::-webkit-details-marker { display: none; }
-    .chat-context summary::before { content: '▶'; font-size: 0.55rem; transition: transform 0.15s; }
-    .chat-context[open] summary::before { transform: rotate(90deg); }
-    .chat-context-headline { color: var(--text-muted); }
-    .chat-context-body {
-      padding: 0.3rem 0.65rem 0.55rem; border-top: 1px solid var(--border-subtle);
-      display: flex; flex-direction: column; gap: 0.15rem;
     }
     .chat-bubble {
       max-width: 82%; padding: 0.6rem 0.85rem;
@@ -669,6 +662,9 @@
   </div>
 </div>
 <div id="status"><span class="dot"></span>Connecting…</div>
+<div id="stall-banner" style="display:none;background:#7c2d12;color:#fed7aa;padding:0.5rem 1rem;border-radius:6px;margin-bottom:0.5rem;font-size:0.82rem;border:1px solid #c2410c;">
+  ⚠ <strong>Smith appears stalled</strong> — <span id="stall-banner-msg"></span>. Check the Steering tab for QA directives.
+</div>
 
 <!-- ── Session strip ─────────────────────────────────────────────────────── -->
 <div id="session-strip">
@@ -686,8 +682,9 @@
   <button class="tab-btn"        onclick="switchTab('coverage')" id="tab-btn-coverage">Coverage</button>
   <button class="tab-btn"        onclick="switchTab('skills')" id="tab-btn-skills">Skills</button>
   <button class="tab-btn"        onclick="switchTab('qa')" id="tab-btn-qa">QA Agent</button>
-  <button class="tab-btn"        onclick="switchTab('conversation')" id="tab-btn-conversation">Conversation</button>
+  <button class="tab-btn"        onclick="switchTab('steering')" id="tab-btn-steering">Steering</button>
   <button class="tab-btn"        onclick="switchTab('threat-model')" id="tab-btn-threat-model">Threat Model</button>
+  <button class="tab-btn"        onclick="switchTab('metrics')" id="tab-btn-metrics">Metrics</button>
   <button class="tab-btn"        onclick="switchTab('logs')">Logs</button>
 </nav>
 
@@ -751,19 +748,34 @@
   <div id="quicklog-wrap">
     <div class="empty-placeholder">No tool activity yet.</div>
   </div>
+  <div class="qa-divider">Cycle history</div>
+  <div id="cycle-history-wrap">
+    <div class="empty-placeholder">No cycles yet — QA starts 30 s after scan begins.</div>
+  </div>
 </div>
 
-<!-- ── Tab: Conversation ──────────────────────────────────────────────────── -->
-<div id="tab-conversation" class="tab-content">
+<!-- ── Tab: Steering ──────────────────────────────────────────────────────── -->
+<div id="tab-steering" class="tab-content">
   <div class="qa-topbar">
     <div class="qa-topbar-left">
-      <div class="qa-dot" style="background:var(--purple);box-shadow:0 0 6px var(--purple)"></div>
-      <span class="qa-label">QA ↔ Smith</span>
+      <div class="qa-dot" style="background:#f97316;box-shadow:0 0 6px #f97316"></div>
+      <span class="qa-label">QA → Smith Steering</span>
     </div>
-    <span class="qa-last-check">cycle history</span>
+    <span id="steering-last-update" class="qa-last-check"></span>
   </div>
-  <div id="conversation-wrap">
-    <div class="empty-placeholder">No cycles yet — QA starts 30 s after scan begins.</div>
+  <div style="font-size:0.74rem;color:var(--text-dim);margin-bottom:0.75rem;line-height:1.5;">
+    Active directives are injected automatically into Smith's tool responses.
+    Status: <span style="color:#f97316">●</span> pending &nbsp;
+            <span style="color:#facc15">●</span> injected &nbsp;
+            <span style="color:#4ade80">●</span> acknowledged &nbsp;
+            <span style="color:#60a5fa">●</span> auto-satisfied
+  </div>
+  <div id="steering-active-wrap">
+    <div class="empty-placeholder">No active steering directives.</div>
+  </div>
+  <div class="qa-divider">History</div>
+  <div id="steering-history-wrap">
+    <div class="empty-placeholder">No steering history yet.</div>
   </div>
 </div>
 
@@ -778,6 +790,17 @@
     <span id="tm-file-ts" style="color:var(--text-dim);font-family:'IBM Plex Mono',monospace;font-size:0.73rem"></span>
   </div>
   <div id="threat-model-wrap" class="empty">No threat model yet — run the threat-modeling in <code>/pentester</code></div>
+</div>
+
+<!-- ── Tab: Metrics ──────────────────────────────────────────────────────── -->
+<div id="tab-metrics" class="tab-content">
+  <div style="display:flex;align-items:center;gap:1rem;margin-bottom:0.75rem">
+    <span class="qa-label">Run Efficiency Metrics</span>
+    <span id="metrics-updated" style="font-size:0.72rem;color:var(--text-dim)"></span>
+  </div>
+  <div id="metrics-wrap">
+    <div class="empty-placeholder">No completed scans yet — metrics appear after session(action='complete').</div>
+  </div>
 </div>
 
 <!-- ── Tab: Logs ─────────────────────────────────────────────────────────── -->
@@ -837,11 +860,12 @@
   let freshIds   = new Set();
   let allData    = { findings: [], diagrams: [] };
   let lastOk     = null;
+  let _steeringData = null;
   let _activeTab = 'findings';
   let _logLines  = [];
 
   // ── Tab switching ─────────────────────────────────────────────────────────
-  const TAB_NAMES = ['findings', 'topology', 'components', 'coverage', 'skills', 'qa', 'conversation', 'threat-model', 'logs'];
+  const TAB_NAMES = ['findings', 'topology', 'components', 'coverage', 'skills', 'qa', 'steering', 'threat-model', 'logs', 'metrics'];
 
   function switchTab(name) {
     _activeTab = name;
@@ -854,8 +878,9 @@
     if (name === 'components')    renderComponentMap(allData.findings || []);
     if (name === 'coverage')      pollCoverage();
     if (name === 'skills')        pollSkills();
-    if (name === 'qa')            pollQA();
-    if (name === 'conversation')  pollQA();
+    if (name === 'qa')        pollQA();
+    if (name === 'steering')  pollQA();
+    if (name === 'metrics')   pollMetrics();
     if (name === 'threat-model')  pollThreatModel();
     if (name === 'logs')          pollLogs();
   }
@@ -1144,8 +1169,8 @@
         document.getElementById('quicklog-wrap').innerHTML =
           '<div class="empty-placeholder">No tool activity yet — start a scan.</div>';
         _qaData = null;
-        _convRenderedCount = 0;
-        document.getElementById('conversation-wrap').innerHTML =
+        _cycleRenderedCount = 0;
+        document.getElementById('cycle-history-wrap').innerHTML =
           '<div class="empty-placeholder">No cycles yet — QA starts 30 s after scan begins.</div>';
 
         // ── Logs tab ──────────────────────────────────────────────────────
@@ -1895,7 +1920,7 @@
     } catch { /* ignore */ }
   }
 
-  let _convRenderedCount = 0;
+  let _cycleRenderedCount = 0;
 
   // Synthesise a readable narrative from Smith's raw action log
   function _smithNarrative(actions) {
@@ -1938,22 +1963,10 @@
   }
 
   // Compact one-liner for the scan-context summary strip
-  function _scanContextHeadline(summary) {
-    const lines = (summary||'').split('\n');
-    const get = key => { const l = lines.find(l => l.startsWith(key)); return l ? l.slice(key.length).trim() : null; };
-    const parts = [];
-    const findings = get('Findings:');       if (findings) parts.push(`Findings: ${findings}`);
-    const coverage = get('Coverage:');       if (coverage) parts.push(coverage.split('—')[0].trim());
-    const gates    = get('Pending gates:');  if (gates)    parts.push(`Gates: ${gates.split(';')[0].trim()}`);
-    const tools    = get('Last tool call:'); if (tools)    parts.push(`Last tool: ${tools}`);
-    return parts.length ? parts.join('  ·  ') : 'Scan state';
-  }
-
-  function renderConversation() {
-    const wrap = document.getElementById('conversation-wrap');
+  function renderCycleHistory() {
+    const wrap = document.getElementById('cycle-history-wrap');
     if (!wrap) return;
-    const qa = _qaData || {};
-    const history = qa.history || [];
+    const history = (_qaData || {}).history || [];
 
     const placeholder = wrap.querySelector('.empty-placeholder');
     if (placeholder && history.length) placeholder.remove();
@@ -1963,32 +1976,18 @@
       return;
     }
 
-    const newCycles = history.slice(_convRenderedCount);
+    const newCycles = history.slice(_cycleRenderedCount);
     if (!newCycles.length) return;
 
     const frag = document.createDocumentFragment();
 
     newCycles.forEach(cycle => {
-      // Timestamp chip
       const tsEl = document.createElement('div');
       tsEl.className = 'chat-ts-chip';
       tsEl.textContent = _qlTime(cycle.ts);
       frag.appendChild(tsEl);
 
-      // Collapsible scan-context block — labelled as automated scan state, not Smith's words
-      const summary = cycle.summary_sent || '';
-      if (summary.trim()) {
-        const ctxEl = document.createElement('details');
-        ctxEl.className = 'chat-context';
-        const headline = _scanContextHeadline(summary);
-        const bodyLines = summary.split('\n').filter(l => l.trim());
-        ctxEl.innerHTML =
-          `<summary><span class="chat-context-headline">Scan state QA reviewed — ${esc(headline)}</span></summary>` +
-          `<div class="chat-context-body">${bodyLines.map(l => `<div>${esc(l)}</div>`).join('')}</div>`;
-        frag.appendChild(ctxEl);
-      }
-
-      // QA bubble — the questions / flags
+      // QA alerts bubble
       const qaDiv = document.createElement('div');
       qaDiv.className = 'chat-bubble qa';
       const alerts = cycle.alerts || [];
@@ -2003,12 +2002,7 @@
       qaDiv.innerHTML = `<div class="chat-sender">QA Agent</div>${alertsInner}`;
       frag.appendChild(qaDiv);
 
-      // Smith response bubble — narrative + collapsible raw actions
-      const actions = cycle.smith_actions || [];
-      const narrative = _smithNarrative(actions);
-      const bubbleClass = narrative.length ? 'chat-bubble smith' : 'chat-bubble smith-idle';
-      const smithDiv = document.createElement('div');
-      // Smith reply bubble — what Smith explicitly said in response to QA alerts
+      // Smith qa_reply bubble (optional)
       const reply = cycle.smith_reply;
       if (reply) {
         const replyDiv = document.createElement('div');
@@ -2019,13 +2013,15 @@
         frag.appendChild(replyDiv);
       }
 
-      smithDiv.className = bubbleClass;
-
-      let inner = `<div class="chat-sender">Smith — actions after this QA cycle</div>`;
+      // Smith actions bubble
+      const actions = cycle.smith_actions || [];
+      const narrative = _smithNarrative(actions);
+      const smithDiv = document.createElement('div');
+      smithDiv.className = narrative.length ? 'chat-bubble smith' : 'chat-bubble smith-idle';
+      let inner = `<div class="chat-sender">Smith — actions after this cycle</div>`;
       if (narrative.length) {
         inner += `<div class="chat-narrative">${narrative.map(p => `<div class="chat-narrative-part">${p}</div>`).join('')}</div>`;
         if (actions.length) {
-          const detailId = `act-${Math.random().toString(36).slice(2)}`;
           inner +=
             `<div class="chat-actions-toggle" onclick="this.nextElementSibling.classList.toggle('open');this.textContent=this.nextElementSibling.classList.contains('open')?'▲ hide raw events':'▼ ${actions.length} raw events'">` +
             `▼ ${actions.length} raw events</div>` +
@@ -2036,29 +2032,214 @@
       } else {
         inner += `<span class="chat-ok">No tool activity recorded between this cycle and the next.</span>`;
       }
-
       smithDiv.innerHTML = inner;
       frag.appendChild(smithDiv);
     });
 
     wrap.appendChild(frag);
-    _convRenderedCount = history.length;
-    wrap.scrollTop = wrap.scrollHeight;
+    _cycleRenderedCount = history.length;
   }
 
   async function pollQA() {
     try {
-      const r = await fetch(`/api/qa?_=${Date.now()}`);
-      if (!r.ok) return;
-      _qaData = await r.json();
-      if (_activeTab === 'qa')           { renderQA(); renderQuickLog(); }
-      if (_activeTab === 'conversation') renderConversation();
+      const [rQA, rSteering] = await Promise.all([
+        fetch(`/api/qa?_=${Date.now()}`),
+        fetch(`/api/steering?_=${Date.now()}`),
+      ]);
+      if (rQA.ok) {
+        _qaData = await rQA.json();
+        if (_activeTab === 'qa')           { renderQA(); renderQuickLog(); renderCycleHistory(); }
 
-      // Badge: show alert count on QA tab button
-      const btn = document.getElementById('tab-btn-qa');
-      const alerts = (_qaData.alerts || []);
-      if (btn) btn.textContent = alerts.length ? `QA Agent (${alerts.length})` : 'QA Agent';
+        // Badge: show alert count on QA tab button
+        const btn = document.getElementById('tab-btn-qa');
+        const alerts = (_qaData.alerts || []);
+        if (btn) btn.textContent = alerts.length ? `QA Agent (${alerts.length})` : 'QA Agent';
+      }
+      if (rSteering.ok) {
+        _steeringData = await rSteering.json();
+        if (_activeTab === 'steering') renderSteering();
+        updateStallBanner(_steeringData.directives || []);
+        // Badge: show active count on Steering tab button
+        const sBtn = document.getElementById('tab-btn-steering');
+        const active = (_steeringData.directives || []).filter(
+          d => d.status === 'pending' || d.status === 'injected'
+        );
+        if (sBtn) sBtn.textContent = active.length ? `Steering (${active.length})` : 'Steering';
+      }
     } catch { /* ignore */ }
+  }
+
+  function renderSteering() {
+    if (!_steeringData) return;
+    const directives = _steeringData.directives || [];
+
+    // Timestamp
+    const lastEl = document.getElementById('steering-last-update');
+    if (lastEl && _steeringData.updated_at) {
+      lastEl.textContent = 'updated ' + new Date(_steeringData.updated_at).toLocaleTimeString();
+    }
+
+    // Active directives (pending + injected)
+    const activeWrap = document.getElementById('steering-active-wrap');
+    const active = directives.filter(d => d.status === 'pending' || d.status === 'injected');
+    if (activeWrap) {
+      if (active.length === 0) {
+        activeWrap.innerHTML = '<div class="empty-placeholder">No active steering directives.</div>';
+      } else {
+        activeWrap.innerHTML = '';
+        active.forEach(d => activeWrap.appendChild(_buildDirectiveCard(d)));
+      }
+    }
+
+    // History (acknowledged + auto_satisfied), newest first
+    const historyWrap = document.getElementById('steering-history-wrap');
+    const done = directives.filter(d => d.status === 'acknowledged' || d.status === 'auto_satisfied');
+    if (historyWrap) {
+      if (done.length === 0) {
+        historyWrap.innerHTML = '<div class="empty-placeholder">No steering history yet.</div>';
+      } else {
+        historyWrap.innerHTML = '';
+        done.forEach(d => historyWrap.appendChild(_buildDirectiveCard(d)));
+      }
+    }
+  }
+
+  function _buildDirectiveCard(d) {
+    const statusColor = { pending: '#f97316', injected: '#facc15', acknowledged: '#4ade80', auto_satisfied: '#60a5fa' };
+    const color = statusColor[d.status] || '#9b98b8';
+    const ts = d.ts ? new Date(d.ts).toLocaleTimeString() : '';
+    const priorityLabel = d.priority === 'high' ? '<span style="color:#f87171">HIGH</span>' : '<span style="color:#facc15">MED</span>';
+    const el = document.createElement('div');
+    el.style.cssText = `background:var(--bg-card);border:1px solid var(--border);border-left:3px solid ${color};border-radius:6px;padding:0.6rem 0.85rem;margin-bottom:0.5rem;font-size:0.82rem;`;
+    el.innerHTML = `
+      <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:0.25rem;">
+        <span style="color:${color};font-weight:600;font-family:'IBM Plex Mono',monospace;font-size:0.76rem;">● ${esc(d.status.replace('_',' ').toUpperCase())}</span>
+        <span style="color:var(--text-dim);font-size:0.72rem;">${priorityLabel} &nbsp; ${esc(ts)}</span>
+      </div>
+      <div style="color:var(--text);font-size:0.8rem;line-height:1.5;margin-bottom:0.2rem;">${esc(d.message || '')}</div>
+      <div style="color:var(--text-dim);font-size:0.72rem;font-family:'IBM Plex Mono',monospace;">${esc(d.code || '')}${d.skill ? ' → ' + esc(d.skill) : ''} &nbsp;|&nbsp; trigger: ${esc(d.trigger || '—')}</div>
+      ${d.ack_message ? `<div style="margin-top:0.3rem;padding:0.3rem 0.5rem;background:rgba(74,222,128,0.08);border-radius:4px;color:#86efac;font-size:0.75rem;">Smith: ${esc(d.ack_message)}</div>` : ''}
+    `;
+    return el;
+  }
+
+  function updateStallBanner(directives) {
+    const banner = document.getElementById('stall-banner');
+    const msgEl  = document.getElementById('stall-banner-msg');
+    if (!banner || !msgEl) return;
+    const stall = directives.find(d =>
+      d.code === 'RESUME_REQUIRED' && (d.status === 'pending' || d.status === 'injected')
+    );
+    if (stall) {
+      const match = (stall.message || '').match(/(\d+)\s*min/);
+      msgEl.textContent = match ? `last activity ${match[1]}min ago` : 'possible stall detected';
+      banner.style.display = 'block';
+    } else {
+      banner.style.display = 'none';
+    }
+  }
+
+  // ── Metrics ───────────────────────────────────────────────────────────────
+
+  let _metricsData = null;
+
+  async function pollMetrics() {
+    try {
+      const r = await fetch(`/api/metrics?_=${Date.now()}`);
+      if (!r.ok) return;
+      _metricsData = await r.json();
+      if (_activeTab === 'metrics') renderMetrics();
+      const btn = document.getElementById('tab-btn-metrics');
+      if (btn) btn.textContent = _metricsData.length ? `Metrics (${_metricsData.length})` : 'Metrics';
+      const upd = document.getElementById('metrics-updated');
+      if (upd && _metricsData.length) upd.textContent = `${_metricsData.length} run(s) recorded`;
+    } catch { /* ignore */ }
+  }
+
+  function renderMetrics() {
+    const wrap = document.getElementById('metrics-wrap');
+    if (!wrap) return;
+    if (!_metricsData || !_metricsData.length) {
+      wrap.innerHTML = '<div class="empty-placeholder">No completed scans yet — metrics appear after session(action=\'complete\').</div>';
+      return;
+    }
+
+    // Show newest first
+    const rows = [..._metricsData].reverse();
+
+    const sev = (r, s) => r[`findings_${s}`] ?? 0;
+    const fmt = v => v == null ? '—' : v;
+    const pct = v => v == null ? '—' : `${v}%`;
+    const dur = v => v == null ? '—' : `${v}m`;
+    const usd = v => v == null ? '—' : `$${v.toFixed(4)}`;
+
+    const cols = [
+      { label: 'Run ID',        fn: r => `<span title="${r.run_id || ''}" style="font-family:monospace;font-size:0.7rem">${(r.run_id || '—').slice(0, 8)}</span>` },
+      { label: 'Target',        fn: r => `<span style="max-width:140px;display:inline-block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${r.target || ''}">${r.target || '—'}</span>` },
+      { label: 'Depth',         fn: r => fmt(r.depth) },
+      { label: 'Status',        fn: r => {
+        const s = r.status || 'complete';
+        const color = s === 'complete' ? 'var(--green)' : s === 'limit_reached' ? 'var(--warning)' : 'var(--red)';
+        return `<span style="color:${color}">${s}</span>`;
+      }},
+      { label: 'Duration',      fn: r => dur(r.duration_minutes) },
+      { label: 'Cost',          fn: r => usd(r.total_cost_usd) },
+      { label: '$/finding',     fn: r => fmt(r.cost_per_finding == null ? null : `$${r.cost_per_finding.toFixed(4)}`) },
+      { label: 'Calls',         fn: r => fmt(r.tool_calls_total) },
+      { label: 'Coverage%',     fn: r => pct(r.coverage_rate_pct) },
+      { label: 'Crit',          fn: r => `<span style="color:var(--red)">${sev(r,'critical')}</span>` },
+      { label: 'High',          fn: r => `<span style="color:var(--orange)">${sev(r,'high')}</span>` },
+      { label: 'Med',           fn: r => `<span style="color:var(--warning)">${sev(r,'medium')}</span>` },
+      { label: 'Low',           fn: r => sev(r,'low') },
+      { label: 'PoC%',          fn: r => pct(r.poc_coverage_rate_pct) },
+      { label: 'FP',            fn: r => fmt(r.false_positive_count) },
+      { label: 'Resumes',       fn: r => {
+        const v = r.resume_events ?? 0;
+        return `<span style="color:${v > 0 ? 'var(--warning)' : 'inherit'}">${v}</span>`;
+      }},
+      { label: 'Dups',          fn: r => {
+        const v = r.duplicate_tool_calls ?? 0;
+        return `<span style="color:${v > 0 ? 'var(--warning)' : 'inherit'}">${v}</span>`;
+      }},
+      { label: 'Steers',        fn: r => fmt(r.steering_interventions) },
+      { label: 'Skills',        fn: r => fmt(r.skill_chain_depth) },
+    ];
+
+    const thead = `<thead><tr>${cols.map(c => `<th>${c.label}</th>`).join('')}</tr></thead>`;
+    const tbody = `<tbody>${rows.map(r =>
+      `<tr>${cols.map(c => `<td>${c.fn(r)}</td>`).join('')}</tr>`
+    ).join('')}</tbody>`;
+
+    wrap.innerHTML = `
+      <div style="overflow-x:auto">
+        <table class="metrics-table">${thead}${tbody}</table>
+      </div>
+      ${rows.length > 1 ? _renderMetricsTrend(rows) : ''}
+    `;
+  }
+
+  function _renderMetricsTrend(rows) {
+    // Simple sparkline-style text summary comparing last 2 runs
+    const [latest, prev] = rows;
+    const delta = (a, b, higherIsBetter) => {
+      if (a == null || b == null) return '';
+      const d = a - b;
+      if (Math.abs(d) < 0.001) return '<span style="color:var(--text-dim)">→</span>';
+      const better = higherIsBetter ? d > 0 : d < 0;
+      const arrow = d > 0 ? '▲' : '▼';
+      const color = better ? 'var(--green)' : 'var(--red)';
+      return `<span style="color:${color}">${arrow} ${Math.abs(d).toFixed(2)}</span>`;
+    };
+    return `
+      <div style="margin-top:1rem;padding:0.75rem 1rem;background:var(--bg-card);border-radius:6px;border:1px solid var(--border);font-size:0.78rem">
+        <strong>vs previous run:</strong>
+        cost ${delta(latest.total_cost_usd, prev.total_cost_usd, false)} &nbsp;
+        coverage ${delta(latest.coverage_rate_pct, prev.coverage_rate_pct, true)} &nbsp;
+        duration ${delta(latest.duration_minutes, prev.duration_minutes, false)} &nbsp;
+        findings ${delta(latest.findings_total, prev.findings_total, true)} &nbsp;
+        resumes ${delta(latest.resume_events, prev.resume_events, false)}
+      </div>
+    `;
   }
 
   // ── Polling intervals ─────────────────────────────────────────────────────
@@ -2068,6 +2249,7 @@
   setInterval(pollSkills,      POLL_MS);
   setInterval(pollThreatModel, POLL_MS);
   setInterval(pollQA,          POLL_MS);
+  setInterval(pollMetrics,     POLL_MS * 6);  // metrics update infrequently — check every ~30s
   setInterval(() => { if (!scanDone && lastOk && _activeTab === 'findings') renderFindings(); }, 1000);
   setInterval(() => { if (!scanDone && _activeTab === 'logs') pollLogs(); }, 3000);
 
@@ -2079,6 +2261,7 @@
   pollThreatModel();
   pollLogs();
   pollQA();
+  pollMetrics();
 </script>
 </body>
 </html>

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -1,0 +1,199 @@
+"""
+Tests for mcp_server.scan_engine.envelope pipeline changes:
+  - Tiered context pressure warnings (P4)
+  - Steering directive injection (P5.6)
+  - Duplicate tool call warning (P5.7)
+"""
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_envelope(summary="", warnings=None, session_state=None):
+    from mcp_server.scan_engine.envelope import Envelope
+    return Envelope(
+        summary=summary,
+        warnings=warnings or [],
+        session_state=session_state or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _check_context_pressure — tiered warnings
+# ---------------------------------------------------------------------------
+
+class TestContextPressureTiers:
+
+    def _run_pressure(self, pressure_value, tmp_path, monkeypatch):
+        import mcp_server.scan_engine.envelope as env_mod
+        import core.session as scan_session
+
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session.start("https://example.com")
+
+        env = _make_envelope(summary="some summary")
+
+        with patch("core.session.get_context_pressure", return_value=pressure_value), \
+             patch("core.session.charge_context"), \
+             patch("mcp_server.scan_engine.envelope._maybe_write_recovery_snapshot"):
+            from mcp_server.scan_engine.envelope import _check_context_pressure
+            result = _check_context_pressure(env, env.to_json())
+        return json.loads(result)
+
+    def test_below_70_percent_no_warning(self, tmp_path, monkeypatch):
+        result = self._run_pressure(0.5, tmp_path, monkeypatch)
+        warnings = result.get("warnings", [])
+        assert not any("CONTEXT_WARNING" in w for w in warnings)
+
+    def test_above_70_advisory_warning(self, tmp_path, monkeypatch):
+        result = self._run_pressure(0.75, tmp_path, monkeypatch)
+        warnings = result.get("warnings", [])
+        assert any("CONTEXT_WARNING" in w for w in warnings)
+        assert not any("EXECUTE NOW" in w for w in warnings)
+
+    def test_above_80_urgent_execute_now(self, tmp_path, monkeypatch):
+        result = self._run_pressure(0.85, tmp_path, monkeypatch)
+        warnings = result.get("warnings", [])
+        assert any("EXECUTE NOW" in w for w in warnings)
+
+    def test_above_90_auto_injects_recovery_brief(self, tmp_path, monkeypatch):
+        import mcp_server.scan_engine.envelope as env_mod
+        import core.session as scan_session
+
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session.start("https://example.com")
+
+        env = _make_envelope(summary="some summary")
+
+        fake_brief = {"status": "running", "EXECUTE_NOW": "scan(tool='httpx', ...)"}
+
+        with patch("core.session.get_context_pressure", return_value=0.95), \
+             patch("core.session.charge_context"), \
+             patch("mcp_server.scan_engine.envelope._maybe_write_recovery_snapshot"), \
+             patch("mcp_server.session_tools._do_recovery", return_value=json.dumps(fake_brief)):
+            from mcp_server.scan_engine.envelope import _check_context_pressure
+            result_str = _check_context_pressure(env, env.to_json())
+
+        result = json.loads(result_str)
+        assert "recovery_brief" in result.get("session_state", {})
+        assert result["session_state"]["recovery_brief"]["EXECUTE_NOW"] == "scan(tool='httpx', ...)"
+
+
+# ---------------------------------------------------------------------------
+# _inject_steering_directives — P5.6
+# ---------------------------------------------------------------------------
+
+class TestSteeringInjection:
+
+    def test_pending_high_directive_prepended_to_summary(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+
+        q = st_mod.SteeringQueue()
+        q.add_directive(
+            code=st_mod.CHAIN_REQUIRED,
+            message="CHAIN NOW: /web-exploit — 2 critical findings confirmed.",
+            priority="high",
+            skill="web-exploit",
+            trigger="SKILL_CHAIN_GAP",
+        )
+
+        env = _make_envelope(summary="original summary")
+        from mcp_server.scan_engine.envelope import _inject_steering_directives
+        _inject_steering_directives(env)
+
+        assert "QA STEERING" in env.summary
+        assert "CHAIN NOW" in env.summary
+        assert "original summary" in env.summary  # original is preserved after the prepend
+
+    def test_pending_medium_directive_goes_to_warnings_only(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+
+        q = st_mod.SteeringQueue()
+        q.add_directive(
+            code=st_mod.RESUME_TESTING,
+            message="Resume testing — 5 pending cells.",
+            priority="medium",
+            trigger="COVERAGE_STALL",
+        )
+
+        env = _make_envelope(summary="original summary")
+        from mcp_server.scan_engine.envelope import _inject_steering_directives
+        _inject_steering_directives(env)
+
+        # Medium: only in warnings, not prepended to summary
+        assert "QA STEER" not in env.summary
+        assert any("RESUME_TESTING" in w or "Resume testing" in w for w in env.warnings)
+
+    def test_directive_marked_injected_after_surfacing(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+
+        q = st_mod.SteeringQueue()
+        did = q.add_directive(
+            code=st_mod.RESUME_REQUIRED,
+            message="Stall detected.",
+            priority="high",
+            trigger="TOOL_INACTIVITY",
+        )
+
+        env = _make_envelope()
+        from mcp_server.scan_engine.envelope import _inject_steering_directives
+        _inject_steering_directives(env)
+
+        directives = q._load()
+        d = next(d for d in directives if d["id"] == did)
+        assert d["status"] == "injected"
+
+    def test_no_directives_no_change(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+
+        env = _make_envelope(summary="clean summary")
+        from mcp_server.scan_engine.envelope import _inject_steering_directives
+        _inject_steering_directives(env)
+
+        assert env.summary == "clean summary"
+        assert env.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# _inject_duplicate_warning — P5.7
+# ---------------------------------------------------------------------------
+
+class TestDuplicateWarning:
+
+    def test_duplicate_warning_injected_into_warnings(self, tmp_path, monkeypatch):
+        import core.session as scan_session
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session.start("https://example.com")
+        # Seed a tool invocation
+        scan_session.add_tool_invocation("nmap", "example.com", "summary", "abc12345")
+
+        env = _make_envelope()
+        from mcp_server.scan_engine.envelope import _inject_duplicate_warning
+        _inject_duplicate_warning(env, "nmap")
+
+        assert any("DUPLICATE_TOOL_CALL" in w for w in env.warnings)
+        assert any("nmap" in w for w in env.warnings)
+
+    def test_no_invocations_no_warning(self, tmp_path, monkeypatch):
+        import core.session as scan_session
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session.start("https://example.com")
+
+        env = _make_envelope()
+        from mcp_server.scan_engine.envelope import _inject_duplicate_warning
+        _inject_duplicate_warning(env, "nmap")
+
+        # No invocations yet — warning still injected (it's about current dup detection)
+        # The warning is always injected when _inject_duplicate_warning is called;
+        # actual dedup decision is made in wrap() before calling this function.
+        # This test just confirms the warning format is correct.
+        warnings_text = " ".join(env.warnings)
+        assert "DUPLICATE_TOOL_CALL" in warnings_text

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -366,7 +366,7 @@ class TestTimePerSkill:
             {"type": "SKILL", "name": "web-exploit",  "ts": ts(10)},
             {"type": "TOOL",  "name": "sqlmap",       "ts": ts(12)},
         ]
-        result = tmp_metrics._compute_time_per_skill(entries, total_minutes=15)
+        result = tmp_metrics._compute_time_per_skill(entries)
         assert "pentester" in result
         assert "web-exploit" in result
         # pentester: from ts(0) to last tool ts(5) = 5 min
@@ -375,7 +375,7 @@ class TestTimePerSkill:
         assert result["web-exploit"] == 2.0
 
     def test_empty_entries_returns_empty(self, tmp_metrics):
-        assert tmp_metrics._compute_time_per_skill([], 30) == {}
+        assert tmp_metrics._compute_time_per_skill([]) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,439 @@
+"""
+Tests for core.metrics — pentest run metrics computation and persistence.
+"""
+import json
+import pytest
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_metrics(tmp_path, monkeypatch):
+    import core.metrics as m
+    monkeypatch.setattr(m, "_METRICS_FILE", tmp_path / "pentest_metrics.jsonl")
+    return m
+
+
+def _make_session(started_offset_min=30):
+    now = datetime.now(timezone.utc)
+    started = (now - timedelta(minutes=started_offset_min)).isoformat()
+    return {
+        "id": "test-run-001",
+        "started": started,
+        "finished": now.isoformat(),
+        "target": "https://example.com",
+        "depth": "standard",
+        "status": "complete",
+        "context_chars_sent": 120000,
+        "tool_invocations": [],
+        "skill_history": [],
+        "gates": [],
+    }
+
+
+def _make_cost():
+    return {"est_cost_usd": 0.042, "tool_calls_done": 18}
+
+
+def _make_findings(severities=None):
+    severities = severities or []
+    findings = []
+    for i, sev in enumerate(severities):
+        findings.append({
+            "id": f"f-{i:03d}",
+            "title": f"Finding {i}",
+            "severity": sev,
+            "status": "confirmed",
+            "poc_files": ["poc.http"] if sev in ("critical", "high") else [],
+            "escalation_leads": [],
+        })
+    return {"meta": {}, "findings": findings, "diagrams": []}
+
+
+def _make_coverage(endpoints=2, total_cells=4, tested=3):
+    matrix = []
+    ep_ids = [f"ep-{i}" for i in range(endpoints)]
+    inj_types = ["sqli", "xss", "ssti", "cmdi"]
+    for i in range(total_cells):
+        matrix.append({
+            "id": f"cell-{i:03d}",
+            "endpoint_id": ep_ids[i % endpoints],
+            "param": "q",
+            "injection_type": inj_types[i % len(inj_types)],
+            "status": "tested_clean" if i < tested else "pending",
+        })
+    return {
+        "meta": {"total_cells": total_cells, "tested": tested, "addressed": tested},
+        "endpoints": [{"id": eid, "path": f"/{eid}", "method": "GET"} for eid in ep_ids],
+        "matrix": matrix,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _compute — basic schema completeness
+# ---------------------------------------------------------------------------
+
+class TestComputeSchema:
+
+    def test_all_schema_fields_present(self, tmp_metrics):
+        session = _make_session()
+        record = tmp_metrics._compute(
+            session=session,
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(["critical", "high", "medium"]),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        required = [
+            "run_id", "ts", "target", "depth", "status", "force_completed",
+            "duration_minutes", "total_cost_usd", "tool_calls_total",
+            "context_chars_total", "cost_per_finding", "tool_calls_per_finding",
+            "endpoint_count", "total_cells", "coverage_rate_pct",
+            "injection_types_tested", "injection_breadth",
+            "findings_total", "findings_critical", "findings_high",
+            "findings_medium", "findings_low", "findings_info",
+            "poc_coverage_rate_pct", "false_positive_count",
+            "escalation_completion_rate_pct",
+            "resume_events", "duplicate_tool_calls",
+            "steering_interventions", "steering_auto_satisfied",
+            "skills_invoked", "skill_chain_depth",
+            "unsatisfied_gate_count", "completion_blockers",
+            "time_per_skill_minutes",
+        ]
+        for field in required:
+            assert field in record, f"Missing field: {field}"
+
+    def test_identity_fields(self, tmp_metrics):
+        session = _make_session()
+        rec = tmp_metrics._compute(
+            session=session,
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(),
+            coverage=_make_coverage(),
+            force_completed=True,
+            completion_blockers=["NO DIAGRAM"],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert rec["run_id"] == "test-run-001"
+        assert rec["target"] == "https://example.com"
+        assert rec["depth"] == "standard"
+        assert rec["force_completed"] is True
+        assert rec["completion_blockers"] == ["NO DIAGRAM"]
+
+
+# ---------------------------------------------------------------------------
+# _compute — cost metrics
+# ---------------------------------------------------------------------------
+
+class TestCostMetrics:
+
+    def test_cost_fields_populated(self, tmp_metrics):
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary={"est_cost_usd": 0.06, "tool_calls_done": 30},
+            findings_data=_make_findings(["critical", "high"]),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert rec["total_cost_usd"] == 0.06
+        assert rec["tool_calls_total"] == 30
+        assert rec["cost_per_finding"] == round(0.06 / 2, 6)
+        assert rec["tool_calls_per_finding"] == round(30 / 2, 2)
+
+    def test_no_findings_cost_per_finding_is_none(self, tmp_metrics):
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert rec["cost_per_finding"] is None
+        assert rec["tool_calls_per_finding"] is None
+
+
+# ---------------------------------------------------------------------------
+# _compute — coverage metrics
+# ---------------------------------------------------------------------------
+
+class TestCoverageMetrics:
+
+    def test_coverage_rate_computed(self, tmp_metrics):
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(),
+            coverage=_make_coverage(total_cells=10, tested=7),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert rec["coverage_rate_pct"] == 70.0
+
+    def test_injection_types_from_tested_cells(self, tmp_metrics):
+        cov = _make_coverage(total_cells=3, tested=3)
+        # Override matrix with known injection types
+        cov["matrix"] = [
+            {"id": "c1", "endpoint_id": "ep-0", "param": "q", "injection_type": "sqli", "status": "tested_clean"},
+            {"id": "c2", "endpoint_id": "ep-0", "param": "q", "injection_type": "xss",  "status": "vulnerable"},
+            {"id": "c3", "endpoint_id": "ep-0", "param": "q", "injection_type": "ssti", "status": "pending"},
+        ]
+        cov["meta"]["total_cells"] = 3
+        cov["meta"]["addressed"] = 2
+
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(),
+            coverage=cov,
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert "sqli" in rec["injection_types_tested"]
+        assert "xss" in rec["injection_types_tested"]
+        assert "ssti" not in rec["injection_types_tested"]
+        assert rec["injection_breadth"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _compute — findings metrics
+# ---------------------------------------------------------------------------
+
+class TestFindingsMetrics:
+
+    def test_severity_counts(self, tmp_metrics):
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(["critical", "critical", "high", "medium", "low", "info"]),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert rec["findings_critical"] == 2
+        assert rec["findings_high"] == 1
+        assert rec["findings_medium"] == 1
+        assert rec["findings_low"] == 1
+        assert rec["findings_info"] == 1
+        assert rec["findings_total"] == 6
+
+    def test_poc_coverage_rate(self, tmp_metrics):
+        data = {
+            "meta": {}, "diagrams": [],
+            "findings": [
+                {"id": "f1", "severity": "critical", "status": "confirmed",
+                 "poc_files": ["poc.http"], "escalation_leads": []},
+                {"id": "f2", "severity": "high", "status": "confirmed",
+                 "poc_files": [], "escalation_leads": []},
+            ],
+        }
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=data,
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        # 1 of 2 high/critical has poc → 50%
+        assert rec["poc_coverage_rate_pct"] == 50.0
+
+    def test_escalation_completion_rate(self, tmp_metrics):
+        data = {
+            "meta": {}, "diagrams": [],
+            "findings": [
+                {"id": "f1", "severity": "critical", "status": "confirmed",
+                 "poc_files": [], "escalation_leads": [
+                     {"lead": "dump db", "status": "done"},
+                     {"lead": "rce", "status": "pending"},
+                 ]},
+            ],
+        }
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=data,
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        # 1 done out of 2 total → 50%
+        assert rec["escalation_completion_rate_pct"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# _compute — context health
+# ---------------------------------------------------------------------------
+
+class TestContextHealth:
+
+    def test_resume_events_counted(self, tmp_metrics):
+        session = _make_session()
+        session["tool_invocations"] = [
+            {"summary": "RESUME DETECTED: post-compaction"},
+            {"summary": "normal tool call"},
+            {"summary": "RESUME DETECTED: again"},
+        ]
+        rec = tmp_metrics._compute(
+            session=session,
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert rec["resume_events"] == 2
+
+    def test_duplicate_tool_calls_counted(self, tmp_metrics):
+        session = _make_session()
+        session["tool_invocations"] = [
+            {"summary": "DUPLICATE_TOOL_CALL: nmap already run"},
+        ]
+        rec = tmp_metrics._compute(
+            session=session,
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        assert rec["duplicate_tool_calls"] == 1
+
+    def test_steering_history_counted(self, tmp_metrics):
+        history = [
+            {"id": "s1", "status": "auto_satisfied"},
+            {"id": "s2", "status": "acknowledged"},
+            {"id": "s3", "status": "auto_satisfied"},
+        ]
+        rec = tmp_metrics._compute(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=history,
+        )
+        assert rec["steering_interventions"] == 3
+        assert rec["steering_auto_satisfied"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _compute_time_per_skill
+# ---------------------------------------------------------------------------
+
+class TestTimePerSkill:
+
+    def test_buckets_tool_events_between_skills(self, tmp_metrics):
+        from datetime import datetime, timezone, timedelta
+
+        base = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        def ts(offset_min):
+            return (base + timedelta(minutes=offset_min)).isoformat()
+
+        entries = [
+            {"type": "SKILL", "name": "pentester",   "ts": ts(0)},
+            {"type": "TOOL",  "name": "nmap",         "ts": ts(2)},
+            {"type": "TOOL",  "name": "httpx",        "ts": ts(5)},
+            {"type": "SKILL", "name": "web-exploit",  "ts": ts(10)},
+            {"type": "TOOL",  "name": "sqlmap",       "ts": ts(12)},
+        ]
+        result = tmp_metrics._compute_time_per_skill(entries, total_minutes=15)
+        assert "pentester" in result
+        assert "web-exploit" in result
+        # pentester: from ts(0) to last tool ts(5) = 5 min
+        assert result["pentester"] == 5.0
+        # web-exploit: from ts(10) to ts(12) = 2 min
+        assert result["web-exploit"] == 2.0
+
+    def test_empty_entries_returns_empty(self, tmp_metrics):
+        assert tmp_metrics._compute_time_per_skill([], 30) == {}
+
+
+# ---------------------------------------------------------------------------
+# _duration_minutes
+# ---------------------------------------------------------------------------
+
+class TestDurationMinutes:
+
+    def test_duration_computed(self, tmp_metrics):
+        session = {
+            "started":  "2025-01-01T10:00:00+00:00",
+            "finished": "2025-01-01T10:30:00+00:00",
+        }
+        assert tmp_metrics._duration_minutes(session) == 30.0
+
+    def test_missing_timestamps_returns_zero(self, tmp_metrics):
+        assert tmp_metrics._duration_minutes({}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# record() — writes to JSONL and load_all() reads it back
+# ---------------------------------------------------------------------------
+
+class TestRecordAndLoad:
+
+    def test_record_appends_to_jsonl(self, tmp_metrics):
+        tmp_metrics.record(
+            session=_make_session(),
+            cost_summary=_make_cost(),
+            findings_data=_make_findings(["high"]),
+            coverage=_make_coverage(),
+            force_completed=False,
+            completion_blockers=[],
+            quick_log_entries=[],
+            steering_history=[],
+        )
+        records = tmp_metrics.load_all()
+        assert len(records) == 1
+        assert records[0]["target"] == "https://example.com"
+
+    def test_multiple_records_appended_in_order(self, tmp_metrics):
+        for i in range(3):
+            s = _make_session()
+            s["id"] = f"run-{i}"
+            tmp_metrics.record(
+                session=s,
+                cost_summary=_make_cost(),
+                findings_data=_make_findings(),
+                coverage=_make_coverage(),
+                force_completed=False,
+                completion_blockers=[],
+                quick_log_entries=[],
+                steering_history=[],
+            )
+        records = tmp_metrics.load_all()
+        assert len(records) == 3
+        assert records[0]["run_id"] == "run-0"
+        assert records[2]["run_id"] == "run-2"
+
+    def test_load_all_empty_file(self, tmp_metrics):
+        assert tmp_metrics.load_all() == []

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -135,24 +135,24 @@ def test_scope_drift_no_tool_entries():
 # ---------------------------------------------------------------------------
 
 def test_coverage_stall_no_coverage_entries():
-    assert _check_coverage_stall({}, [_tool_entry()]) is None
+    assert _check_coverage_stall([_tool_entry()]) is None
 
 
 def test_coverage_stall_pending_zero():
     entries = [_coverage_entry(pending=0, offset_min=35)]
-    assert _check_coverage_stall({}, entries) is None
+    assert _check_coverage_stall(entries) is None
 
 
 def test_coverage_stall_under_15_min():
     entries = [_coverage_entry(pending=5, offset_min=10)]
-    assert _check_coverage_stall({}, entries) is None
+    assert _check_coverage_stall(entries) is None
 
 
 def test_coverage_stall_fires_at_15_min(tmp_path, monkeypatch):
     import core.steering as st_mod
     monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
     entries = [_coverage_entry(pending=8, offset_min=20)]
-    alert = _check_coverage_stall({}, entries)
+    alert = _check_coverage_stall(entries)
     assert alert is not None
     assert alert["code"] == "COVERAGE_STALL"
     assert alert["urgency"] == "high"
@@ -163,7 +163,7 @@ def test_coverage_stall_generates_directive(tmp_path, monkeypatch):
     import core.steering as st_mod
     monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
     entries = [_coverage_entry(pending=3, offset_min=20)]
-    _check_coverage_stall({}, entries)
+    _check_coverage_stall(entries)
     q = st_mod.SteeringQueue()
     assert any(d["code"] == "RESUME_TESTING" for d in q._load())
 

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -1,9 +1,13 @@
 """
-Tests for core.qa_agent — session check and QADaemon cycle logic.
+Tests for core.qa_agent — deterministic checks and QADaemon cycle logic.
+
+All check functions now operate on structured data (quick_log entries, JSON dicts).
+No regex parsing of summary text.
 """
 import asyncio
 import json
 import pytest
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,11 +15,41 @@ import core.qa_agent
 import core.quick_log
 from core.qa_agent import (
     _session_is_running, _read_qa_state,
-    _sanitize_history, _init_llm, _build_graph, QADaemon,
-    _deterministic_qa_checks, _load_json, _format_findings_for_semantic_review,
-    _deduplicate,
+    _sanitize_history, QADaemon,
+    _deterministic_qa_checks, _load_json,
+    _deduplicate, _merge_alerts,
+    _check_scope_drift, _check_coverage_stall, _check_spider_without_coverage,
+    _check_poc_gap, _check_tool_inactivity, _check_bulk_marking,
+    _check_coverage_integrity, _check_missing_diagram, _check_no_spider_after_httpx,
+    _check_endpoint_trigger_gaps, _check_coverage_gap, _check_injection_breadth,
 )
 from core.quick_log import QuickLog
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ts(offset_min: int = 0) -> str:
+    """ISO timestamp offset_min minutes in the past."""
+    return (datetime.now(timezone.utc) - timedelta(minutes=offset_min)).isoformat()
+
+
+def _tool_entry(name: str = "nmap", target: str = "https://example.com", offset_min: int = 1) -> dict:
+    return {"type": "TOOL", "name": name, "target": target, "ts": _ts(offset_min)}
+
+
+def _spider_entry(endpoints_found: int = 10, offset_min: int = 1) -> dict:
+    return {"type": "SPIDER", "endpoints_found": endpoints_found, "ts": _ts(offset_min)}
+
+
+def _coverage_entry(pending: int = 0, na_untooled: int = 0, untooled: int = 0,
+                    offset_min: int = 1) -> dict:
+    return {
+        "type": "COVERAGE", "pending": pending, "tested": 5,
+        "na_untooled": na_untooled, "untooled": untooled,
+        "ts": _ts(offset_min),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -53,276 +87,326 @@ def test_session_is_running_returns_false_when_corrupt_json(tmp_path, monkeypatc
 # ---------------------------------------------------------------------------
 
 def test_load_json_returns_empty_when_file_missing(tmp_path):
-    result = _load_json(tmp_path / "nonexistent.json")
-    assert result == {}
+    assert _load_json(tmp_path / "nonexistent.json") == {}
 
 
 def test_load_json_returns_parsed_dict(tmp_path):
     f = tmp_path / "data.json"
     f.write_text(json.dumps({"key": "value", "num": 42}))
-    result = _load_json(f)
-    assert result == {"key": "value", "num": 42}
+    assert _load_json(f) == {"key": "value", "num": 42}
 
 
 def test_load_json_returns_empty_on_corrupt_json(tmp_path):
     f = tmp_path / "bad.json"
     f.write_text("not valid json {{{")
-    result = _load_json(f)
-    assert result == {}
+    assert _load_json(f) == {}
 
 
 # ---------------------------------------------------------------------------
-# _deterministic_qa_checks()
+# _check_scope_drift
 # ---------------------------------------------------------------------------
 
-def test_deterministic_no_alerts_on_clean_summary():
-    alerts = _deterministic_qa_checks("1 tool call: nmap", {}, {})
-    assert alerts == []
+def test_scope_drift_no_target_skips():
+    entries = [_tool_entry("nmap", "evil.com")]
+    assert _check_scope_drift(entries, {}) is None
 
 
-def test_deterministic_scope_drift_detected():
-    summary = "Possible off-scope targets used: evil.com"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "SCOPE_DRIFT" in codes
-    scope_alert = next(a for a in alerts if a["code"] == "SCOPE_DRIFT")
-    assert scope_alert["urgency"] == "high"
-    assert scope_alert["blocking"] is False
-    assert "evil.com" in scope_alert["message"]
+def test_scope_drift_detected():
+    entries = [_tool_entry("nmap", "evil.com")]
+    alert = _check_scope_drift(entries, {"target": "https://example.com"})
+    assert alert is not None
+    assert alert["code"] == "SCOPE_DRIFT"
+    assert alert["urgency"] == "high"
+    assert "evil.com" in alert["message"]
 
 
-def test_deterministic_coverage_stall_detected():
-    summary = "WARNING: coverage stale (35 min), 10 pending"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "COVERAGE_STALL" in codes
-    stall = next(a for a in alerts if a["code"] == "COVERAGE_STALL")
-    assert stall["urgency"] == "high"
-    assert "10 cells" in stall["message"]
+def test_scope_drift_in_scope_target_ignored():
+    entries = [_tool_entry("httpx", "https://example.com/api/users")]
+    assert _check_scope_drift(entries, {"target": "https://example.com"}) is None
 
 
-def test_deterministic_coverage_stall_skipped_when_pending_zero():
-    summary = "WARNING: coverage stale (35 min), 0 pending"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "COVERAGE_STALL" not in codes
+def test_scope_drift_no_tool_entries():
+    entries = [_spider_entry()]
+    assert _check_scope_drift(entries, {"target": "https://example.com"}) is None
 
 
-def test_deterministic_spider_without_coverage():
-    summary = "Endpoints found: 15"
-    coverage_data = {"meta": {"total_cells": 0}}
-    alerts = _deterministic_qa_checks(summary, {}, coverage_data)
-    codes = [a["code"] for a in alerts]
-    assert "SPIDER_WITHOUT_COVERAGE" in codes
-    alert = next(a for a in alerts if a["code"] == "SPIDER_WITHOUT_COVERAGE")
+# ---------------------------------------------------------------------------
+# _check_coverage_stall
+# ---------------------------------------------------------------------------
+
+def test_coverage_stall_no_coverage_entries():
+    assert _check_coverage_stall({}, [_tool_entry()]) is None
+
+
+def test_coverage_stall_pending_zero():
+    entries = [_coverage_entry(pending=0, offset_min=35)]
+    assert _check_coverage_stall({}, entries) is None
+
+
+def test_coverage_stall_under_15_min():
+    entries = [_coverage_entry(pending=5, offset_min=10)]
+    assert _check_coverage_stall({}, entries) is None
+
+
+def test_coverage_stall_fires_at_15_min(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [_coverage_entry(pending=8, offset_min=20)]
+    alert = _check_coverage_stall({}, entries)
+    assert alert is not None
+    assert alert["code"] == "COVERAGE_STALL"
+    assert alert["urgency"] == "high"
+    assert "8 cells" in alert["message"]
+
+
+def test_coverage_stall_generates_directive(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [_coverage_entry(pending=3, offset_min=20)]
+    _check_coverage_stall({}, entries)
+    q = st_mod.SteeringQueue()
+    assert any(d["code"] == "RESUME_TESTING" for d in q._load())
+
+
+# ---------------------------------------------------------------------------
+# _check_spider_without_coverage
+# ---------------------------------------------------------------------------
+
+def test_spider_without_coverage_no_spider():
+    assert _check_spider_without_coverage([_tool_entry()], {}) is None
+
+
+def test_spider_without_coverage_fires():
+    entries = [_spider_entry(15)]
+    alert = _check_spider_without_coverage(entries, {"meta": {"total_cells": 0}})
+    assert alert is not None
+    assert alert["code"] == "SPIDER_WITHOUT_COVERAGE"
     assert "15" in alert["message"]
 
 
-def test_deterministic_spider_without_coverage_skipped_when_matrix_populated():
-    summary = "Endpoints found: 15"
-    coverage_data = {"meta": {"total_cells": 30}}
-    alerts = _deterministic_qa_checks(summary, {}, coverage_data)
-    codes = [a["code"] for a in alerts]
-    assert "SPIDER_WITHOUT_COVERAGE" not in codes
+def test_spider_without_coverage_skipped_when_matrix_populated():
+    entries = [_spider_entry(15)]
+    assert _check_spider_without_coverage(entries, {"meta": {"total_cells": 30}}) is None
 
 
-def test_deterministic_poc_gap_detected():
-    findings_data = {
-        "findings": [
-            {"title": "SQLi", "severity": "critical", "poc_files": []},
-            {"title": "XSS", "severity": "high"},
-        ]
-    }
-    alerts = _deterministic_qa_checks("", findings_data, {})
-    codes = [a["code"] for a in alerts]
-    assert "POC_GAP" in codes
-    poc = next(a for a in alerts if a["code"] == "POC_GAP")
-    assert poc["urgency"] == "medium"
-    assert "2/2" in poc["message"]
+# ---------------------------------------------------------------------------
+# _check_poc_gap
+# ---------------------------------------------------------------------------
+
+def test_poc_gap_no_findings():
+    assert _check_poc_gap({}) is None
 
 
-def test_deterministic_poc_gap_truncates_titles_at_three():
-    """More than 3 missing-PoC findings should show +N more in the message."""
-    findings_data = {
-        "findings": [
-            {"title": f"Finding {i}", "severity": "critical", "poc_files": []}
-            for i in range(5)
-        ]
-    }
-    alerts = _deterministic_qa_checks("", findings_data, {})
-    poc = next(a for a in alerts if a["code"] == "POC_GAP")
-    assert "+2 more" in poc["message"]
+def test_poc_gap_all_have_poc():
+    data = {"findings": [{"title": "SQLi", "severity": "critical", "poc_files": ["sqli.http"]}]}
+    assert _check_poc_gap(data) is None
 
 
-def test_deterministic_poc_gap_skipped_when_all_have_poc():
-    findings_data = {
-        "findings": [
-            {"title": "SQLi", "severity": "critical", "poc_files": ["sqli.http"]},
-        ]
-    }
-    alerts = _deterministic_qa_checks("", findings_data, {})
-    codes = [a["code"] for a in alerts]
-    assert "POC_GAP" not in codes
+def test_poc_gap_fires_high_urgency(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    data = {"findings": [
+        {"title": "SQLi", "severity": "critical", "poc_files": []},
+        {"title": "XSS",  "severity": "high",     "poc_files": []},
+    ]}
+    alert = _check_poc_gap(data)
+    assert alert is not None
+    assert alert["code"] == "POC_GAP"
+    assert alert["urgency"] == "high"
+    assert "2/2" in alert["message"]
 
 
-def test_deterministic_skill_chain_gap():
-    summary = "Findings: 2 critical, 1 high"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "SKILL_CHAIN_GAP" in codes
+def test_poc_gap_generates_poc_required_directive(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    data = {"findings": [{"title": "SQLi", "severity": "critical", "poc_files": []}]}
+    _check_poc_gap(data)
+    q = st_mod.SteeringQueue()
+    assert any(d["code"] == "POC_REQUIRED" for d in q._load())
 
 
-def test_deterministic_skill_chain_gap_skipped_when_web_exploit_ran():
-    summary = "Findings: 2 critical, 1 high\nweb-exploit ran"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "SKILL_CHAIN_GAP" not in codes
+def test_poc_gap_truncates_titles_at_three(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    data = {"findings": [
+        {"title": f"Finding {i}", "severity": "critical", "poc_files": []}
+        for i in range(5)
+    ]}
+    alert = _check_poc_gap(data)
+    assert "+2 more" in alert["message"]
 
 
-def test_deterministic_tool_inactivity_above_threshold():
-    summary = "Last tool call: 15 minutes ago"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "TOOL_INACTIVITY" in codes
-    inact = next(a for a in alerts if a["code"] == "TOOL_INACTIVITY")
-    assert inact["urgency"] == "low"
-    assert "15min" in inact["message"]
+# ---------------------------------------------------------------------------
+# _check_tool_inactivity
+# ---------------------------------------------------------------------------
+
+def test_tool_inactivity_no_tools():
+    assert _check_tool_inactivity([]) is None
 
 
-def test_deterministic_tool_inactivity_below_threshold():
-    summary = "Last tool call: 5 minutes ago"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "TOOL_INACTIVITY" not in codes
+def test_tool_inactivity_below_threshold():
+    entries = [_tool_entry(offset_min=5)]
+    assert _check_tool_inactivity(entries) is None
 
 
-def test_deterministic_bulk_marking_detected():
-    summary = "Bulk-marking warning: 8 N/A cells lack tested_by"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "BULK_MARKING" in codes
-    bulk = next(a for a in alerts if a["code"] == "BULK_MARKING")
-    assert bulk["blocking"] is True
+def test_tool_inactivity_medium_between_10_and_15(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [_tool_entry(offset_min=12)]
+    alert = _check_tool_inactivity(entries)
+    assert alert is not None
+    assert alert["code"] == "TOOL_INACTIVITY"
+    assert alert["urgency"] == "medium"
 
 
-def test_deterministic_coverage_integrity_detected():
-    summary = "5 tested/vulnerable cells have no tested_by tool"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "COVERAGE_INTEGRITY" in codes
-    integ = next(a for a in alerts if a["code"] == "COVERAGE_INTEGRITY")
-    assert integ["blocking"] is True
-    assert "5" in integ["message"]
+def test_tool_inactivity_high_over_15(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [_tool_entry(offset_min=20)]
+    alert = _check_tool_inactivity(entries)
+    assert alert is not None
+    assert alert["urgency"] == "high"
+    q = st_mod.SteeringQueue()
+    assert any(d["code"] == "RESUME_REQUIRED" for d in q._load())
 
 
-def test_deterministic_gate_pending_high_urgency():
-    summary = "Pending gates: credential-audit (requires: /credential-audit) triggered 20min ago"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "GATE_PENDING" in codes
-    gate = next(a for a in alerts if a["code"] == "GATE_PENDING")
-    assert gate["urgency"] == "high"
-    assert "20min" in gate["message"]
+def test_tool_inactivity_counts_spider_entries():
+    entries = [_spider_entry(offset_min=5)]
+    assert _check_tool_inactivity(entries) is None
 
 
-def test_deterministic_gate_pending_medium_urgency():
-    summary = "Pending gates: post-exploit (requires: /post-exploit) triggered 8min ago"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "GATE_PENDING" in codes
-    gate = next(a for a in alerts if a["code"] == "GATE_PENDING")
-    assert gate["urgency"] == "medium"
+# ---------------------------------------------------------------------------
+# _check_bulk_marking
+# ---------------------------------------------------------------------------
+
+def test_bulk_marking_no_coverage_entries():
+    assert _check_bulk_marking([]) is None
 
 
-def test_deterministic_gate_pending_skipped_when_recent():
-    summary = "Pending gates: post-exploit (requires: /post-exploit) triggered 2min ago"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "GATE_PENDING" not in codes
+def test_bulk_marking_below_threshold():
+    entries = [_coverage_entry(na_untooled=5)]
+    assert _check_bulk_marking(entries) is None
 
 
-def test_deterministic_rce_gate_false_positive():
-    summary = "Pending gates: rce-check (requires: /post-exploit) triggered 10min ago\nFindings: 2 medium, 1 low"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "RCE_GATE_FALSE_POSITIVE" in codes
+def test_bulk_marking_fires():
+    entries = [_coverage_entry(na_untooled=15)]
+    alert = _check_bulk_marking(entries)
+    assert alert is not None
+    assert alert["code"] == "BULK_MARKING"
+    assert alert["blocking"] is True
+    assert "15" in alert["message"]
 
 
-def test_deterministic_rce_gate_not_false_positive_with_high_finding():
-    summary = "Pending gates: rce-check (requires: /post-exploit) triggered 10min ago\nFindings: 1 high"
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
-    assert "RCE_GATE_FALSE_POSITIVE" not in codes
+# ---------------------------------------------------------------------------
+# _check_coverage_integrity
+# ---------------------------------------------------------------------------
+
+def test_coverage_integrity_no_entries():
+    assert _check_coverage_integrity([]) is None
 
 
-def test_deterministic_multiple_alerts_can_fire():
-    summary = (
-        "Possible off-scope targets used: evil.com\n"
-        "Last tool call: 20 minutes ago\n"
-        "Bulk-marking warning: 3 N/A cells lack tested_by"
-    )
-    alerts = _deterministic_qa_checks(summary, {}, {})
-    codes = [a["code"] for a in alerts]
+def test_coverage_integrity_zero_untooled():
+    entries = [_coverage_entry(untooled=0)]
+    assert _check_coverage_integrity(entries) is None
+
+
+def test_coverage_integrity_fires():
+    entries = [_coverage_entry(untooled=5)]
+    alert = _check_coverage_integrity(entries)
+    assert alert is not None
+    assert alert["code"] == "COVERAGE_INTEGRITY"
+    assert alert["blocking"] is True
+    assert "5" in alert["message"]
+
+
+# ---------------------------------------------------------------------------
+# _check_missing_diagram
+# ---------------------------------------------------------------------------
+
+def test_missing_diagram_no_findings():
+    assert _check_missing_diagram({}) is None
+
+
+def test_missing_diagram_has_diagram():
+    data = {"findings": [{"id": "f1"}], "diagrams": [{"title": "arch"}]}
+    assert _check_missing_diagram(data) is None
+
+
+def test_missing_diagram_fires():
+    data = {"findings": [{"id": "f1"}], "diagrams": []}
+    alert = _check_missing_diagram(data)
+    assert alert is not None
+    assert alert["code"] == "NO_DIAGRAM"
+    assert alert["urgency"] == "medium"
+
+
+def test_missing_diagram_fires_when_diagrams_key_absent():
+    data = {"findings": [{"id": "f1"}]}
+    assert _check_missing_diagram(data) is not None
+
+
+# ---------------------------------------------------------------------------
+# _check_no_spider_after_httpx
+# ---------------------------------------------------------------------------
+
+def test_no_spider_no_httpx():
+    entries = [_tool_entry("nmap")]
+    assert _check_no_spider_after_httpx(entries) is None
+
+
+def test_no_spider_httpx_with_spider():
+    entries = [_tool_entry("httpx"), _spider_entry()]
+    assert _check_no_spider_after_httpx(entries) is None
+
+
+def test_no_spider_fires_after_httpx():
+    entries = [_tool_entry("httpx"), _tool_entry("nuclei")]
+    alert = _check_no_spider_after_httpx(entries)
+    assert alert is not None
+    assert alert["code"] == "NO_SPIDER"
+    assert alert["urgency"] == "medium"
+
+
+# ---------------------------------------------------------------------------
+# _deterministic_qa_checks — signature and integration
+# ---------------------------------------------------------------------------
+
+def test_deterministic_no_alerts_on_clean_state(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [_tool_entry(offset_min=2)]
+    alerts = _deterministic_qa_checks(entries, {}, {}, {"target": "https://example.com"})
+    assert alerts == []
+
+
+def test_deterministic_scope_drift_detected(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [_tool_entry("nmap", "evil.com")]
+    alerts = _deterministic_qa_checks(entries, {}, {}, {"target": "https://example.com"})
+    assert any(a["code"] == "SCOPE_DRIFT" for a in alerts)
+
+
+def test_deterministic_spider_without_coverage(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [_spider_entry(15)]
+    alerts = _deterministic_qa_checks(entries, {}, {"meta": {"total_cells": 0}}, {})
+    assert any(a["code"] == "SPIDER_WITHOUT_COVERAGE" for a in alerts)
+
+
+def test_deterministic_multiple_alerts_fire(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    entries = [
+        _tool_entry("nmap", "evil.com"),           # scope drift
+        _tool_entry("nmap", "evil.com", offset_min=20),  # inactivity
+        _coverage_entry(na_untooled=15),            # bulk marking
+    ]
+    alerts = _deterministic_qa_checks(entries, {}, {}, {"target": "https://example.com"})
+    codes = {a["code"] for a in alerts}
     assert "SCOPE_DRIFT" in codes
-    assert "TOOL_INACTIVITY" in codes
     assert "BULK_MARKING" in codes
-
-
-# ---------------------------------------------------------------------------
-# _format_findings_for_semantic_review()
-# ---------------------------------------------------------------------------
-
-def test_format_findings_empty_findings():
-    result = _format_findings_for_semantic_review({})
-    assert result == ""
-
-
-def test_format_findings_no_high_critical():
-    findings_data = {
-        "findings": [
-            {"title": "Info leak", "severity": "info"},
-            {"title": "Low issue", "severity": "low"},
-        ]
-    }
-    result = _format_findings_for_semantic_review(findings_data)
-    assert result == ""
-
-
-def test_format_findings_includes_high_critical():
-    findings_data = {
-        "findings": [
-            {
-                "title": "SQL Injection",
-                "severity": "critical",
-                "description": "Classic SQLi on login",
-                "evidence": "' OR 1=1",
-                "business_impact": "Full DB access",
-            },
-            {
-                "title": "XSS",
-                "severity": "high",
-                "description": "Stored XSS in profile",
-                "evidence": "<script>alert(1)</script>",
-            },
-        ]
-    }
-    result = _format_findings_for_semantic_review(findings_data)
-    assert "[CRITICAL]" in result
-    assert "SQL Injection" in result
-    assert "[HIGH]" in result
-    assert "XSS" in result
-
-
-def test_format_findings_caps_at_ten():
-    findings_data = {
-        "findings": [
-            {"title": f"Finding {i}", "severity": "high", "description": "desc"}
-            for i in range(15)
-        ]
-    }
-    result = _format_findings_for_semantic_review(findings_data)
-    # Only 10 should be included — count how many [HIGH] markers appear
-    assert result.count("[HIGH]") == 10
 
 
 # ---------------------------------------------------------------------------
@@ -336,21 +420,19 @@ def test_deduplicate_empty_lists():
 def test_deduplicate_no_previous_keeps_all():
     new_alerts = [
         {"code": "SCOPE_DRIFT", "urgency": "high", "message": "drift detected"},
-        {"code": "POC_GAP", "urgency": "medium", "message": "missing pocs"},
+        {"code": "POC_GAP", "urgency": "high", "message": "missing pocs"},
     ]
-    result = _deduplicate(new_alerts, [])
-    assert len(result) == 2
+    assert len(_deduplicate(new_alerts, [])) == 2
 
 
 def test_deduplicate_drops_same_code_and_message():
     alert = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "drift detected"}
-    result = _deduplicate([alert], [alert])
-    assert result == []
+    assert _deduplicate([alert], [alert]) == []
 
 
 def test_deduplicate_keeps_same_code_different_message():
     prev = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "old target"}
-    new = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "new target"}
+    new  = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "new target"}
     result = _deduplicate([new], [prev])
     assert len(result) == 1
     assert result[0]["message"] == "new target"
@@ -358,18 +440,16 @@ def test_deduplicate_keeps_same_code_different_message():
 
 def test_deduplicate_keeps_different_codes():
     prev = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "drift"}
-    new = {"code": "POC_GAP", "urgency": "medium", "message": "missing"}
+    new  = {"code": "POC_GAP",    "urgency": "high", "message": "missing"}
     result = _deduplicate([new], [prev])
     assert len(result) == 1
     assert result[0]["code"] == "POC_GAP"
 
 
-def test_deduplicate_returns_new_when_urgency_changed():
-    prev = {"code": "TOOL_INACTIVITY", "urgency": "low", "message": "idle 15min"}
-    new = {"code": "TOOL_INACTIVITY", "urgency": "high", "message": "idle 15min"}
-    # Same message → deduped regardless of urgency change (dedup is by code+message)
-    result = _deduplicate([new], [prev])
-    assert result == []
+def test_deduplicate_same_message_deduped_regardless_of_urgency():
+    prev = {"code": "TOOL_INACTIVITY", "urgency": "low",  "message": "idle 15min"}
+    new  = {"code": "TOOL_INACTIVITY", "urgency": "high", "message": "idle 15min"}
+    assert _deduplicate([new], [prev]) == []
 
 
 # ---------------------------------------------------------------------------
@@ -385,8 +465,7 @@ def test_read_qa_state_returns_parsed_json(tmp_path, monkeypatch):
     qa_state = tmp_path / "qa_state.json"
     qa_state.write_text(json.dumps({"alerts": [], "ts": "2026-01-01T00:00:00+00:00"}))
     monkeypatch.setattr(core.qa_agent, "_QA_STATE_FILE", qa_state)
-    result = _read_qa_state()
-    assert result["alerts"] == []
+    assert _read_qa_state()["alerts"] == []
 
 
 def test_read_qa_state_returns_empty_on_corrupt_json(tmp_path, monkeypatch):
@@ -397,20 +476,20 @@ def test_read_qa_state_returns_empty_on_corrupt_json(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _sanitize_history()
+# _sanitize_history() — summary_sent no longer stored
 # ---------------------------------------------------------------------------
 
 def test_sanitize_history_filters_non_dicts():
-    raw = [{"ts": "2026-01-01T00:00:00+00:00", "summary_sent": "s", "alerts": [], "smith_actions": []}, "not-a-dict", 42]
-    result = _sanitize_history(raw)
-    assert len(result) == 1
+    raw = [{"ts": "2026-01-01T00:00:00+00:00", "alerts": [], "smith_actions": []},
+           "not-a-dict", 42]
+    assert len(_sanitize_history(raw)) == 1
 
 
 def test_sanitize_history_caps_field_length():
     long_ts = "X" * 100
     alerts = [{"urgency": "high", "message": "a"}] * 20
-    smith = [{"type": "TOOL"}] * 100
-    raw = [{"ts": long_ts, "summary_sent": "s", "alerts": alerts, "smith_actions": smith}]
+    smith  = [{"type": "TOOL"}] * 100
+    raw = [{"ts": long_ts, "alerts": alerts, "smith_actions": smith}]
     result = _sanitize_history(raw)
     assert len(result[0]["ts"]) <= 50
     assert len(result[0]["alerts"]) <= 10
@@ -418,45 +497,46 @@ def test_sanitize_history_caps_field_length():
 
 
 def test_sanitize_history_keeps_valid_alert_dicts():
-    raw = [{"ts": "t", "summary_sent": "s",
-            "alerts": [{"urgency": "high"}, "not-dict"],
-            "smith_actions": []}]
-    result = _sanitize_history(raw)
-    assert result[0]["alerts"] == [{"urgency": "high"}]
+    raw = [{"ts": "t", "alerts": [{"urgency": "high"}, "not-dict"], "smith_actions": []}]
+    assert _sanitize_history(raw)[0]["alerts"] == [{"urgency": "high"}]
 
 
 def test_sanitize_history_empty_list():
     assert _sanitize_history([]) == []
 
 
-def test_sanitize_history_includes_smith_reply_when_present():
-    raw = [{"ts": "t", "summary_sent": "s", "alerts": [],
-            "smith_actions": [], "smith_reply": "Acknowledged."}]
-    result = _sanitize_history(raw)
-    assert result[0]["smith_reply"] == "Acknowledged."
+def test_sanitize_history_smith_reply_preserved():
+    raw = [{"ts": "t", "alerts": [], "smith_actions": [], "smith_reply": "Acknowledged."}]
+    assert _sanitize_history(raw)[0]["smith_reply"] == "Acknowledged."
 
 
-def test_sanitize_history_smith_reply_is_none_when_absent():
-    raw = [{"ts": "t", "summary_sent": "s", "alerts": [], "smith_actions": []}]
-    result = _sanitize_history(raw)
-    assert result[0]["smith_reply"] is None
+def test_sanitize_history_smith_reply_none_when_absent():
+    raw = [{"ts": "t", "alerts": [], "smith_actions": []}]
+    assert _sanitize_history(raw)[0]["smith_reply"] is None
 
 
 def test_sanitize_history_truncates_long_smith_reply():
-    long_reply = "A" * 3000
-    raw = [{"ts": "t", "summary_sent": "s", "alerts": [],
-            "smith_actions": [], "smith_reply": long_reply}]
+    raw = [{"ts": "t", "alerts": [], "smith_actions": [], "smith_reply": "A" * 3000}]
+    assert len(_sanitize_history(raw)[0]["smith_reply"]) <= 2000
+
+
+def test_sanitize_history_no_summary_sent_in_output():
+    """summary_sent is removed — history entries should not have this field."""
+    raw = [{"ts": "t", "summary_sent": "old prompt", "alerts": [], "smith_actions": []}]
     result = _sanitize_history(raw)
-    assert len(result[0]["smith_reply"]) <= 2000
+    assert "summary_sent" not in result[0]
 
 
 # ---------------------------------------------------------------------------
-# QADaemon._cycle() — early-return guards
+# QADaemon._cycle() — guards and state
 # ---------------------------------------------------------------------------
 
-def _setup_cycle_files(tmp_path, monkeypatch, status="running"):
+def _setup_cycle_files(tmp_path, monkeypatch, status="running", session_extra=None):
+    session_data = {"status": status}
+    if session_extra:
+        session_data.update(session_extra)
     session_file = tmp_path / "session.json"
-    session_file.write_text(json.dumps({"status": status}))
+    session_file.write_text(json.dumps(session_data))
     monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
 
     qa_state = tmp_path / "qa_state.json"
@@ -471,6 +551,13 @@ def _setup_cycle_files(tmp_path, monkeypatch, status="running"):
     return qa_state
 
 
+def _mock_ql(entries=None, since=None):
+    m = MagicMock()
+    m.read_all.return_value = entries or []
+    m.read_since.return_value = since or []
+    return m
+
+
 @pytest.mark.asyncio
 async def test_cycle_skips_when_session_not_running(tmp_path, monkeypatch):
     qa_state = _setup_cycle_files(tmp_path, monkeypatch, status="complete")
@@ -482,10 +569,7 @@ async def test_cycle_skips_when_session_not_running(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_cycle_skips_when_quick_log_is_empty(tmp_path, monkeypatch):
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-
-    test_log = QuickLog(path=tmp_path / "quick_log.json")
-    monkeypatch.setattr(core.quick_log, "quick_log", test_log)
-
+    monkeypatch.setattr(core.quick_log, "quick_log", QuickLog(path=tmp_path / "ql.json"))
     daemon = QADaemon()
     await daemon._cycle()
     assert not qa_state.exists()
@@ -493,62 +577,46 @@ async def test_cycle_skips_when_quick_log_is_empty(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cycle_skips_when_no_new_alerts(tmp_path, monkeypatch):
-    """Cycle skips writing when deterministic + semantic both produce no alerts."""
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-
-    # Activity exists but no triggers in the summary
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "1 tool call: nmap"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_tool_entry(offset_min=2)]))
     daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
     await daemon._cycle()
-
     assert not qa_state.exists()
 
 
 @pytest.mark.asyncio
 async def test_cycle_writes_qa_state_with_deterministic_alert(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
+    # SPIDER entry with empty coverage → SPIDER_WITHOUT_COVERAGE fires
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_spider_entry(12)]))
     daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
     await daemon._cycle()
-
     assert qa_state.exists()
     data = json.loads(qa_state.read_text())
-    codes = [a["code"] for a in data["alerts"]]
-    assert "SCOPE_DRIFT" in codes
+    assert any(a["code"] == "SPIDER_WITHOUT_COVERAGE" for a in data["alerts"])
     assert "ts" in data
     assert "history" in data
 
 
 @pytest.mark.asyncio
 async def test_cycle_caps_alerts_at_four(tmp_path, monkeypatch):
-    """Cycle keeps at most 4 alerts."""
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_spider_entry()]))
 
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = (
-        "Possible off-scope targets used: evil.com\n"
-        "Last tool call: 20 minutes ago\n"
-        "Bulk-marking warning: 3 N/A cells lack tested_by\n"
-        "5 tested/vulnerable cells have no tested_by tool\n"
-        "WARNING: coverage stale (40 min), 5 pending"
-    )
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
-    await daemon._cycle()
+    six_alerts = [
+        {"code": f"ALERT{i}", "urgency": "high", "blocking": False, "message": f"msg{i}"}
+        for i in range(6)
+    ]
+    with patch("core.qa_agent._deterministic_qa_checks", return_value=six_alerts):
+        daemon = QADaemon()
+        await daemon._cycle()
 
     data = json.loads(qa_state.read_text())
     assert len(data["alerts"]) <= 4
@@ -556,36 +624,33 @@ async def test_cycle_caps_alerts_at_four(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cycle_captures_smith_actions_in_history(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-    # Seed previous history so prev_cycle_ts is set
+    # Seed previous history
     qa_state.write_text(json.dumps({
         "ts": "2025-12-31T00:00:00+00:00",
         "alerts": [],
-        "history": [{"ts": "2025-12-31T00:00:00+00:00", "summary_sent": "prev",
+        "history": [{"ts": "2025-12-31T00:00:00+00:00",
                      "alerts": [], "smith_actions": [], "smith_reply": None}],
     }))
-
     new_action = {"type": "TOOL", "name": "nuclei", "ts": "2099-12-31T23:59:59+00:00"}
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
-    mock_ql.read_since.return_value = [new_action]
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_spider_entry()], since=[new_action]))
     daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
     await daemon._cycle()
-
     data = json.loads(qa_state.read_text())
     assert len(data["history"]) == 2
-    smith_actions = data["history"][-1]["smith_actions"]
-    assert any(a.get("name") == "nuclei" for a in smith_actions)
+    assert any(a.get("name") == "nuclei" for a in data["history"][-1]["smith_actions"])
 
 
 @pytest.mark.asyncio
 async def test_cycle_caps_history_at_20(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
     existing_history = [
-        {"ts": f"2026-01-{i:02d}T00:00:00+00:00", "summary_sent": "s",
+        {"ts": f"2026-01-{i:02d}T00:00:00+00:00",
          "alerts": [], "smith_actions": [], "smith_reply": None}
         for i in range(1, 21)
     ]
@@ -594,370 +659,253 @@ async def test_cycle_caps_history_at_20(tmp_path, monkeypatch):
         "alerts": [],
         "history": existing_history,
     }))
-
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_spider_entry()]))
     daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
     await daemon._cycle()
-
     data = json.loads(qa_state.read_text())
     assert len(data["history"]) == 20
 
 
 @pytest.mark.asyncio
 async def test_cycle_handles_corrupt_qa_state_gracefully(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
     qa_state.write_text("not valid json {{{")
-
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_spider_entry()]))
     daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
     await daemon._cycle()
-
     data = json.loads(qa_state.read_text())
     assert len(data["history"]) == 1
 
 
 @pytest.mark.asyncio
-async def test_cycle_invokes_semantic_review_for_high_findings(tmp_path, monkeypatch):
-    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-
-    findings_file = tmp_path / "findings.json"
-    findings_file.write_text(json.dumps({
-        "findings": [
-            {"title": "SQLi", "severity": "critical",
-             "description": "Classic injection", "evidence": "payload", "poc_files": ["poc.http"]},
-        ]
-    }))
-    monkeypatch.setattr(core.qa_agent, "_FINDINGS_FILE", findings_file)
-
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "1 tool call: sqlmap"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
-    semantic_alerts = [{"code": "FINDING_QUALITY", "urgency": "medium",
-                        "blocking": False, "message": "Severity appears overclaimed"}]
-    mock_graph = MagicMock()
-
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    with patch("asyncio.to_thread", new=AsyncMock(return_value={"alerts": semantic_alerts})):
-        await daemon._cycle()
-
-    data = json.loads(qa_state.read_text())
-    codes = [a["code"] for a in data["alerts"]]
-    assert "FINDING_QUALITY" in codes
-
-
-@pytest.mark.asyncio
-async def test_cycle_skips_semantic_review_when_no_high_findings(tmp_path, monkeypatch):
-    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-
-    findings_file = tmp_path / "findings.json"
-    findings_file.write_text(json.dumps({
-        "findings": [
-            {"title": "Minor info", "severity": "info", "description": "d"},
-        ]
-    }))
-    monkeypatch.setattr(core.qa_agent, "_FINDINGS_FILE", findings_file)
-
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "Possible off-scope targets used: evil.com"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
-    invoke_called = []
-    mock_graph = MagicMock()
-    mock_graph.invoke = lambda *a, **kw: invoke_called.append(True) or {"alerts": []}
-
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    with patch("asyncio.to_thread", new=AsyncMock(side_effect=AssertionError("should not call"))):
-        await daemon._cycle()
-
-    assert not invoke_called
-
-
-@pytest.mark.asyncio
-async def test_cycle_handles_semantic_review_exception(tmp_path, monkeypatch):
-    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-
-    findings_file = tmp_path / "findings.json"
-    findings_file.write_text(json.dumps({
-        "findings": [
-            {"title": "SQLi", "severity": "critical", "description": "d", "poc_files": ["poc.http"]},
-        ]
-    }))
-    monkeypatch.setattr(core.qa_agent, "_FINDINGS_FILE", findings_file)
-
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "1 tool call: sqlmap"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
-    mock_graph = MagicMock()
-    daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: mock_graph)
-
-    # Semantic review raises an exception — cycle should not crash
-    with patch("asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("LLM timeout"))):
-        await daemon._cycle()  # should not raise
-
-
-@pytest.mark.asyncio
 async def test_cycle_skips_write_when_alerts_unchanged(tmp_path, monkeypatch):
-    """When no new alerts are generated, qa_state is not rewritten."""
     qa_state = _setup_cycle_files(tmp_path, monkeypatch)
-
-    # Pre-seed qa_state with an existing alert
     existing_alert = {"code": "SCOPE_DRIFT", "urgency": "high", "blocking": False,
-                      "message": "Possible off-scope targets used: evil.com"}
+                      "message": "Scope drift: tools ran against evil.com"}
     qa_state.write_text(json.dumps({
         "ts": "2026-01-01T00:00:00+00:00",
         "alerts": [existing_alert],
         "history": [],
     }))
-
-    # Summary produces no deterministic alerts, no high/critical findings
-    mock_ql = MagicMock()
-    mock_ql.summarize.return_value = "1 tool call: nmap"
-    mock_ql.read_since.return_value = []
-    monkeypatch.setattr(core.quick_log, "quick_log", mock_ql)
-
+    # Entries that produce no deterministic alerts
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_tool_entry(offset_min=2)]))
     daemon = QADaemon()
-    monkeypatch.setattr(daemon, "_get_graph", lambda: None)
-
     mtime_before = qa_state.stat().st_mtime
     await daemon._cycle()
     assert qa_state.stat().st_mtime == mtime_before
 
 
-# ---------------------------------------------------------------------------
-# _init_llm()
-# ---------------------------------------------------------------------------
-
-def test_init_llm_openai_provider():
-    mock_cls = MagicMock(return_value=MagicMock())
-    with patch.dict("sys.modules", {"langchain_openai": MagicMock(ChatOpenAI=mock_cls)}):
-        result = _init_llm("openai:gpt-4o-mini")
-    mock_cls.assert_called_once_with(model="gpt-4o-mini", max_tokens=512)
-
-
-def test_init_llm_anthropic_provider():
-    mock_cls = MagicMock(return_value=MagicMock())
-    with patch.dict("sys.modules", {"langchain_anthropic": MagicMock(ChatAnthropic=mock_cls)}):
-        result = _init_llm("anthropic:claude-haiku-4-5-20251001")
-    mock_cls.assert_called_once_with(model="claude-haiku-4-5-20251001", max_tokens=512)
-
-
-def test_init_llm_ollama_provider():
-    mock_cls = MagicMock(return_value=MagicMock())
-    with patch.dict("sys.modules", {"langchain_ollama": MagicMock(ChatOllama=mock_cls)}):
-        result = _init_llm("ollama:qwen2.5:7b")
-    mock_cls.assert_called_once_with(model="qwen2.5:7b", num_predict=512)
-
-
-def test_init_llm_unknown_provider_raises():
-    with pytest.raises(ValueError, match="Unknown QA_MODEL provider"):
-        _init_llm("fakevendor:some-model")
-
-
-def test_init_llm_no_colon_defaults_to_openai():
-    mock_cls = MagicMock(return_value=MagicMock())
-    with patch.dict("sys.modules", {"langchain_openai": MagicMock(ChatOpenAI=mock_cls)}):
-        _init_llm("gpt-4o-mini")
-    mock_cls.assert_called_once_with(model="gpt-4o-mini", max_tokens=512)
-
-
-# ---------------------------------------------------------------------------
-# _build_graph()
-# ---------------------------------------------------------------------------
-
-def test_build_graph_returns_none_when_langgraph_missing():
-    with patch.dict("sys.modules", {"langgraph": None, "langgraph.graph": None,
-                                     "langchain_core": None, "langchain_core.messages": None}):
-        result = _build_graph()
-    assert result is None
-
-
-def test_build_graph_returns_none_when_llm_init_fails(monkeypatch):
-    mock_state_graph = MagicMock()
-    mock_graph_instance = MagicMock()
-    mock_state_graph.return_value = mock_graph_instance
-
-    fake_langgraph = MagicMock()
-    fake_langgraph.graph.StateGraph = mock_state_graph
-    fake_langgraph.graph.END = "END"
-
-    fake_lc_core = MagicMock()
-
-    with patch.dict("sys.modules", {
-        "langgraph": fake_langgraph,
-        "langgraph.graph": fake_langgraph.graph,
-        "langchain_core": fake_lc_core,
-        "langchain_core.messages": fake_lc_core.messages,
-    }):
-        monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
-        with patch("core.qa_agent._init_llm", side_effect=Exception("no key")):
-            result = _build_graph()
-    assert result is None
-
-
-def test_build_graph_returns_compiled_graph(monkeypatch):
-    mock_compiled = MagicMock()
-    mock_sg_instance = MagicMock()
-    mock_sg_instance.compile.return_value = mock_compiled
-    mock_sg_cls = MagicMock(return_value=mock_sg_instance)
-
-    fake_langgraph_graph = MagicMock()
-    fake_langgraph_graph.StateGraph = mock_sg_cls
-    fake_langgraph_graph.END = "END"
-
-    fake_lc_core_messages = MagicMock()
-
-    with patch.dict("sys.modules", {
-        "langgraph": MagicMock(graph=fake_langgraph_graph),
-        "langgraph.graph": fake_langgraph_graph,
-        "langchain_core": MagicMock(messages=fake_lc_core_messages),
-        "langchain_core.messages": fake_lc_core_messages,
-    }):
-        monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
-        mock_llm = MagicMock()
-        with patch("core.qa_agent._init_llm", return_value=mock_llm):
-            result = _build_graph()
-
-    assert result is mock_compiled
-
-
-# ---------------------------------------------------------------------------
-# QADaemon._get_graph() — lazy-builds only once
-# ---------------------------------------------------------------------------
-
-def test_get_graph_builds_once(monkeypatch):
-    build_calls = []
-
-    def fake_build():
-        build_calls.append(1)
-        return MagicMock()
-
+@pytest.mark.asyncio
+async def test_cycle_history_has_no_summary_sent(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    qa_state = _setup_cycle_files(tmp_path, monkeypatch)
+    monkeypatch.setattr(core.quick_log, "quick_log",
+                        _mock_ql(entries=[_spider_entry()]))
     daemon = QADaemon()
-    with patch("core.qa_agent._build_graph", side_effect=fake_build):
-        daemon._get_graph()
-        daemon._get_graph()
-
-    assert len(build_calls) == 1
+    await daemon._cycle()
+    data = json.loads(qa_state.read_text())
+    for entry in data["history"]:
+        assert "summary_sent" not in entry
 
 
 # ---------------------------------------------------------------------------
-# _build_graph() — node execution (invoke_llm + parse_response)
+# _merge_alerts() — fixed dedup
 # ---------------------------------------------------------------------------
 
-def test_build_graph_nodes_parse_valid_json(monkeypatch):
-    """Exercises invoke_llm and parse_response nodes with a mocked LLM."""
+def test_merge_alerts_changed_alerts_first():
+    new_alert  = {"code": "POC_GAP",    "urgency": "high", "message": "new"}
+    persistent = {"code": "SCOPE_DRIFT","urgency": "high", "message": "drift"}
+    result = _merge_alerts([new_alert], [new_alert, persistent], cap=4)
+    assert result[0]["code"] == "POC_GAP"
+
+
+def test_merge_alerts_preserves_persistent_when_new_fires():
+    persistent1 = {"code": "SCOPE_DRIFT",    "urgency": "high",   "message": "drift"}
+    persistent2 = {"code": "COVERAGE_STALL", "urgency": "medium", "message": "stale"}
+    new_alert   = {"code": "POC_GAP",        "urgency": "high",   "message": "new poc"}
+    result = _merge_alerts([new_alert], [new_alert, persistent1, persistent2], cap=4)
+    codes = {a["code"] for a in result}
+    assert codes == {"POC_GAP", "SCOPE_DRIFT", "COVERAGE_STALL"}
+
+
+def test_merge_alerts_respects_cap():
+    alerts = [{"code": f"A{i}", "urgency": "low", "message": f"m{i}"} for i in range(6)]
+    assert len(_merge_alerts(alerts, alerts, cap=4)) == 4
+
+
+def test_merge_alerts_no_duplicate_codes():
+    a = {"code": "SCOPE_DRIFT", "urgency": "high", "message": "same"}
+    assert len(_merge_alerts([a], [a], cap=4)) == 1
+
+
+def test_merge_alerts_empty_inputs():
+    assert _merge_alerts([], []) == []
+
+
+# ---------------------------------------------------------------------------
+# _check_injection_breadth
+# ---------------------------------------------------------------------------
+
+def _make_cell(ep_id, param, param_type, injection_type, status="pending"):
+    return {"id": f"cell-{ep_id}-{param}-{injection_type}", "endpoint_id": ep_id,
+            "param": param, "param_type": param_type, "injection_type": injection_type,
+            "status": status}
+
+
+def test_injection_breadth_no_matrix():
+    assert _check_injection_breadth({"matrix": []}) is None
+
+
+def test_injection_breadth_no_sqli_cells():
+    matrix = [_make_cell("ep1", "q", "query", "xss")]
+    assert _check_injection_breadth({"matrix": matrix}) is None
+
+
+def test_injection_breadth_full_coverage():
+    matrix = [_make_cell("ep1", "q", "query", t)
+              for t in ("sqli", "xss", "ssti", "ssrf", "cmdi")]
+    assert _check_injection_breadth({"matrix": matrix}) is None
+
+
+def test_injection_breadth_missing_types():
+    matrix = [_make_cell("ep1", "username", "body_json", "sqli")]
+    alert = _check_injection_breadth({"matrix": matrix})
+    assert alert is not None
+    assert alert["code"] == "INJECTION_BREADTH_GAP"
+    assert alert["urgency"] == "high"
+    assert "username" in alert["message"]
+
+
+def test_injection_breadth_endpoint_param_skipped():
+    matrix = [{"id": "c1", "endpoint_id": "ep1", "param": "_endpoint",
+               "param_type": "endpoint", "injection_type": "sqli", "status": "pending"}]
+    assert _check_injection_breadth({"matrix": matrix}) is None
+
+
+def test_injection_breadth_partial_missing():
+    matrix = [_make_cell("ep1", "id", "query", "sqli"),
+              _make_cell("ep1", "id", "query", "xss")]
+    alert = _check_injection_breadth({"matrix": matrix})
+    assert alert is not None
+    assert "ssti" in alert["message"] or "ssrf" in alert["message"]
+
+
+# ---------------------------------------------------------------------------
+# _check_endpoint_trigger_gaps
+# ---------------------------------------------------------------------------
+
+def _gate(gid, required, status="pending", triggered_at=None, trigger="api endpoint"):
+    return {"id": gid, "status": status, "required_skills": required,
+            "triggered_at": triggered_at or _ts(0), "trigger": trigger}
+
+
+def test_trigger_gaps_no_gates():
+    assert _check_endpoint_trigger_gaps({}) == []
+
+
+def test_trigger_gaps_satisfied_gate_skipped():
+    sd = {"gates": [_gate("g1", ["api-security"], status="satisfied")], "skill_history": []}
+    assert _check_endpoint_trigger_gaps(sd) == []
+
+
+def test_trigger_gaps_all_skills_satisfied():
+    sd = {"gates": [_gate("g1", ["api-security"])],
+          "skill_history": [{"skill": "api-security"}]}
+    assert _check_endpoint_trigger_gaps(sd) == []
+
+
+def test_trigger_gaps_missing_skill_fires_alert():
+    sd = {"gates": [_gate("g1", ["api-security"])], "skill_history": []}
+    alerts = _check_endpoint_trigger_gaps(sd)
+    assert len(alerts) == 1
+    assert alerts[0]["code"] == "ENDPOINT_TRIGGER_GAP"
+    assert "/api-security" in alerts[0]["message"]
+
+
+def test_trigger_gaps_elapsed_over_15_is_high(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+    sd = {"gates": [_gate("g1", ["credential-audit"], triggered_at=_ts(20))],
+          "skill_history": []}
+    alerts = _check_endpoint_trigger_gaps(sd)
+    assert alerts[0]["urgency"] == "high"
+
+
+def test_trigger_gaps_elapsed_under_15_is_medium():
+    sd = {"gates": [_gate("g1", ["credential-audit"], triggered_at=_ts(0))],
+          "skill_history": []}
+    assert _check_endpoint_trigger_gaps(sd)[0]["urgency"] == "medium"
+
+
+def test_trigger_gaps_bad_timestamp_defaults_to_zero():
+    sd = {"gates": [{"id": "g1", "status": "pending", "required_skills": ["web-exploit"],
+                     "triggered_at": "not-a-date", "trigger": "upload"}],
+          "skill_history": []}
+    alerts = _check_endpoint_trigger_gaps(sd)
+    assert len(alerts) == 1
+    assert alerts[0]["urgency"] == "medium"
+
+
+# ---------------------------------------------------------------------------
+# _check_coverage_gap
+# ---------------------------------------------------------------------------
+
+def test_coverage_gap_no_endpoints():
+    assert _check_coverage_gap({"endpoints": []}, {}) == []
+
+
+def test_coverage_gap_unclassified_endpoint_ignored():
+    cov = {"endpoints": [{"path": "/static/image.png"}]}
+    assert _check_coverage_gap(cov, {}) == []
+
+
+def test_coverage_gap_skill_already_run():
+    cov = {"endpoints": [{"path": "/graphql"}]}
+    sd  = {"skill_history": [{"skill": "api-security"}]}
+    assert _check_coverage_gap(cov, sd) == []
+
+
+def test_coverage_gap_skill_missing_fires_alert():
+    cov = {"endpoints": [{"path": "/graphql"}]}
+    alerts = _check_coverage_gap(cov, {"skill_history": []})
+    assert len(alerts) == 1
+    assert alerts[0]["code"] == "COVERAGE_GAP"
+    assert "api-security" in alerts[0]["message"]
+
+
+def test_coverage_gap_multiple_same_type_grouped():
+    cov = {"endpoints": [{"path": "/graphql"}, {"path": "/graph/query"}]}
+    alerts = _check_coverage_gap(cov, {"skill_history": []})
+    assert len(alerts) == 1
+    assert "2 graphql" in alerts[0]["message"]
+
+
+def test_coverage_gap_financial_endpoint_flags_business_logic():
+    cov = {"endpoints": [{"path": "/api/payment"}]}
+    alerts = _check_coverage_gap(cov, {"skill_history": []})
+    assert any("business-logic" in a["message"] for a in alerts)
+
+
+def test_coverage_gap_import_error_returns_empty(monkeypatch):
+    import sys
+    import types
+    original = sys.modules.get("core.coverage")
+    broken = types.ModuleType("core.coverage")
+    sys.modules["core.coverage"] = broken
     try:
-        from langgraph.graph import StateGraph  # noqa: F401
-    except ImportError:
-        pytest.skip("langgraph not installed")
-
-    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
-    mock_llm = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = json.dumps({
-        "alerts": [
-            {"code": "FINDING_QUALITY", "urgency": "high",
-             "blocking": False, "message": "severity overclaimed"}
-        ]
-    })
-    mock_llm.invoke.return_value = mock_response
-
-    with patch("core.qa_agent._init_llm", return_value=mock_llm):
-        graph = _build_graph()
-
-    assert graph is not None
-    result = graph.invoke({"summary": "test findings", "raw_response": "", "alerts": []})
-    assert len(result["alerts"]) == 1
-    assert result["alerts"][0]["code"] == "FINDING_QUALITY"
-    assert result["alerts"][0]["urgency"] == "high"
-
-
-def test_build_graph_nodes_handle_invalid_json(monkeypatch):
-    """parse_response should return empty alerts for non-JSON LLM output."""
-    try:
-        from langgraph.graph import StateGraph  # noqa: F401
-    except ImportError:
-        pytest.skip("langgraph not installed")
-
-    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
-    mock_llm = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = "not valid json at all"
-    mock_llm.invoke.return_value = mock_response
-
-    with patch("core.qa_agent._init_llm", return_value=mock_llm):
-        graph = _build_graph()
-
-    assert graph is not None
-    result = graph.invoke({"summary": "test", "raw_response": "", "alerts": []})
-    assert result["alerts"] == []
-
-
-def test_build_graph_nodes_filter_alerts_without_message(monkeypatch):
-    """parse_response drops alert dicts that have no 'message' field."""
-    try:
-        from langgraph.graph import StateGraph  # noqa: F401
-    except ImportError:
-        pytest.skip("langgraph not installed")
-
-    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
-    mock_llm = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = json.dumps({
-        "alerts": [
-            {"code": "FINDING_QUALITY", "urgency": "high"},  # no message → filtered
-            {"code": "FINDING_QUALITY", "urgency": "medium", "message": "real alert"},
-        ]
-    })
-    mock_llm.invoke.return_value = mock_response
-
-    with patch("core.qa_agent._init_llm", return_value=mock_llm):
-        graph = _build_graph()
-
-    assert graph is not None
-    result = graph.invoke({"summary": "test", "raw_response": "", "alerts": []})
-    assert len(result["alerts"]) == 1
-    assert result["alerts"][0]["message"] == "real alert"
-
-
-def test_build_graph_nodes_handle_non_list_alerts(monkeypatch):
-    """parse_response should produce empty alerts when JSON alerts field is not a list."""
-    try:
-        from langgraph.graph import StateGraph  # noqa: F401
-    except ImportError:
-        pytest.skip("langgraph not installed")
-
-    monkeypatch.setenv("QA_MODEL", "openai:gpt-4o-mini")
-    mock_llm = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = json.dumps({"alerts": "not-a-list"})
-    mock_llm.invoke.return_value = mock_response
-
-    with patch("core.qa_agent._init_llm", return_value=mock_llm):
-        graph = _build_graph()
-
-    assert graph is not None
-    result = graph.invoke({"summary": "test", "raw_response": "", "alerts": []})
-    assert result["alerts"] == []
+        from core.qa_agent import _check_coverage_gap
+        assert _check_coverage_gap({"endpoints": [{"path": "/graphql"}]}, {}) == []
+    finally:
+        if original is not None:
+            sys.modules["core.coverage"] = original
+        else:
+            sys.modules.pop("core.coverage", None)
 
 
 # ---------------------------------------------------------------------------
@@ -966,7 +914,6 @@ def test_build_graph_nodes_handle_non_list_alerts(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_calls_cycle_and_swallows_exceptions(tmp_path, monkeypatch):
-    """run() must not propagate _cycle() exceptions and must keep looping."""
     session_file = tmp_path / "session.json"
     session_file.write_text(json.dumps({"status": "running"}))
     monkeypatch.setattr(core.qa_agent, "_SESSION_FILE", session_file)
@@ -990,218 +937,3 @@ async def test_run_calls_cycle_and_swallows_exceptions(tmp_path, monkeypatch):
             pass
 
     assert call_count == 2
-
-
-# ── _check_injection_breadth ──────────────────────────────────────────────────
-
-def _make_cell(ep_id, param, param_type, injection_type, status="pending"):
-    return {
-        "id": f"cell-{ep_id}-{param}-{injection_type}",
-        "endpoint_id": ep_id,
-        "param": param,
-        "param_type": param_type,
-        "injection_type": injection_type,
-        "status": status,
-    }
-
-
-def test_injection_breadth_no_matrix():
-    result = core.qa_agent._check_injection_breadth({"matrix": []})
-    assert result is None
-
-
-def test_injection_breadth_no_sqli_cells():
-    """Params without sqli cells are ignored."""
-    matrix = [_make_cell("ep1", "q", "query", "xss")]
-    result = core.qa_agent._check_injection_breadth({"matrix": matrix})
-    assert result is None
-
-
-def test_injection_breadth_full_coverage():
-    """Param has sqli + all four breadth types — no alert."""
-    matrix = [
-        _make_cell("ep1", "q", "query", "sqli"),
-        _make_cell("ep1", "q", "query", "xss"),
-        _make_cell("ep1", "q", "query", "ssti"),
-        _make_cell("ep1", "q", "query", "ssrf"),
-        _make_cell("ep1", "q", "query", "cmdi"),
-    ]
-    result = core.qa_agent._check_injection_breadth({"matrix": matrix})
-    assert result is None
-
-
-def test_injection_breadth_missing_types():
-    """Param has sqli but is missing xss/ssti/ssrf/cmdi — alert fires."""
-    matrix = [_make_cell("ep1", "username", "body_json", "sqli")]
-    result = core.qa_agent._check_injection_breadth({"matrix": matrix})
-    assert result is not None
-    assert result["code"] == "INJECTION_BREADTH_GAP"
-    assert result["urgency"] == "high"
-    assert "username" in result["message"]
-    assert "xss" in result["message"]
-
-
-def test_injection_breadth_endpoint_param_skipped():
-    """_endpoint params are never checked for breadth."""
-    matrix = [
-        {"id": "c1", "endpoint_id": "ep1", "param": "_endpoint",
-         "param_type": "endpoint", "injection_type": "sqli", "status": "pending"},
-    ]
-    result = core.qa_agent._check_injection_breadth({"matrix": matrix})
-    assert result is None
-
-
-def test_injection_breadth_partial_missing():
-    """Alert message lists which types are missing."""
-    matrix = [
-        _make_cell("ep1", "id", "query", "sqli"),
-        _make_cell("ep1", "id", "query", "xss"),
-        # missing ssti, ssrf, cmdi
-    ]
-    result = core.qa_agent._check_injection_breadth({"matrix": matrix})
-    assert result is not None
-    assert "ssti" in result["message"] or "ssrf" in result["message"]
-
-
-# ---------------------------------------------------------------------------
-# _check_endpoint_trigger_gaps
-# ---------------------------------------------------------------------------
-
-from core.qa_agent import _check_endpoint_trigger_gaps, _check_coverage_gap
-from datetime import datetime, timezone, timedelta
-
-
-def _gate(gid, required, status="pending", triggered_at=None, trigger="api endpoint"):
-    return {
-        "id": gid,
-        "status": status,
-        "required_skills": required,
-        "triggered_at": triggered_at or datetime.now(timezone.utc).isoformat(),
-        "trigger": trigger,
-    }
-
-
-def test_trigger_gaps_no_gates():
-    assert _check_endpoint_trigger_gaps({}) == []
-
-
-def test_trigger_gaps_satisfied_gate_skipped():
-    sd = {"gates": [_gate("g1", ["api-security"], status="satisfied")], "skill_history": []}
-    assert _check_endpoint_trigger_gaps(sd) == []
-
-
-def test_trigger_gaps_all_skills_satisfied():
-    sd = {
-        "gates": [_gate("g1", ["api-security"])],
-        "skill_history": [{"skill": "api-security"}],
-    }
-    assert _check_endpoint_trigger_gaps(sd) == []
-
-
-def test_trigger_gaps_missing_skill_fires_alert():
-    sd = {
-        "gates": [_gate("g1", ["api-security"])],
-        "skill_history": [],
-    }
-    alerts = _check_endpoint_trigger_gaps(sd)
-    assert len(alerts) == 1
-    assert alerts[0]["code"] == "ENDPOINT_TRIGGER_GAP"
-    assert "/api-security" in alerts[0]["message"]
-
-
-def test_trigger_gaps_elapsed_over_15_is_high():
-    old_time = (datetime.now(timezone.utc) - timedelta(minutes=20)).isoformat()
-    sd = {
-        "gates": [_gate("g1", ["credential-audit"], triggered_at=old_time)],
-        "skill_history": [],
-    }
-    alerts = _check_endpoint_trigger_gaps(sd)
-    assert alerts[0]["urgency"] == "high"
-
-
-def test_trigger_gaps_elapsed_under_15_is_medium():
-    recent = datetime.now(timezone.utc).isoformat()
-    sd = {
-        "gates": [_gate("g1", ["credential-audit"], triggered_at=recent)],
-        "skill_history": [],
-    }
-    alerts = _check_endpoint_trigger_gaps(sd)
-    assert alerts[0]["urgency"] == "medium"
-
-
-def test_trigger_gaps_bad_timestamp_defaults_to_zero():
-    sd = {
-        "gates": [{"id": "g1", "status": "pending", "required_skills": ["web-exploit"],
-                   "triggered_at": "not-a-date", "trigger": "upload"}],
-        "skill_history": [],
-    }
-    alerts = _check_endpoint_trigger_gaps(sd)
-    assert len(alerts) == 1
-    assert alerts[0]["urgency"] == "medium"  # elapsed=0 < 15
-
-
-# ---------------------------------------------------------------------------
-# _check_coverage_gap
-# ---------------------------------------------------------------------------
-
-def test_coverage_gap_no_endpoints():
-    assert _check_coverage_gap({"endpoints": []}, {}) == []
-
-
-def test_coverage_gap_unclassified_endpoint_ignored():
-    cov = {"endpoints": [{"path": "/static/image.png"}]}
-    assert _check_coverage_gap(cov, {}) == []
-
-
-def test_coverage_gap_skill_already_run():
-    cov = {"endpoints": [{"path": "/graphql"}]}
-    sd = {"skill_history": [{"skill": "api-security"}]}
-    assert _check_coverage_gap(cov, sd) == []
-
-
-def test_coverage_gap_skill_missing_fires_alert():
-    cov = {"endpoints": [{"path": "/graphql"}]}
-    sd = {"skill_history": []}
-    alerts = _check_coverage_gap(cov, sd)
-    assert len(alerts) == 1
-    assert alerts[0]["code"] == "COVERAGE_GAP"
-    assert "api-security" in alerts[0]["message"]
-
-
-def test_coverage_gap_multiple_same_type_grouped():
-    cov = {"endpoints": [{"path": "/graphql"}, {"path": "/graph/query"}]}
-    sd = {"skill_history": []}
-    alerts = _check_coverage_gap(cov, sd)
-    # Both are graphql type — grouped into one alert
-    assert len(alerts) == 1
-    assert "2 graphql" in alerts[0]["message"]
-
-
-def test_coverage_gap_financial_endpoint_flags_business_logic():
-    cov = {"endpoints": [{"path": "/api/payment"}]}
-    sd = {"skill_history": []}
-    alerts = _check_coverage_gap(cov, sd)
-    assert any("business-logic" in a["message"] for a in alerts)
-
-
-def test_coverage_gap_import_error_returns_empty(monkeypatch):
-    """Exception during classify_endpoint import → returns []."""
-    import sys
-    # Remove core.coverage from sys.modules so the dynamic import triggers
-    # a fresh import, then patch it so it raises AttributeError on access
-    original = sys.modules.get("core.coverage")
-    # Replace core.coverage with a module-like object missing classify_endpoint
-    import types
-    broken = types.ModuleType("core.coverage")
-    # No classify_endpoint attribute → accessing it raises AttributeError
-    sys.modules["core.coverage"] = broken
-    try:
-        from core.qa_agent import _check_coverage_gap
-        cov = {"endpoints": [{"path": "/graphql"}]}
-        result = _check_coverage_gap(cov, {})
-        assert result == []
-    finally:
-        if original is not None:
-            sys.modules["core.coverage"] = original
-        else:
-            sys.modules.pop("core.coverage", None)

--- a/tests/test_recovery_integration.py
+++ b/tests/test_recovery_integration.py
@@ -1,0 +1,182 @@
+"""
+Integration tests for the context recovery flow.
+
+These tests verify the full recovery pipeline:
+  - session start + coverage + findings written to disk
+  - session(action='recovery') returns correct in_progress_cells with notes
+  - set_skill resume detection returns recovery brief inline
+  - recovery brief finding count matches findings.json
+"""
+import asyncio
+import json
+import pytest
+from unittest.mock import patch, AsyncMock
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_session(tmp_path, monkeypatch):
+    """Redirect all disk state to tmp_path and start a running session."""
+    import core.session as scan_session
+    import core.coverage as cov_mod
+    import core.findings as findings_mod
+
+    monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+    monkeypatch.setattr(cov_mod, "COVERAGE_FILE", tmp_path / "coverage_matrix.json")
+    monkeypatch.setattr(findings_mod, "FINDINGS_FILE", tmp_path / "findings.json")
+
+    scan_session.start("https://example.com", depth="thorough", scope=["example.com"])
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Test: recovery brief contains in_progress cells with notes
+# ---------------------------------------------------------------------------
+
+def test_recovery_brief_contains_in_progress_cells(tmp_session, monkeypatch):
+    import core.coverage as cov_mod
+    import core.session as scan_session
+
+    monkeypatch.setattr(cov_mod, "COVERAGE_FILE", tmp_session / "coverage_matrix.json")
+
+    # Register an endpoint (sync version via direct matrix manipulation)
+    matrix_data = {
+        "meta": {"total_cells": 2, "tested": 0, "vulnerable": 0, "addressed": 0},
+        "endpoints": [{"id": "ep-1", "path": "/api/users", "method": "GET"}],
+        "matrix": [
+            {
+                "id": "cell-001",
+                "endpoint_id": "ep-1",
+                "param": "id",
+                "injection_type": "sqli",
+                "status": "in_progress",
+                "notes": "Union blocked. Trying blind time-based. 10s delay promising.",
+                "finding_id": None,
+            },
+            {
+                "id": "cell-002",
+                "endpoint_id": "ep-1",
+                "param": "name",
+                "injection_type": "xss",
+                "status": "pending",
+                "notes": "",
+                "finding_id": None,
+            },
+        ],
+    }
+    (tmp_session / "coverage_matrix.json").write_text(json.dumps(matrix_data))
+
+    from mcp_server.session_tools import _do_recovery
+    brief = json.loads(_do_recovery())
+
+    # The in_progress cell drives EXECUTE_NOW and action_required
+    execute_now = brief.get("EXECUTE_NOW", "")
+    action_required = brief.get("action_required", [])
+    assert "in_progress" in str(action_required).lower() or "cell-001" in execute_now or "sqli" in execute_now
+    # Coverage should reflect the pending cells
+    assert brief.get("coverage") is not None
+
+
+# ---------------------------------------------------------------------------
+# Test: recovery brief finding count matches findings.json
+# ---------------------------------------------------------------------------
+
+def test_recovery_brief_finding_count_matches_findings_json(tmp_session, monkeypatch):
+    import core.findings as findings_mod
+    import asyncio
+
+    monkeypatch.setattr(findings_mod, "FINDINGS_FILE", tmp_session / "findings.json")
+    monkeypatch.setattr(findings_mod, "_lock", asyncio.Lock())
+
+    # Write 3 findings directly
+    findings_data = {
+        "meta": {"target": "https://example.com"},
+        "findings": [
+            {"id": "f-001", "title": "SQLi in /api/users", "severity": "critical",
+             "status": "confirmed", "escalation_leads": [
+                 {"lead": "Dump users table", "status": "pending"}
+             ]},
+            {"id": "f-002", "title": "XSS in search", "severity": "high",
+             "status": "confirmed", "escalation_leads": []},
+            {"id": "f-003", "title": "SSRF via callback", "severity": "high",
+             "status": "confirmed", "escalation_leads": []},
+        ],
+        "diagrams": [],
+    }
+    (tmp_session / "findings.json").write_text(json.dumps(findings_data))
+
+    from mcp_server.session_tools import _do_recovery
+    brief = json.loads(_do_recovery())
+
+    # findings count should reflect the 3 we wrote
+    assert brief.get("findings", 0) == 3
+
+    # pending_escalations should include the SQLi finding's lead
+    escalations = brief.get("pending_escalations", [])
+    assert any(e["finding_id"] == "f-001" for e in escalations)
+    assert any("Dump users table" in e.get("pending_leads", []) for e in escalations)
+
+
+# ---------------------------------------------------------------------------
+# Test: set_skill resume detection returns recovery brief on second invocation
+# ---------------------------------------------------------------------------
+
+def test_set_skill_resume_detection(tmp_session, monkeypatch):
+    import core.session as scan_session
+    import core.steering as st_mod
+
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_session / "steering_queue.json")
+
+    from mcp_server.session_tools import _do_set_skill
+
+    # First invocation — not a resume
+    result1 = _do_set_skill({"skill": "pentester", "reason": "starting pentest"})
+    assert "RESUME DETECTED" not in result1
+
+    # Second invocation of same skill — should trigger resume detection
+    result2 = _do_set_skill({"skill": "pentester", "reason": "re-invoking after compaction"})
+    assert "RESUME DETECTED" in result2
+    # The recovery brief JSON should be embedded
+    assert "EXECUTE_NOW" in result2 or "status" in result2
+
+
+# ---------------------------------------------------------------------------
+# Test: same-target session start appends recovery brief
+# ---------------------------------------------------------------------------
+
+def test_same_target_start_includes_recovery_state(tmp_session, monkeypatch):
+    import core.session as scan_session
+    import core.findings as findings_mod
+    import core.coverage as cov_mod
+
+    monkeypatch.setattr(findings_mod, "FINDINGS_FILE", tmp_session / "findings.json")
+    monkeypatch.setattr(cov_mod, "COVERAGE_FILE", tmp_session / "coverage_matrix.json")
+
+    # Write a coverage matrix so has_data is True
+    cov_data = {
+        "meta": {"total_cells": 1, "tested": 0, "addressed": 0},
+        "endpoints": [{"id": "ep-1", "path": "/", "method": "GET"}],
+        "matrix": [{"id": "c-1", "endpoint_id": "ep-1", "param": "q",
+                     "injection_type": "sqli", "status": "pending", "notes": ""}],
+    }
+    (tmp_session / "coverage_matrix.json").write_text(json.dumps(cov_data))
+
+    from mcp_server.session_tools import _do_start
+    with patch("mcp_server.session_tools._do_recovery", return_value='{"status":"running","EXECUTE_NOW":"resume"}'):
+        result = _do_start({
+            "target": "https://example.com",  # same target
+            "depth": "thorough",
+        })
+
+    assert "recovery" in result.lower() or "resume" in result.lower() or "RESUME" in result

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for core.steering — SteeringQueue and SteeringDirective.
+"""
+import pytest
+from core.steering import (
+    SteeringQueue,
+    RESUME_REQUIRED,
+    CHAIN_REQUIRED,
+    RESUME_TESTING,
+)
+
+
+@pytest.fixture
+def queue(tmp_path, monkeypatch):
+    """Isolated SteeringQueue backed by a temp file."""
+    import core.steering as st_mod
+    steering_file = tmp_path / "steering_queue.json"
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", steering_file)
+    q = SteeringQueue()
+    # Patch the module-level file reference used inside the queue instance
+    import unittest.mock as mock
+    with mock.patch.object(q, "_load", wraps=lambda: (
+        __import__("json").loads(steering_file.read_text()).get("directives", [])
+        if steering_file.exists() else []
+    )):
+        pass
+    # Simpler: just monkeypatch _STEERING_FILE at class-method level
+    # The queue reads _STEERING_FILE from the module global directly
+    return q, steering_file
+
+
+# Use a simpler fixture that just patches the module global
+@pytest.fixture
+def q(tmp_path, monkeypatch):
+    import core.steering as st_mod
+    steering_file = tmp_path / "steering_queue.json"
+    monkeypatch.setattr(st_mod, "_STEERING_FILE", steering_file)
+    return SteeringQueue()
+
+
+class TestAddDirective:
+    def test_creates_entry_in_file(self, q, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q2 = SteeringQueue()
+        directive_id = q2.add_directive(
+            code=CHAIN_REQUIRED,
+            message="CHAIN NOW: /web-exploit",
+            priority="high",
+            skill="web-exploit",
+            trigger="SKILL_CHAIN_GAP",
+        )
+        assert directive_id is not None
+        assert directive_id.startswith("steer-")
+        directives = q2._load()
+        assert len(directives) == 1
+        d = directives[0]
+        assert d["code"] == CHAIN_REQUIRED
+        assert d["skill"] == "web-exploit"
+        assert d["status"] == "pending"
+        assert d["priority"] == "high"
+        assert d["trigger"] == "SKILL_CHAIN_GAP"
+
+    def test_dedup_same_code_and_skill_pending(self, q, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q2 = SteeringQueue()
+        id1 = q2.add_directive(code=CHAIN_REQUIRED, message="msg1", skill="web-exploit", trigger="X")
+        id2 = q2.add_directive(code=CHAIN_REQUIRED, message="msg2", skill="web-exploit", trigger="X")
+        assert id1 is not None
+        assert id2 is None  # deduped
+        assert len(q2._load()) == 1
+
+    def test_dedup_only_applies_to_pending_or_injected(self, q, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q2 = SteeringQueue()
+        id1 = q2.add_directive(code=CHAIN_REQUIRED, message="msg1", skill="web-exploit", trigger="X")
+        q2.acknowledge(id1)
+        id2 = q2.add_directive(code=CHAIN_REQUIRED, message="msg2", skill="web-exploit", trigger="X")
+        assert id2 is not None  # acknowledged — can create new one
+        assert len(q2._load()) == 2
+
+    def test_different_skills_not_deduped(self, q, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q2 = SteeringQueue()
+        id1 = q2.add_directive(code=CHAIN_REQUIRED, message="m1", skill="web-exploit", trigger="X")
+        id2 = q2.add_directive(code=CHAIN_REQUIRED, message="m2", skill="credential-audit", trigger="X")
+        assert id1 is not None
+        assert id2 is not None
+        assert len(q2._load()) == 2
+
+
+class TestStatusTransitions:
+    def test_mark_injected(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        did = q.add_directive(code=RESUME_REQUIRED, message="msg", trigger="TOOL_INACTIVITY")
+        q.mark_injected(did)
+        d = q._load()[0]
+        assert d["status"] == "injected"
+        assert d["injected_at"] is not None
+
+    def test_acknowledge(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        did = q.add_directive(code=RESUME_REQUIRED, message="msg", trigger="TOOL_INACTIVITY")
+        result = q.acknowledge(did, message="I will resume now")
+        assert result is True
+        d = q._load()[0]
+        assert d["status"] == "acknowledged"
+        assert d["ack_message"] == "I will resume now"
+        assert d["acknowledged_at"] is not None
+
+    def test_acknowledge_returns_false_for_unknown_id(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        result = q.acknowledge("steer-nonexistent")
+        assert result is False
+
+    def test_auto_satisfy(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        did = q.add_directive(code=CHAIN_REQUIRED, message="chain web-exploit", skill="web-exploit", trigger="GAP")
+        satisfied = q.auto_satisfy("web-exploit")
+        assert did in satisfied
+        d = q._load()[0]
+        assert d["status"] == "auto_satisfied"
+
+    def test_auto_satisfy_does_not_affect_other_skills(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        d1 = q.add_directive(code=CHAIN_REQUIRED, message="chain web", skill="web-exploit", trigger="G")
+        d2 = q.add_directive(code=CHAIN_REQUIRED, message="chain cred", skill="credential-audit", trigger="G")
+        q.auto_satisfy("web-exploit")
+        directives = {d["id"]: d for d in q._load()}
+        assert directives[d1]["status"] == "auto_satisfied"
+        assert directives[d2]["status"] == "pending"  # unaffected
+
+
+class TestQueryMethods:
+    def test_get_pending_returns_only_pending(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        d1 = q.add_directive(code=RESUME_REQUIRED, message="m1", trigger="T")
+        d2 = q.add_directive(code=CHAIN_REQUIRED, message="m2", skill="web-exploit", trigger="T")
+        q.mark_injected(d1)  # d1 now injected, not pending
+        pending = q.get_pending()
+        assert len(pending) == 1
+        assert pending[0].id == d2
+
+    def test_get_injected(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        d1 = q.add_directive(code=RESUME_REQUIRED, message="m1", trigger="T")
+        q.mark_injected(d1)
+        injected = q.get_injected()
+        assert len(injected) == 1
+        assert injected[0].id == d1
+
+    def test_get_history_returns_all_newest_first(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        d1 = q.add_directive(code=RESUME_REQUIRED, message="first", trigger="T")
+        d2 = q.add_directive(code=CHAIN_REQUIRED, message="second", skill="s", trigger="T")
+        history = q.get_history()
+        assert len(history) == 2
+        assert history[0]["id"] == d2  # newest first
+        assert history[1]["id"] == d1
+
+    def test_acknowledge_latest_injected(self, tmp_path, monkeypatch):
+        import core.steering as st_mod
+        monkeypatch.setattr(st_mod, "_STEERING_FILE", tmp_path / "steering_queue.json")
+        q = SteeringQueue()
+        d1 = q.add_directive(code=RESUME_REQUIRED, message="m1", trigger="T")
+        q.mark_injected(d1)
+        acked_id = q.acknowledge_latest_injected(message="understood")
+        assert acked_id == d1
+        d = q._load()[0]
+        assert d["status"] == "acknowledged"
+        assert d["ack_message"] == "understood"


### PR DESCRIPTION
…engine

- core/metrics.py: pentest run metrics appended to pentest_metrics.jsonl at scan completion
- core/steering.py: QA-driven steering queue that injects directives into tool envelopes
- mcp_server/scan_engine/envelope.py: integrate steering queue and recovery snapshot
- mcp_server/scan_engine/state.py, budget.py: related scan engine improvements
- mcp_server/session_tools.py: session tool updates for steering and recovery
- core/qa_agent.py: major refactor for metrics and steering integration
- core/api_server.py: API server updates
- templates/dashboard.html: dashboard improvements
- tests: full test coverage for new modules (envelope, metrics, steering, recovery integration)
- .gitignore: ignore steering_queue.json, recovery_latest.json, pentest_metrics.jsonl
- skills: bump to feat/hotwire-recovery-context