### PR TITLE
Add Codex support alongside existing clients

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .codex/hooks/post-compact.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/post-compact.sh
+++ b/.codex/hooks/post-compact.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# post-compact.sh - Codex SessionStart(compact) hook
+# Reads session.json after context compaction and injects a brief
+# recovery reminder so Codex resumes the active skill workflow.
+# Exits silently when no session is running (no noise outside pentests).
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SESSION_FILE="$REPO_DIR/session.json"
+
+[[ ! -f "$SESSION_FILE" ]] && exit 0
+
+python3 - "$SESSION_FILE" <<'PYEOF'
+import json, sys
+
+try:
+    data = json.loads(open(sys.argv[1]).read())
+except Exception:
+    sys.exit(0)
+
+if data.get("status") != "running":
+    sys.exit(0)
+
+skill = data.get("skill", "")
+target = data.get("target", "")
+depth = data.get("depth", "")
+step = data.get("current_step", "")
+tools = data.get("tools_called", [])
+
+print("CONTEXT RECOVERY AFTER COMPACTION")
+print(f"Active scan: {target} (depth={depth})")
+if tools:
+    print(f"Tools already run: {', '.join(tools)}")
+if step:
+    print(f"Resume at step: {step}")
+if skill:
+    print(f"Active skill: /{skill}")
+    print(f"Call session(action='recovery') for a compact brief of where to resume.")
+else:
+    print("Call session(action='recovery') to get a compact recovery brief.")
+PYEOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# Pentest Agent
+
+You are a security researcher with access to penetration testing tools via MCP and a set of security analysis skills. Skill workflows, chaining rules, and scan logic live in the skill files — not here.
+
+## MCP Tools
+
+Five consolidated tools. Each dispatches to multiple underlying scanners/actions via the first parameter.
+
+### `scan(tool, target, flags, options)`
+Run any security scanner.
+
+| tool | target type | options (defaults) |
+|------|-------------|--------------------|
+| nmap | host/IP | ports=top-1000 |
+| naabu | host/IP | ports=top-100 |
+| subfinder | domain | |
+| httpx | URL | |
+| nuclei | URL | templates=cve,exposure,misconfig,default-login |
+| ffuf | URL | wordlist=common.txt, extensions= |
+| spider | URL | depth=3, mode=fast\|playwright, cookies={}, max_pages=200 |
+| semgrep | path | |
+| trufflehog | path | |
+| fuzzyai | URL | attack=jailbreak, provider=openai, model= |
+| pyrit | URL | attack=prompt_injection, objective=, max_turns=5, scorer=self_ask |
+| garak | URL | probes=dan,encoding,promptinject,..., generator=rest |
+| promptfoo | URL | plugins=prompt-injection,..., attack_strategies=jailbreak,crescendo |
+| metasploit | host/IP | module=, payload=, rport=, lhost=, lport=4444 |
+
+### `kali(command, timeout)`
+Run any command in the Kali container (auto-starts if needed). Hundreds of tools: nikto, sqlmap, gobuster, hydra, testssl, enum4linux-ng, wapiti, searchsploit, etc.
+
+### `http(action, url, method, headers, body, options)`
+Raw HTTP requests and PoC saving.
+- `action="request"` — send an HTTP request. options: `poc=false`, `burp_proxy=http://127.0.0.1:8080`
+- `action="save_poc"` — save a raw .http file to pocs/. options: `title=poc`, `notes=`
+
+### `report(action, data)`
+Log findings, diagrams, notes, and coverage matrix updates.
+- `action="finding"` — data: `{title, severity, target, description, evidence, tool_used, cve}`
+- `action="diagram"` — data: `{title, mermaid}`
+- `action="note"` — data: `{message}`
+- `action="dashboard"` — data: `{port: 8888}`
+- `action="coverage"` — data: `{type, ...}` — manage the coverage matrix:
+  - `type="endpoint"` — register endpoint + auto-generate cells: `{path, method, params=[{name, type, value_hint}], discovered_by, auth_context}`
+  - `type="tested"` — mark cell tested: `{cell_id, status (tested_clean|vulnerable|not_applicable|skipped), notes, finding_id}`
+  - `type="bulk_tested"` — mark multiple cells: `{updates=[{cell_id, status, notes, finding_id}]}`
+  - `type="reset"` — clear the matrix
+
+### `session(action, options)`
+Scan lifecycle and infrastructure.
+- `action="start"` — options: `{target, depth, scope, out_of_scope, max_cost_usd, max_time_minutes, max_tool_calls, model_profile=full}` (model_profile: full|medium|small)
+- `action="complete"` — options: `{notes}`
+- `action="status"` — returns current scan state (tools run, findings count, cost, remaining calls). **When the response includes `qa_alerts`, immediately call `session(action="qa_reply")` with your acknowledgment before continuing.**
+- `action="qa_reply"` — options: `{message}` — log your response to the QA agent's alerts. Call this every time `session(action="status")` returns non-empty `qa_alerts`. Write one sentence per alert: what you acknowledge and what you will do. This is what the human sees in the QA ↔ Smith conversation view.
+- `action="recovery"` — returns compact recovery brief after context compaction; includes `EXECUTE_NOW` with the next concrete tool call
+- `action="artifact"` — options: `{id, mode=summary, max_chars=4000, pattern=}` — retrieve raw tool output stored by the scan engine
+- `action="start_kali"` / `action="stop_kali"` — Kali container lifecycle
+- `action="start_metasploit"` / `action="stop_metasploit"` — Metasploit container lifecycle
+- `action="pull_images"` — pre-pull all Docker images
+- `action="set_skill"` — options: `{skill, reason, chained_from}` — log skill selection with reasoning; **call this before invoking or following any skill workflow**
+- `action="set_codebase"` — options: `{path}` — set local codebase for semgrep/trufflehog
+
+## Skill Logging (mandatory)
+
+Before invoking or following **any** skill workflow, always call:
+
+```
+session(action="set_skill", options={
+  "skill": "<skill-name>",
+  "reason": "<1–2 sentences explaining why you chose this skill>",
+  "chained_from": "<parent skill name when chaining; omit for the first skill>"
+})
+```
+
+This writes a `SKILL_START` or `SKILL_CHAIN` entry to `pentest.log` and enriches `session.json`'s `skill_history` with the decision context. It is mandatory — always call it immediately before starting the skill workflow.
+
+## Available Skills
+
+Skills contain full structured workflows. In Codex they are installed as personal skills and can be invoked by name; in opencode they appear as `/command-name`. Always prefer following a skill over improvising a workflow from scratch — the skill files contain all chaining rules, tool sequences, and completion gates.
+
+**Skill chaining (how to invoke a sub-skill mid-workflow):**
+- **Codex**: call `session(action="set_skill", ...)`, then follow the installed skill named `<name>`; if it is not available in the client, read `skills/<name>/SKILL.md` from this repo and follow it inline.
+- **opencode / other clients**: read the skill command file at `~/.config/opencode/commands/<name>.md` and follow its workflow inline with the provided arguments
+
+| Command | Purpose | Invoke when |
+|---------|---------|-------------|
+| `/pentester` | Full pentest orchestrator — recon → exploitation → report | General web/network pentest request |
+| `/web-exploit` | Deep injection, auth, logic, and business-logic exploitation | Web app confirmed; systematic endpoint testing needed |
+| `/param-fuzz` | Auth stripping, type confusion, boundary values, mass assignment discovery, entropy/predictability analysis of generated IDs and tokens | After /web-exploit on any app with structured parameters or generated values (tokens, IDs, PINs, reference numbers) |
+| `/business-logic` | Understanding-first BL testing: value/quantity logic abuse, workflow bypass, state machine abuse, BOLA/BFLA, replay/idempotency, quota bypass, time manipulation, multi-tenant isolation — domain-agnostic | Any multi-user app with stateful workflows, numeric fields, or role-based access |
+| `/codebase` | OWASP ASVS 5.0 white-box source code review | Local codebase path provided |
+| `/ai-redteam` | OWASP LLM Top 10 red-team — prompt injection, jailbreaks, data extraction | AI/chatbot/LLM target |
+| `/cloud-security` | AWS/Azure/GCP IAM, storage, serverless posture assessment | Cloud account target |
+| `/ad-assessment` | Active Directory — trusts, GPO, ACL, ADCS (ESC1-8), delegation | Domain controller / Windows AD environment |
+| `/network-assess` | VLAN hopping, ARP, LLMNR/NBT-NS, SNMP, NFS, segmentation | Internal LAN/network target |
+| `/lateral-movement` | Pass-the-hash, Kerberoasting, NTLM relay, WMI/WinRM, pivoting | Post-initial-access; need to move laterally |
+| `/credential-audit` | Brute-force, spraying, MFA bypass, OAuth/OIDC, session entropy | Authentication surface testing |
+| `/post-exploit` | Privesc (Linux/Windows), persistence, credential harvesting, pivoting | Shell access obtained |
+| `/container-k8s-security` | Container escape, Docker socket, K8s RBAC, pod security, etcd | Docker / Kubernetes target |
+| `/osint` | Subdomain enumeration, email harvest, Shodan, CT logs, Wayback | External recon phase; passive information gathering |
+| `/ssl-tls-audit` | TLS protocol versions, cipher suites, cert chain, POODLE/BEAST/Heartbleed | Any HTTPS/TLS endpoint |
+| `/email-security` | SPF/DKIM/DMARC, open relay, spoofing, SMTP security, MTA-STS | Domain email infrastructure |
+| `/metasploit` | Exploit validation and exploitation via Metasploit Framework | CVE to exploit; need controlled exploitation |
+| `/reverse-shell` | Reverse shell payload generation and listener management | Need shell on target system |
+| `/analyze-cve` | CVE exploitability analysis, code path tracing, Burp PoC generation | Known CVE in a dependency |
+| `/aikido-triage` | Triage Aikido security CSV against local codebase; verdict each finding | Aikido CSV scan results provided |
+| `/gh-export` | Format all confirmed findings as GitHub issue markdown blocks | **User request only** |
+| `/remediate` | Fix vulnerabilities in source code | **User request only** |
+| `/threat-modeling` | PASTA framework + 4-question threat model | **User request only** |
+| `/report` | Generate a styled PDF pentest report from findings.json | **User request only** |
+| `/request-cves` | Generate MITRE CVE request packages and GitHub Security Advisory drafts | Novel vulnerability discovered; need CVE disclosure |
+
+**NEVER auto-invoke `/report`, `/gh-export`, `/remediate`, or `/threat-modeling` — these are user-triggered only. Do not invoke them at the end of a scan unless the user explicitly asks.**
+
+## Project layout
+- `mcp_server/__main__.py` — entry point, crash logging, module imports
+- `mcp_server/_app.py` — FastMCP singleton, `_run()` dispatcher, `_clip()` helper
+- `mcp_server/scan_tools.py` — `scan()` tool (nmap, naabu, httpx, nuclei, ffuf, spider, semgrep, trufflehog, fuzzyai, pyrit)
+- `mcp_server/kali_tools.py` — `kali()` tool (freeform Kali commands)
+- `mcp_server/http_tools.py` — `http()` tool (raw HTTP + PoC saving)
+- `mcp_server/report_tools.py` — `report()` tool (findings, diagrams, notes, dashboard)
+- `mcp_server/session_tools.py` — `session()` tool (scan lifecycle, Kali infra, codebase target)
+- `core/` — server infrastructure (session, cost tracking, logging, findings, dashboard)
+- `tools/` — security scanner definitions + Docker runners
+- `skills/` — skill definitions (submodule)
+- `installers/` — setup and teardown scripts
+
+## Setup
+```bash
+cd /path/to/agent-smith
+./installers/install_codex.sh   # Codex
+./installers/install.sh         # Claude Code
+./installers/install_opencode.sh # OpenCode
+```
+
+### Docker images
+- **Lightweight tools** (nmap, naabu, httpx, nuclei, ffuf, subfinder, semgrep, trufflehog): public Docker Hub images. Auto-pull on first use. Call `session(action="pull_images")` to pre-fetch.
+- **kali-mcp**: custom image — must be built locally with `docker build -t pentest-agent/kali-mcp ./tools/kali/`. Container auto-starts on first `kali()` call and persists until `session(action="stop_kali")`. Uses the kali-server-mcp HTTP API on port 5001.
+- **metasploit**: custom image — `docker build -t pentest-agent/metasploit ./tools/metasploit/`. Auto-starts on first `scan(tool="metasploit")` call. API on port 5002.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Skills teach *methodology*; the LLM invents the actual attacks. No two scans loo
 - 🛠 **Bring your own LLM.** 
 
 
