### PR TITLE
fix: wire SSE transport in opencode installer; fix opencode.json path

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -51,7 +51,7 @@ claude mcp add --scope user --transport sse pentest-agent \
 ok "MCP server registered with Claude Code (scope: user, transport: sse)"
 
 # ── Register MCP server with opencode (SSE transport) ────────────────────────
-OPENCODE_CONFIG="$HOME/.config/opencode/config.json"
+OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
 if [[ -f "$OPENCODE_CONFIG" ]]; then
     echo ""
     echo "Registering pentest-agent MCP server with opencode..."

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -39,9 +39,16 @@ echo "Installing Python dependencies..."
 poetry -C "$REPO_DIR" install --no-interaction
 ok "Poetry dependencies installed"
 
+# ── Start MCP SSE daemon ──────────────────────────────────────────────────────
+echo ""
+echo "Starting MCP SSE server..."
+chmod +x "$REPO_DIR/installers/start-mcp-server.sh"
+"$REPO_DIR/installers/start-mcp-server.sh" restart
+ok "MCP SSE server running on localhost:7778"
+
 # ── Register MCP server + instructions in opencode config ────────────────────
 echo ""
-echo "Registering pentest-agent MCP server in opencode config..."
+echo "Registering pentest-agent MCP server (SSE) in opencode config..."
 mkdir -p "$OPENCODE_CONFIG_DIR"
 
 python3 - <<PYEOF
@@ -56,13 +63,12 @@ try:
 except Exception:
     data = {}
 
-# MCP server entry
+# MCP server entry — SSE transport (shared daemon on 127.0.0.1:7778)
 mcp = data.setdefault("mcp", {})
 mcp["pentest-agent"] = {
-    "type":    "local",
-    "command": ["poetry", "-C", str(repo_dir), "run", "python", "-m", "mcp_server"],
+    "type":    "sse",
+    "url":     "http://127.0.0.1:7778/sse",
     "enabled": True,
-    "timeout": 660000,   # 11 minutes — 10% above the kali() tool's default 600 s command timeout
 }
 
 # Add CLAUDE.md to global instructions (avoid duplicates)
@@ -73,8 +79,18 @@ if instructions_entry not in instructions:
 
 config_path.write_text(json.dumps(data, indent=2) + "\n")
 PYEOF
-ok "MCP server registered in $OPENCODE_CONFIG"
+ok "MCP server registered in $OPENCODE_CONFIG (transport: sse)"
 ok "CLAUDE.md added to global instructions"
+
+# ── Install launchd plist for auto-start on login ────────────────────────────
+echo ""
+echo "Installing launchd plist..."
+PLIST_SRC="$REPO_DIR/installers/com.agent-smith.mcp-sse.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/com.agent-smith.mcp-sse.plist"
+sed "s|REPO_DIR|$REPO_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
+launchctl unload "$PLIST_DST" 2>/dev/null || true
+launchctl load "$PLIST_DST"
+ok "launchd plist installed — MCP server auto-starts on login and restarts on crash"
 
 # ── Ask whether to overwrite existing skill files ────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
- `install_opencode.sh` now mirrors `install.sh`'s SSE setup: starts the shared MCP SSE daemon on `127.0.0.1:7778`, registers pentest-agent in `opencode.json` as `{type: sse, url: ...}`, and installs the launchd plist for auto-start on login. Previously it registered as a stdio `type: local` command, so opencode users were missing the shared-daemon benefits and never got the launchd auto-start.
- Fix `install.sh` writing to `~/.config/opencode/config.json` (not opencode's spec path) → switched to `opencode.json`. That bug was silently skipping opencode registration whenever `install.sh` was run.

Both installers now produce identical opencode `mcp.pentest-agent` entries and use the same daemon.

## Test plan
- [ ] Run `installers/install_opencode.sh` on a clean machine — verify `~/.config/opencode/opencode.json` contains `"mcp": {"pentest-agent": {"type": "sse", "url": "http://127.0.0.1:7778/sse", "enabled": true}}` and `~/Library/LaunchAgents/com.agent-smith.mcp-sse.plist` is loaded.
- [ ] `curl -sf http://127.0.0.1:7778/sse` returns a stream (daemon up).
- [ ] Open opencode, run `/pentester` — MCP tools (`scan`, `kali`, `http`, `report`, `session`) are reachable.
- [ ] Run `installers/install.sh` against a setup with an existing `opencode.json` — confirm the opencode registration step runs (no longer prints "opencode config not found") and the SSE entry is written.
- [ ] Reboot — daemon comes back up via launchd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)