### PR TITLE
fix: use opencode's "remote" mcp type, not invalid "sse"

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -55,7 +55,7 @@ OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
 if [[ -f "$OPENCODE_CONFIG" ]]; then
     echo ""
     echo "Registering pentest-agent MCP server with opencode..."
-    jq '.mcp["pentest-agent"] = {"type": "sse", "url": "http://127.0.0.1:7778/sse"}' \
+    jq '.mcp["pentest-agent"] = {"type": "remote", "url": "http://127.0.0.1:7778/sse", "enabled": true}' \
         "$OPENCODE_CONFIG" > "$OPENCODE_CONFIG.tmp" \
         && mv "$OPENCODE_CONFIG.tmp" "$OPENCODE_CONFIG"
     ok "MCP server registered with opencode"

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -63,10 +63,11 @@ try:
 except Exception:
     data = {}
 
-# MCP server entry — SSE transport (shared daemon on 127.0.0.1:7778)
+# MCP server entry — remote transport (shared SSE daemon on 127.0.0.1:7778).
+# opencode's schema uses "remote" for any HTTP/SSE MCP server; there is no "sse" type.
 mcp = data.setdefault("mcp", {})
 mcp["pentest-agent"] = {
-    "type":    "sse",
+    "type":    "remote",
     "url":     "http://127.0.0.1:7778/sse",
     "enabled": True,
 }
@@ -79,7 +80,7 @@ if instructions_entry not in instructions:
 
 config_path.write_text(json.dumps(data, indent=2) + "\n")
 PYEOF
-ok "MCP server registered in $OPENCODE_CONFIG (transport: sse)"
+ok "MCP server registered in $OPENCODE_CONFIG (transport: remote/SSE)"
 ok "CLAUDE.md added to global instructions"
 
 # ── Install launchd plist for auto-start on login ────────────────────────────


### PR DESCRIPTION
## Summary
Follow-up to #88. opencode's config schema (https://opencode.ai/config.json) defines two MCP transport types — `local` (stdio) and `remote` (HTTP/SSE). It does **not** define `sse`. The previous installer wrote `{"type": "sse", ...}` to `opencode.json`, which opencode silently ignored — so the server never showed up in opencode's `status` even with the SSE daemon running fine.

Switched both installers to `{"type": "remote", "url": "http://127.0.0.1:7778/sse", "enabled": true}`, which is the shape opencode actually accepts for an HTTP/SSE MCP server.

Claude Code's side is unchanged — `claude mcp add --transport sse ...` already writes the correct `{"type": "sse", ...}` to `~/.claude.json` (that's the value Claude Code's own CLI uses; the two clients just speak different config dialects).

## Test plan
- [ ] Run `installers/install_opencode.sh` (or `install.sh`) — verify `~/.config/opencode/opencode.json` contains `"mcp.pentest-agent": {"type": "remote", "url": "http://127.0.0.1:7778/sse", "enabled": true}`.
- [ ] Restart opencode, run its MCP status command — `pentest-agent` is listed and tools (`scan`, `kali`, `http`, `report`, `session`) are reachable.
- [ ] Confirm Claude Code still works (`~/.claude.json` should still have `{"type": "sse", "url": "..."}` from `claude mcp add --transport sse`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)