### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
Potential fix for [https://github.com/0x0pointer/agent-smith/security/code-scanning/31](https://github.com/0x0pointer/agent-smith/security/code-scanning/31)

Add an explicit `permissions` block with the minimum required scope.  
Best fix: set workflow-level permissions to `contents: read` directly under the `on:` section (or near top-level keys), so all jobs inherit it unless overridden. This preserves behavior and documents intent.

In `.github/workflows/discord-notify.yml`, insert:

```yml
permissions:
  contents: read
```

No imports/methods/dependencies are needed; this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