-Works with Claude Code, [OpenCode](https://opencode.ai) (any provider — OpenAI, Gemini, Ollama, OpenRouter, local models), or any MCP-capable client.
+Works with Claude Code, OpenAI Codex, [OpenCode](https://opencode.ai) (any provider — OpenAI, Gemini, Ollama, OpenRouter, local models), or any MCP-capable client.
 - 📦 **End-to-end deliverables.** 
 
 
@@ -105,9 +105,9 @@ The skills are inspiration. The LLM is the operator.
 
 ## Use cases
 
-Drop in any of these the moment you start your client/agent. No setup beyond `./installers/install.sh`
+Drop in any of these the moment you start your client/agent. No setup beyond the installer for your client.
 
-Below are the skills you can use in your OpenCode or Claude Code, these are just a couple examples and use cases as we have more then 25+ Cyber Security skills.
+Below are the skills you can use in Codex, OpenCode, or Claude Code, these are just a couple examples and use cases as we have more then 25+ Cyber Security skills.
 
 ### 1. Run a full pentest, hands-off
 
@@ -178,9 +178,10 @@ agent-smith ships an MCP server. Anything that speaks MCP can drive it.
 
 <table>
   <tr>
-    <th width="33%">Claude Code</th>
-    <th width="33%">OpenCode (BYO LLM)</th>
-    <th width="33%">Custom MCP client</th>
+    <th width="25%">Claude Code</th>
+    <th width="25%">Codex</th>
+    <th width="25%">OpenCode (BYO LLM)</th>
+    <th width="25%">Custom MCP client</th>
   </tr>
   <tr>
     <td>
@@ -189,6 +190,13 @@ agent-smith ships an MCP server. Anything that speaks MCP can drive it.
 cd agent-smith
 ./installers/install.sh</code></pre>
       Requires <a href="https://docs.anthropic.com/en/docs/claude-code">Claude Code</a> + an Anthropic API key.
+    </td>
+    <td>
+      OpenAI's coding agent. Installs AGENTS.md instructions, Codex skills, and the stdio MCP server.
+      <pre><code>git clone --recursive &lt;repo&gt;
+cd agent-smith
+./installers/install_codex.sh</code></pre>
+      Requires <a href="https://developers.openai.com/codex">Codex</a>. Restart Codex after install so the MCP server and skills reload.
     </td>
     <td>
       Open-source coding agent that supports <strong>any</strong> provider — OpenAI, Anthropic, Google, OpenRouter, Ollama, llama.cpp, vLLM, your own endpoint.
@@ -243,7 +251,7 @@ The LLM decides what to run. Each tool's output is aggregated and returned to th
 ```mermaid
 flowchart TD
     User["You<br/>/pentester · /codebase · /ai-redteam · /threat-modeling"]
-    Agent["Your LLM client<br/>Claude Code · OpenCode · MCP-capable IDE"]
+    Agent["Your LLM client<br/>Claude Code · Codex · OpenCode · MCP-capable IDE"]
     MCP["mcp_server/<br/>5 consolidated tools<br/>scan · kali · http · report · session"]
     Docker["Docker containers<br/>ephemeral --rm · 2 GB RAM · 1.5 CPU<br/>nmap · nuclei · httpx · ffuf · semgrep · trufflehog"]
     Kali["Kali Linux container<br/>persistent · port 5001<br/>nikto · sqlmap · hydra · testssl · pyrit"]
@@ -560,9 +568,13 @@ docs/gifs/               Demo gifs (drop your recordings here)
 
 installers/
   install.sh                     Claude Code installer
+  install_codex.sh               Codex installer
   install_opencode.sh            OpenCode installer (BYO LLM)
   uninstall.sh                   Remove MCP config and installed skills
   opencode-pentest-recovery.mjs  Compaction recovery plugin for OpenCode
+
+.codex/                          Codex project hooks
+AGENTS.md                        Codex project instructions
 ```
 </details>
 

--- a/installers/install_codex.sh
+++ b/installers/install_codex.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# install_codex.sh - set up pentest-agent for OpenAI Codex
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+CODEX_SKILLS_DIR="$CODEX_HOME/skills"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}[ok]${NC} $*"; }
+warn() { echo -e "${YELLOW}[warn]${NC} $*"; }
+die()  { echo -e "${RED}[err]${NC} $*"; exit 1; }
+
+echo ""
+echo "  pentest-agent installer (Codex)"
+echo "  ==============================="
+echo ""
+
+# Prerequisites
+command -v docker >/dev/null 2>&1 || die "docker not found - install Docker Desktop first."
+command -v poetry >/dev/null 2>&1 || die "poetry not found - install with: curl -sSL https://install.python-poetry.org | python3 -"
+command -v codex  >/dev/null 2>&1 || die "codex not found - install Codex first: https://developers.openai.com/codex"
+command -v node   >/dev/null 2>&1 || warn "node not found - Mermaid diagrams will render client-side (install Node.js v18+ for server-side pre-rendering)"
+
+ok "Prerequisites satisfied (docker, poetry, codex)"
+
+mkdir -p "$CODEX_HOME"
+
+echo ""
+echo "Pulling skills submodule..."
+git -C "$REPO_DIR" submodule update --init --recursive
+ok "Skills submodule up to date"
+
+echo ""
+echo "Installing Python dependencies..."
+poetry -C "$REPO_DIR" install --no-interaction
+ok "Poetry dependencies installed"
+
+# Codex launches this server over stdio. The absolute repo path is intentional:
+# the MCP server needs this checkout's .env, logs, tools, and session files.
+echo ""
+echo "Registering pentest-agent MCP server with Codex (stdio)..."
+codex mcp remove pentest-agent >/dev/null 2>&1 || true
+codex mcp add pentest-agent -- poetry -C "$REPO_DIR" run python -m mcp_server
+ok "MCP server registered with Codex"
+
+# Project instructions and hooks live in the repo. AGENTS.md is read by Codex
+# automatically; the hook preserves scan recovery hints after compaction.
+chmod +x "$REPO_DIR/.codex/hooks/post-compact.sh" 2>/dev/null || true
+ok "Codex project instructions and hooks are ready"
+
+echo ""
+_FORCE_SKILLS=false
+if find "$CODEX_SKILLS_DIR" -mindepth 2 -maxdepth 2 -name SKILL.md 2>/dev/null | grep -q .; then
+    printf "  Existing personal Codex skills found in %s.\n" "$CODEX_SKILLS_DIR"
+    printf "  Overwrite pentest-agent skill copies with fresh copies from the repo? [Y/n]: "
+    IFS= read -r _overwrite_answer </dev/tty || true
+    echo ""
+    if [[ "${_overwrite_answer:-Y}" =~ ^[Yy]$ ]]; then
+        _FORCE_SKILLS=true
+        ok "Will overwrite pentest-agent skill copies"
+    else
+        warn "Keeping existing Codex skill files - skipping skill installation"
+    fi
+else
+    _FORCE_SKILLS=true
+fi
+
+_SKILL_OK=0
+_SKILL_MISSING=()
+
+_install_skill_dir() {
+    local name="$1"
+    local src="$2"
+    local dst="$CODEX_SKILLS_DIR/$name"
+
+    if [ ! -f "$src/SKILL.md" ]; then
+        warn "Skill ${name} source not found: $src/SKILL.md (skipping)"
+        _SKILL_MISSING+=("$name")
+        return
+    fi
+
+    [[ "$_FORCE_SKILLS" == false ]] && return 0
+
+    rm -rf "$dst"
+    mkdir -p "$dst"
+    cp -R "$src"/. "$dst"/
+    _SKILL_OK=$((_SKILL_OK + 1))
+}
+
+_install_markdown_skill() {
+    local name="$1"
+    local src="$2"
+    local dst="$CODEX_SKILLS_DIR/$name"
+
+    if [ ! -f "$src" ]; then
+        warn "Skill ${name} source not found: $src (skipping)"
+        _SKILL_MISSING+=("$name")
+        return
+    fi
+
+    [[ "$_FORCE_SKILLS" == false ]] && return 0
+
+    rm -rf "$dst"
+    mkdir -p "$dst"
+    cp "$src" "$dst/SKILL.md"
+    _SKILL_OK=$((_SKILL_OK + 1))
+}
+
+echo ""
+echo "Installing Codex skills..."
+mkdir -p "$CODEX_SKILLS_DIR"
+
+_install_markdown_skill "pentester" "$REPO_DIR/skills/pentester.md"
+
+for _skill_file in "$REPO_DIR"/skills/*/SKILL.md; do
+    [ -e "$_skill_file" ] || continue
+    _skill_dir="$(dirname "$_skill_file")"
+    _skill_name="$(basename "$_skill_dir")"
+
+    # OpenCode has a client-specific variant; Codex uses skills/pentester.md.
+    [ "$_skill_name" = "pentester-opencode" ] && continue
+
+    _install_skill_dir "$_skill_name" "$_skill_dir"
+done
+
+ok "$_SKILL_OK Codex skills installed"
+if [ ${#_SKILL_MISSING[@]} -gt 0 ]; then
+    warn "Missing skills (run 'git submodule update --init --recursive' to fetch): ${_SKILL_MISSING[*]}"
+fi
+
+echo ""
+echo "API keys are stored in $REPO_DIR/.env (mode 600) and loaded automatically."
+echo "Press Enter to skip any key you do not need right now."
+echo ""
+
+ENV_FILE="$REPO_DIR/.env"
+if [ ! -f "$ENV_FILE" ] && [ -f "$REPO_DIR/.env.example" ]; then
+    cp "$REPO_DIR/.env.example" "$ENV_FILE"
+else
+    touch "$ENV_FILE"
+fi
+chmod 600 "$ENV_FILE"
+
+_ask_key() {
+    local key="$1"
+    local desc="$2"
+    local value=""
+    local existing
+    existing=$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-) || true
+    if [[ -n "$existing" ]]; then
+        printf "  %s already set. New value (Enter to keep): " "$key"
+    else
+        printf "  %s - %s\n  Value (Enter to skip): " "$key" "$desc"
+    fi
+    IFS= read -r -s value </dev/tty || true
+    echo ""
+    if [[ -n "$value" ]]; then
+        python3 -c "
+import pathlib, sys
+p = pathlib.Path(sys.argv[1])
+lines = [l for l in p.read_text().splitlines() if not l.startswith(sys.argv[2] + '=')]
+lines.append(sys.argv[2] + '=' + sys.argv[3])
+p.write_text('\n'.join(lines) + '\n')
+" "$ENV_FILE" "$key" "$value"
+        ok "$key saved"
+    elif [[ -n "$existing" ]]; then
+        ok "$key unchanged"
+    else
+        warn "$key skipped"
+    fi
+}
+
+_ask_key "OPENAI_API_KEY"       "OpenAI key - FuzzyAI and PyRIT attacker/scorer"
+_ask_key "ANTHROPIC_API_KEY"    "Anthropic key - FuzzyAI anthropic provider"
+_ask_key "AZURE_OPENAI_API_KEY" "Azure OpenAI key - FuzzyAI azure provider"
+
+echo ""
+echo "  Docker images"
+echo "  -------------"
+echo ""
+
+_SCANNER_IMAGES=(
+    "instrumentisto/nmap"
+    "projectdiscovery/naabu"
+    "projectdiscovery/httpx"
+    "projectdiscovery/nuclei"
+    "projectdiscovery/subfinder"
+    "semgrep/semgrep"
+    "trufflesecurity/trufflehog"
+)
+
+printf "  Pull lightweight scanner images? (~2 min) [Y/n]: "
+read -r _pull_answer || true
+if [[ "${_pull_answer:-Y}" =~ ^[Yy]$ ]]; then
+    for img in "${_SCANNER_IMAGES[@]}"; do
+        if docker pull "$img" >/dev/null 2>&1; then
+            ok "Pulled $img"
+        else
+            warn "Failed to pull $img (will auto-pull on first use)"
+        fi
+    done
+else
+    warn "Scanner image pull skipped - images will auto-pull on first use"
+fi
+
+echo ""
+
+printf "  Build Kali image? (~10 min - required for most skills) [Y/n]: "
+read -r _kali_answer || true
+if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
+    echo "  Building pentest-agent/kali-mcp (this may take a while)..."
+    if docker build -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then
+        ok "Kali image built: pentest-agent/kali-mcp"
+    else
+        warn "Kali build failed - run manually: docker build -t pentest-agent/kali-mcp $REPO_DIR/tools/kali/"
+    fi
+else
+    warn "Kali build skipped - run later: docker build -t pentest-agent/kali-mcp $REPO_DIR/tools/kali/"
+fi
+
+echo ""
+
+printf "  Build Metasploit image? (~5 min - required for /metasploit skill) [Y/n]: "
+read -r _msf_answer || true
+if [[ "${_msf_answer:-Y}" =~ ^[Yy]$ ]]; then
+    echo "  Building pentest-agent/metasploit..."
+    if docker build -t pentest-agent/metasploit "$REPO_DIR/tools/metasploit/" 2>&1 | tail -5; then
+        ok "Metasploit image built: pentest-agent/metasploit"
+    else
+        warn "Metasploit build failed - run manually: docker build -t pentest-agent/metasploit $REPO_DIR/tools/metasploit/"
+    fi
+else
+    warn "Metasploit build skipped - run later: docker build -t pentest-agent/metasploit $REPO_DIR/tools/metasploit/"
+fi
+
+echo ""
+echo "  Install complete!"
+echo ""
+echo "  Start Codex in this repo and ask for a skill, for example:"
+echo "    /pentester scan https://target.com"
+echo "    /codebase path=./src"
+echo ""
+warn "On first open, Codex may ask you to trust this project's AGENTS.md and .codex hooks."
+warn "Approve that prompt to enable compaction recovery during long scans."
+echo ""


### PR DESCRIPTION
adds OpenAI Codex as a supported client while keeping the existing Claude Code and OpenCode configs intact.

Changes include:

Dedicated install_codex.sh installer
Codex MCP registration via stdio
Codex skill installation into ~/.codex/skills
Project-level AGENTS.md guidance for Codex workflows
Portable .codex compaction recovery hook
README updates documenting Codex setup next to Claude Code, OpenCode, and custom MCP clients