### PR TITLE
Make skill installation dynamic across clients

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -25,9 +25,14 @@ ok "Prerequisites satisfied (docker, poetry, claude)"
 
 # ── Pull skills submodule ────────────────────────────────────────────────────
 echo ""
-echo "Pulling skills submodule..."
-git -C "$REPO_DIR" submodule update --init --recursive
-ok "Skills submodule up to date"
+echo "Updating skills submodule from upstream..."
+if git -C "$REPO_DIR" submodule update --init --recursive --remote skills; then
+    ok "Skills submodule updated to $(git -C "$REPO_DIR/skills" rev-parse --short HEAD)"
+else
+    warn "Could not update skills from upstream — falling back to the pinned submodule commit"
+    git -C "$REPO_DIR" submodule update --init --recursive skills
+    ok "Skills submodule checked out at pinned commit $(git -C "$REPO_DIR/skills" rev-parse --short HEAD)"
+fi
 
 # ── Python dependencies ───────────────────────────────────────────────────────
 echo ""
@@ -99,6 +104,28 @@ _cp() {
     cp "$src" "$dst"
 }
 
+_SKILL_OK=0
+_SKILL_MISSING=()
+
+_install_skill_dir() {
+    local name="$1"
+    local src="$2"
+    local dst="$HOME/.claude/skills/$name"
+
+    if [ ! -f "$src/SKILL.md" ]; then
+        warn "Skill /${name} source not found: $src/SKILL.md (skipping)"
+        _SKILL_MISSING+=("$name")
+        return
+    fi
+
+    [[ "$_FORCE_SKILLS" == false ]] && return 0
+
+    rm -rf "$dst"
+    mkdir -p "$dst"
+    cp -R "$src"/. "$dst"/
+    _SKILL_OK=$((_SKILL_OK + 1))
+}
+
 # ── Install /pentester slash command ──────────────────────────────────────────
 echo ""
 echo "Installing /pentester slash command..."
@@ -110,123 +137,22 @@ ok "/pentester command available in all Claude sessions"
 echo ""
 echo "Installing security analysis skills..."
 
