### PR TITLE
fix: set PYTHONPATH so venv Python can locate mcp_server package

### DIFF
--- a/installers/start-mcp-server.sh
+++ b/installers/start-mcp-server.sh
@@ -25,7 +25,7 @@ case "${1:-start}" in
             echo "✗ Could not determine venv Python path — run 'poetry -C $REPO_DIR install' first"
             exit 1
         fi
-        nohup "$VENV_PYTHON" -m mcp_server --transport sse \
+        nohup env PYTHONPATH="$REPO_DIR" "$VENV_PYTHON" -m mcp_server --transport sse \
             --host 127.0.0.1 --port "$PORT" >> "$LOG_FILE" 2>&1 &
         echo $! > "$PID_FILE"
         # Wait up to 8s for readiness


### PR DESCRIPTION
## Summary

- `start-mcp-server.sh` invoked the venv Python directly via `nohup "$VENV_PYTHON" -m mcp_server`, but the repo root was never added to `sys.path`
- This caused `No module named mcp_server` on any fresh install or after a launchd restart
- Fix: prepend `env PYTHONPATH="$REPO_DIR"` to the `nohup` call so Python can always locate the package

## Test plan

- [x] Run `./installers/install.sh` on a clean environment and confirm the MCP SSE server starts without the module error
- [x] Run `./installers/start-mcp-server.sh restart` and verify it reports running on port 7778
- [ ] Confirm `curl http://127.0.0.1:7778/sse` returns a response

🤖 Generated with [Claude Code](https://claude.com/claude-code)