### PR TITLE
fix: keep findings polling after scan complete

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -900,19 +900,18 @@
       statusEl.textContent = s.status || '—';
       statusEl.className   = `session-status-${s.status || 'running'}`;
 
-      // Stop polling once the scan is complete — prevents DOM updates
-      // that break text selection and copy/paste.
+      // Mark scan done for UI status only — findings still poll so the
+      // dashboard stays accurate across session restarts and force-completes.
       if (s.status === 'complete' && !scanDone) {
         scanDone = true;
         document.getElementById('status').innerHTML =
-          '<span class="dot" style="background:#6e7681;animation:none"></span>Scan complete — polling paused';
+          '<span class="dot" style="background:#6e7681;animation:none"></span>Scan complete';
       }
     } catch { /* session may not exist yet */ }
   }
 
   // ── Findings tab ──────────────────────────────────────────────────────────
   async function pollFindings() {
-    if (scanDone) return;
     try {
       const r = await fetch(`/api/findings?_=${Date.now()}`);
       if (!r.ok) throw new Error('not found');


### PR DESCRIPTION
## Summary

- Removes the `if (scanDone) return;` guard on `pollFindings()` so findings keep updating after the scan is marked complete
- Fixes the dashboard going stale across session restarts and force-completes — findings logged after completion were never displayed
- Updates status label from `"Scan complete — polling paused"` to `"Scan complete"`

## Test plan

- [ ] Run a scan to completion and verify findings continue to appear if new ones are logged
- [ ] Restart the dashboard mid-scan and confirm findings remain accurate after `status === 'complete'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)