-mkdir -p "$HOME/.claude/skills/analyze-cve"
-_cp "$REPO_DIR/skills/analyze-cve/SKILL.md" "$HOME/.claude/skills/analyze-cve/SKILL.md"
-ok "/analyze-cve skill installed"
+mkdir -p "$HOME/.claude/skills"
+for _skill_file in "$REPO_DIR"/skills/*/SKILL.md; do
+    [ -e "$_skill_file" ] || continue
+    _skill_dir="$(dirname "$_skill_file")"
+    _skill_name="$(basename "$_skill_dir")"
 
-mkdir -p "$HOME/.claude/skills/threat-modeling"
-_cp "$REPO_DIR/skills/threat-modeling/SKILL.md" "$HOME/.claude/skills/threat-modeling/SKILL.md"
-ok "/threat-modeling skill installed"
+    # OpenCode has a client-specific variant; Claude uses skills/pentester.md.
+    [ "$_skill_name" = "pentester-opencode" ] && continue
 
-mkdir -p "$HOME/.claude/skills/aikido-triage"
-_cp "$REPO_DIR/skills/aikido-triage/SKILL.md" "$HOME/.claude/skills/aikido-triage/SKILL.md"
-ok "/aikido-triage skill installed"
+    _install_skill_dir "$_skill_name" "$_skill_dir"
+done
 
-mkdir -p "$HOME/.claude/skills/gh-export"
-_cp "$REPO_DIR/skills/gh-export/SKILL.md" "$HOME/.claude/skills/gh-export/SKILL.md"
-ok "/gh-export skill installed"
-
-mkdir -p "$HOME/.claude/skills/ai-redteam"
-_cp "$REPO_DIR/skills/ai-redteam/SKILL.md" "$HOME/.claude/skills/ai-redteam/SKILL.md"
-ok "/ai-redteam skill installed"
-
-mkdir -p "$HOME/.claude/skills/container-k8s-security"
-_cp "$REPO_DIR/skills/container-k8s-security/SKILL.md" "$HOME/.claude/skills/container-k8s-security/SKILL.md"
-ok "/container-k8s-security skill installed"
-
-mkdir -p "$HOME/.claude/skills/cloud-security"
-_cp "$REPO_DIR/skills/cloud-security/SKILL.md" "$HOME/.claude/skills/cloud-security/SKILL.md"
-ok "/cloud-security skill installed"
-
-mkdir -p "$HOME/.claude/skills/ad-assessment"
-_cp "$REPO_DIR/skills/ad-assessment/SKILL.md" "$HOME/.claude/skills/ad-assessment/SKILL.md"
-ok "/ad-assessment skill installed"
-
-mkdir -p "$HOME/.claude/skills/email-security"
-_cp "$REPO_DIR/skills/email-security/SKILL.md" "$HOME/.claude/skills/email-security/SKILL.md"
-ok "/email-security skill installed"
-
-mkdir -p "$HOME/.claude/skills/metasploit"
-_cp "$REPO_DIR/skills/metasploit/SKILL.md" "$HOME/.claude/skills/metasploit/SKILL.md"
-ok "/metasploit skill installed"
-
-mkdir -p "$HOME/.claude/skills/reverse-shell"
-_cp "$REPO_DIR/skills/reverse-shell/SKILL.md" "$HOME/.claude/skills/reverse-shell/SKILL.md"
-ok "/reverse-shell skill installed"
-
-mkdir -p "$HOME/.claude/skills/web-exploit/refs"
-_cp "$REPO_DIR/skills/web-exploit/SKILL.md" "$HOME/.claude/skills/web-exploit/SKILL.md"
-if [ -d "$REPO_DIR/skills/web-exploit/refs" ]; then
-    for _ref_src in "$REPO_DIR/skills/web-exploit/refs/"*; do
-        _cp "$_ref_src" "$HOME/.claude/skills/web-exploit/refs/$(basename "$_ref_src")"
-    done
+ok "$_SKILL_OK security analysis skills installed"
+if [ ${#_SKILL_MISSING[@]} -gt 0 ]; then
+    warn "Missing skills: ${_SKILL_MISSING[*]}"
 fi
-ok "/web-exploit skill installed (with lazy-loaded injection refs)"
-
-mkdir -p "$HOME/.claude/skills/api-security"
-_cp "$REPO_DIR/skills/api-security/SKILL.md" "$HOME/.claude/skills/api-security/SKILL.md"
-ok "/api-security skill installed"
-
-mkdir -p "$HOME/.claude/skills/colang-gen"
-_cp "$REPO_DIR/skills/colang-gen/SKILL.md" "$HOME/.claude/skills/colang-gen/SKILL.md"
-ok "/colang-gen skill installed"
-
-mkdir -p "$HOME/.claude/skills/codebase"
-_cp "$REPO_DIR/skills/codebase/SKILL.md" "$HOME/.claude/skills/codebase/SKILL.md"
-ok "/codebase skill installed"
-
-mkdir -p "$HOME/.claude/skills/remediate"
-_cp "$REPO_DIR/skills/remediate/SKILL.md" "$HOME/.claude/skills/remediate/SKILL.md"
-ok "/remediate skill installed"
-
-mkdir -p "$HOME/.claude/skills/credential-audit"
-_cp "$REPO_DIR/skills/credential-audit/SKILL.md" "$HOME/.claude/skills/credential-audit/SKILL.md"
-ok "/credential-audit skill installed"
-
-mkdir -p "$HOME/.claude/skills/lateral-movement"
-_cp "$REPO_DIR/skills/lateral-movement/SKILL.md" "$HOME/.claude/skills/lateral-movement/SKILL.md"
-ok "/lateral-movement skill installed"
-
-mkdir -p "$HOME/.claude/skills/network-assess"
-_cp "$REPO_DIR/skills/network-assess/SKILL.md" "$HOME/.claude/skills/network-assess/SKILL.md"
-ok "/network-assess skill installed"
-
-mkdir -p "$HOME/.claude/skills/osint"
-_cp "$REPO_DIR/skills/osint/SKILL.md" "$HOME/.claude/skills/osint/SKILL.md"
-ok "/osint skill installed"
-
-mkdir -p "$HOME/.claude/skills/post-exploit"
-_cp "$REPO_DIR/skills/post-exploit/SKILL.md" "$HOME/.claude/skills/post-exploit/SKILL.md"
-ok "/post-exploit skill installed"
-
-mkdir -p "$HOME/.claude/skills/ssl-tls-audit"
-_cp "$REPO_DIR/skills/ssl-tls-audit/SKILL.md" "$HOME/.claude/skills/ssl-tls-audit/SKILL.md"
-ok "/ssl-tls-audit skill installed"
-
-mkdir -p "$HOME/.claude/skills/request-cves"
-_cp "$REPO_DIR/skills/request-cves/SKILL.md" "$HOME/.claude/skills/request-cves/SKILL.md"
-ok "/request-cves skill installed"
-
-mkdir -p "$HOME/.claude/skills/param-fuzz"
-_cp "$REPO_DIR/skills/param-fuzz/SKILL.md" "$HOME/.claude/skills/param-fuzz/SKILL.md"
-ok "/param-fuzz skill installed"
-
-mkdir -p "$HOME/.claude/skills/business-logic"
-_cp "$REPO_DIR/skills/business-logic/SKILL.md" "$HOME/.claude/skills/business-logic/SKILL.md"
-ok "/business-logic skill installed"
-
-mkdir -p "$HOME/.claude/skills/compliance/refs"
-_cp "$REPO_DIR/skills/compliance/SKILL.md" "$HOME/.claude/skills/compliance/SKILL.md"
-if [ -d "$REPO_DIR/skills/compliance/refs" ]; then
-    for _ref_src in "$REPO_DIR/skills/compliance/refs/"*; do
-        _cp "$_ref_src" "$HOME/.claude/skills/compliance/refs/$(basename "$_ref_src")"
-    done
-fi
-ok "/compliance skill installed (with ASVS 5.0 CSV ref)"
-
-mkdir -p "$HOME/.claude/skills/report"
-_cp "$REPO_DIR/skills/report/SKILL.md" "$HOME/.claude/skills/report/SKILL.md"
-ok "/report skill installed"
 
 # ── API keys (AI testing tools) ──────────────────────────────────────────────
 echo ""

--- a/installers/install_codex.sh
+++ b/installers/install_codex.sh
@@ -27,9 +27,14 @@ ok "Prerequisites satisfied (docker, poetry, codex)"
 mkdir -p "$CODEX_HOME"
 
 echo ""
-echo "Pulling skills submodule..."
-git -C "$REPO_DIR" submodule update --init --recursive
-ok "Skills submodule up to date"
+echo "Updating skills submodule from upstream..."
+if git -C "$REPO_DIR" submodule update --init --recursive --remote skills; then
+    ok "Skills submodule updated to $(git -C "$REPO_DIR/skills" rev-parse --short HEAD)"
+else
+    warn "Could not update skills from upstream - falling back to the pinned submodule commit"
+    git -C "$REPO_DIR" submodule update --init --recursive skills
+    ok "Skills submodule checked out at pinned commit $(git -C "$REPO_DIR/skills" rev-parse --short HEAD)"
+fi
 
 echo ""
 echo "Installing Python dependencies..."
@@ -126,7 +131,7 @@ done
 
 ok "$_SKILL_OK Codex skills installed"
 if [ ${#_SKILL_MISSING[@]} -gt 0 ]; then
-    warn "Missing skills (run 'git submodule update --init --recursive' to fetch): ${_SKILL_MISSING[*]}"
+    warn "Missing skills (re-run the installer to fetch the latest skills submodule): ${_SKILL_MISSING[*]}"
 fi
 
 echo ""

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -29,9 +29,14 @@ ok "Prerequisites satisfied (docker, poetry, opencode)"
 
 # ── Pull skills submodule ────────────────────────────────────────────────────
 echo ""
-echo "Pulling skills submodule..."
-git -C "$REPO_DIR" submodule update --init --recursive
-ok "Skills submodule up to date"
+echo "Updating skills submodule from upstream..."
+if git -C "$REPO_DIR" submodule update --init --recursive --remote skills; then
+    ok "Skills submodule updated to $(git -C "$REPO_DIR/skills" rev-parse --short HEAD)"
+else
+    warn "Could not update skills from upstream — falling back to the pinned submodule commit"
+    git -C "$REPO_DIR" submodule update --init --recursive skills
+    ok "Skills submodule checked out at pinned commit $(git -C "$REPO_DIR/skills" rev-parse --short HEAD)"
+fi
 
 # ── Python dependencies ───────────────────────────────────────────────────────
 echo ""
@@ -139,7 +144,11 @@ echo "Installing slash commands..."
 mkdir -p "$OPENCODE_COMMANDS_DIR"
 
 # /pentester — top-level command
-_cp "$REPO_DIR/skills/pentester.md" "$OPENCODE_COMMANDS_DIR/pentester.md"
+if [ -f "$REPO_DIR/skills/pentester-opencode/SKILL.md" ]; then
+    _cp "$REPO_DIR/skills/pentester-opencode/SKILL.md" "$OPENCODE_COMMANDS_DIR/pentester.md"
+else
+    _cp "$REPO_DIR/skills/pentester.md" "$OPENCODE_COMMANDS_DIR/pentester.md"
+fi
 ok "/pentester command installed"
 
 # Skill commands — each gets its own file
@@ -157,51 +166,43 @@ _install_skill() {
     _SKILL_OK=$((_SKILL_OK + 1))
 }
 
-_install_skill "analyze-cve"            "$REPO_DIR/skills/analyze-cve/SKILL.md"
-_install_skill "threat-model"           "$REPO_DIR/skills/threat-modeling/SKILL.md"
-_install_skill "aikido-triage"          "$REPO_DIR/skills/aikido-triage/SKILL.md"
-_install_skill "gh-export"              "$REPO_DIR/skills/gh-export/SKILL.md"
-_install_skill "ai-redteam"             "$REPO_DIR/skills/ai-redteam/SKILL.md"
-_install_skill "colang-gen"             "$REPO_DIR/skills/colang-gen/SKILL.md"
-_install_skill "container-k8s-security" "$REPO_DIR/skills/container-k8s-security/SKILL.md"
-_install_skill "cloud-security"         "$REPO_DIR/skills/cloud-security/SKILL.md"
-_install_skill "ad-assessment"          "$REPO_DIR/skills/ad-assessment/SKILL.md"
-_install_skill "email-security"         "$REPO_DIR/skills/email-security/SKILL.md"
-_install_skill "metasploit"             "$REPO_DIR/skills/metasploit/SKILL.md"
-_install_skill "reverse-shell"          "$REPO_DIR/skills/reverse-shell/SKILL.md"
-_install_skill "web-exploit"            "$REPO_DIR/skills/web-exploit/SKILL.md"
-_install_skill "api-security"           "$REPO_DIR/skills/api-security/SKILL.md"
-_install_skill "codebase"               "$REPO_DIR/skills/codebase/SKILL.md"
-_install_skill "remediate"              "$REPO_DIR/skills/remediate/SKILL.md"
-_install_skill "credential-audit"       "$REPO_DIR/skills/credential-audit/SKILL.md"
-_install_skill "lateral-movement"       "$REPO_DIR/skills/lateral-movement/SKILL.md"
-_install_skill "network-assess"         "$REPO_DIR/skills/network-assess/SKILL.md"
-_install_skill "osint"                  "$REPO_DIR/skills/osint/SKILL.md"
-_install_skill "post-exploit"           "$REPO_DIR/skills/post-exploit/SKILL.md"
-_install_skill "ssl-tls-audit"          "$REPO_DIR/skills/ssl-tls-audit/SKILL.md"
-_install_skill "request-cves"           "$REPO_DIR/skills/request-cves/SKILL.md"
-_install_skill "param-fuzz"             "$REPO_DIR/skills/param-fuzz/SKILL.md"
-_install_skill "business-logic"         "$REPO_DIR/skills/business-logic/SKILL.md"
-ok "$_SKILL_OK skill commands installed"
-if [ ${#_SKILL_MISSING[@]} -gt 0 ]; then
-    warn "Missing skills (run \`git submodule update --init --recursive\` to fetch): ${_SKILL_MISSING[*]}"
+for _skill_file in "$REPO_DIR"/skills/*/SKILL.md; do
+    [ -e "$_skill_file" ] || continue
+    _skill_name="$(basename "$(dirname "$_skill_file")")"
+
+    # /pentester is installed from the OpenCode-specific variant above.
+    [ "$_skill_name" = "pentester-opencode" ] && continue
+
+    _install_skill "$_skill_name" "$_skill_file"
+done
+
+# Backwards-compatible alias used by older docs and installs.
+if [ -f "$REPO_DIR/skills/threat-modeling/SKILL.md" ]; then
+    _install_skill "threat-model" "$REPO_DIR/skills/threat-modeling/SKILL.md"
 fi
 
-# ── Install web-exploit reference files (lazy-loaded per injection type) ─────
-echo ""
-echo "Installing web-exploit reference files..."
-REFS_SRC="$REPO_DIR/skills/web-exploit/refs"
-REFS_DST="$OPENCODE_COMMANDS_DIR/web-exploit-refs"
-if [ -d "$REFS_SRC" ]; then
-    mkdir -p "$REFS_DST"
-    for _ref_src in "$REFS_SRC"/*.md; do
-        _cp "$_ref_src" "$REFS_DST/$(basename "$_ref_src")"
-    done
-    REF_COUNT=$(ls "$REFS_DST"/*.md 2>/dev/null | wc -l | tr -d ' ')
-    ok "$REF_COUNT injection reference files installed (lazy-loaded to save context)"
-else
-    warn "web-exploit/refs/ not found — refs will be read from repo at runtime"
+ok "$_SKILL_OK skill commands installed"
+if [ ${#_SKILL_MISSING[@]} -gt 0 ]; then
+    warn "Missing skills (re-run the installer to fetch the latest skills submodule): ${_SKILL_MISSING[*]}"
 fi
+
+# ── Install skill reference files (lazy-loaded support material) ─────────────
+echo ""
+echo "Installing skill reference files..."
+_REF_OK=0
+for _refs_src in "$REPO_DIR"/skills/*/refs; do
+    [ -d "$_refs_src" ] || continue
+    _skill_name="$(basename "$(dirname "$_refs_src")")"
+    _refs_dst="$OPENCODE_COMMANDS_DIR/${_skill_name}-refs"
+
+    [[ "$_FORCE_SKILLS" == false ]] && continue
+
+    rm -rf "$_refs_dst"
+    mkdir -p "$_refs_dst"
+    cp -R "$_refs_src"/. "$_refs_dst"/
+    _REF_OK=$((_REF_OK + 1))
+done
+ok "$_REF_OK skill reference directories installed"
 
 # ── AI testing API keys (FuzzyAI + PyRIT) ────────────────────────────────────
 echo ""

--- a/installers/uninstall_codex.sh
+++ b/installers/uninstall_codex.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# uninstall_codex.sh - remove pentest-agent from OpenAI Codex
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+CODEX_SKILLS_DIR="$CODEX_HOME/skills"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}[ok]${NC} $*"; }
+warn() { echo -e "${YELLOW}[warn]${NC} $*"; }
+
+echo ""
+echo "  pentest-agent uninstaller (Codex)"
+echo "  ================================="
+echo ""
+
+# Remove the Codex MCP registration. This only changes Codex's MCP config; it
+# does not remove the repo, .env, logs, Docker images, or Poetry virtualenv.
+if command -v codex >/dev/null 2>&1; then
+    codex mcp remove pentest-agent >/dev/null 2>&1 \
+        && ok "pentest-agent MCP server removed from Codex" \
+        || warn "pentest-agent MCP server was not registered with Codex (skipping)"
+else
+    warn "codex CLI not found - skipping MCP removal"
+fi
+
+if [ ! -d "$CODEX_SKILLS_DIR" ]; then
+    warn "$CODEX_SKILLS_DIR not found - skipping skill removal"
+    echo ""
+    echo "  Uninstall complete."
+    exit 0
+fi
+
+_TMP_SKILLS="$(mktemp)"
+trap 'rm -f "$_TMP_SKILLS"' EXIT
+
+# Fallback list covers Smith skills installed by older installers even when the
+# current skills submodule is incomplete or has local edits.
+cat > "$_TMP_SKILLS" <<'EOF'
+ad-assessment
+ai-redteam
+aikido-triage
+analyze-cve
+api-security
+business-logic
+cloud-security
+codebase
+colang-gen
+compliance
+container-k8s-security
+credential-audit
+email-security
+gh-export
+lateral-movement
+metasploit
+network-assess
+oauth-security
+osint
+param-fuzz
+pentester
+post-exploit
+remediate
+report
+request-cves
+reverse-shell
+ssl-tls-audit
+threat-modeling
+web-exploit
+EOF
+
+# Also include any current repo skill directories so newly added Smith skills do
+# not require a matching uninstaller patch.
+if [ -d "$REPO_DIR/skills" ]; then
+    for _skill_file in "$REPO_DIR"/skills/*/SKILL.md; do
+        [ -e "$_skill_file" ] || continue
+        _skill_name="$(basename "$(dirname "$_skill_file")")"
+        [ "$_skill_name" = "pentester-opencode" ] && continue
+        printf '%s\n' "$_skill_name" >> "$_TMP_SKILLS"
+    done
+fi
+
+_REMOVED=0
+_SKIPPED=0
+while IFS= read -r _skill_name; do
+    [ -n "$_skill_name" ] || continue
+    _skill_dir="$CODEX_SKILLS_DIR/$_skill_name"
+    if [ -d "$_skill_dir" ]; then
+        rm -rf "$_skill_dir"
+        ok "Removed Codex skill: $_skill_name"
+        _REMOVED=$((_REMOVED + 1))
+    else
+        _SKIPPED=$((_SKIPPED + 1))
+    fi
+done < <(sort -u "$_TMP_SKILLS")
+
+echo ""
+ok "Removed $_REMOVED Codex skill directories"
+if [ "$_SKIPPED" -gt 0 ]; then
+    warn "$_SKIPPED Smith skill directories were not installed (skipped)"
+fi
+
+echo ""
+echo "  Uninstall complete."
+echo "  Note: Docker images, containers, .env, logs, and the Poetry virtualenv were NOT removed."
+echo "  To clean Docker artifacts manually:"
+echo "    docker rm -f pentest-kali pentest-metasploit 2>/dev/null || true"
+echo "    docker rmi pentest-agent/kali-mcp pentest-agent/metasploit 2>/dev/null || true"
+echo ""


### PR DESCRIPTION
Update the Claude, OpenCode, and Codex installers to fetch the latest skills submodule from upstream and install skills dynamically from skills/*/SKILL.md. This ensures newly added skills are picked up automatically without editing installer scripts.

Also adds a Codex uninstaller that removes the pentest-agent MCP registration and installed Codex skill directories while leaving Docker images, logs, .env, and local runtime state intact.