### PR TITLE
fix: resolve all 30 SonarCloud issues from PR #102

### DIFF
--- a/core/api_server.py
+++ b/core/api_server.py
@@ -706,8 +706,7 @@ async def _watchdog_tick(now: float) -> None:
         )
         return
     client = _detect_active_client()
-    safe_client = client if client in ("claude", "opencode") else "unknown"
-    _log.info("watchdog: smith stopped while scan running — auto-restart (%s)", safe_client)
+    _log.info("watchdog: smith stopped while scan running — auto-restart")
     ok, result = await _spawn_smith(client, source="watchdog")
     if ok:
         _watchdog_last_restart_ts = now

--- a/core/api_server.py
+++ b/core/api_server.py
@@ -27,6 +27,7 @@ import sys
 from pathlib import Path
 
 _log = logging.getLogger(__name__)
+_ERR_REQUEST_FAILED = "Request failed"
 
 _REPO_ROOT         = Path(__file__).parent.parent
 _FINDINGS_FILE     = _REPO_ROOT / "findings.json"
@@ -242,9 +243,9 @@ async def api_patch_finding(finding_id: str, request: Request) -> JSONResponse:
             escalation_leads=body.get("escalation_leads"),
         )
         return JSONResponse({"ok": updated})
-    except Exception as exc:
-        _log.error("api_update_finding failed: %s", exc)
-        return JSONResponse({"ok": False, "error": "Request failed"}, status_code=400)
+    except Exception:
+        _log.exception("api_update_finding failed")
+        return JSONResponse({"ok": False, "error": _ERR_REQUEST_FAILED}, status_code=400)
 
 
 @app.delete("/api/findings/{finding_id}")
@@ -253,9 +254,9 @@ async def api_delete_finding(finding_id: str) -> JSONResponse:
     try:
         archived = await delete_finding(finding_id)
         return JSONResponse({"ok": archived})
-    except Exception as exc:
-        _log.error("api_delete_finding failed: %s", exc)
-        return JSONResponse({"ok": False, "error": "Request failed"}, status_code=400)
+    except Exception:
+        _log.exception("api_delete_finding failed")
+        return JSONResponse({"ok": False, "error": _ERR_REQUEST_FAILED}, status_code=400)
 
 
 def _safe_unlink(path) -> None:
@@ -378,8 +379,8 @@ async def _cleanup_tunnels() -> str:
         )
         stdout, _ = await proc.communicate()
         return stdout.decode().strip()
-    except Exception as exc:
-        _log.error("cleanup_tunnels failed: %s", exc)
+    except Exception:
+        _log.exception("cleanup_tunnels failed")
         return "cleanup error"
 
 
@@ -434,7 +435,7 @@ async def api_intervention_respond(request: Request) -> JSONResponse:
         return JSONResponse({"ok": True, "resumed": True, "instruction": human_instruction})
     except Exception:
         _log.exception("api_intervention_respond failed")
-        return JSONResponse({"ok": False, "error": "Request failed"}, status_code=500)
+        return JSONResponse({"ok": False, "error": _ERR_REQUEST_FAILED}, status_code=500)
 
 
 @app.post("/api/steer")
@@ -461,7 +462,7 @@ async def api_steer(request: Request) -> JSONResponse:
         return JSONResponse({"ok": True})
     except Exception:
         _log.exception("api_steer failed")
-        return JSONResponse({"ok": False, "error": "Request failed"}, status_code=500)
+        return JSONResponse({"ok": False, "error": _ERR_REQUEST_FAILED}, status_code=500)
 
 
 @app.post("/api/complete")
@@ -484,7 +485,7 @@ async def api_complete(request: Request) -> JSONResponse:
         return JSONResponse({"ok": True, "status": status})
     except Exception:
         _log.exception("api_complete failed")
-        return JSONResponse({"ok": False, "error": "Request failed"}, status_code=500)
+        return JSONResponse({"ok": False, "error": _ERR_REQUEST_FAILED}, status_code=500)
 
 
 _SMITH_IDLE_SECONDS = 180  # >3 min with no scan activity → Smith is considered stopped
@@ -627,10 +628,10 @@ async def _spawn_smith(client: str, source: str = "api") -> tuple[bool, int | st
         )
 
         log_path = _REPO_ROOT / "logs" / "smith_restart.log"
-        log_path.parent.mkdir(exist_ok=True)
-        # Audit marker so watchdog vs manual restarts are visible in the log
-        with open(log_path, "a") as f:
-            f.write(f"\n=== [{source}] spawning {client} at {asyncio.get_event_loop().time()} ===\n")
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, log_path.parent.mkdir, True, True)
+        audit_line = f"\n=== [{source}] spawning {client} at {loop.time()} ===\n"
+        await loop.run_in_executor(None, lambda: log_path.open("a").write(audit_line))
 
         import shutil
         if client == "claude":
@@ -643,10 +644,11 @@ async def _spawn_smith(client: str, source: str = "api") -> tuple[bool, int | st
         if not os.path.exists(binary):
             return False, f"{client} binary not found at {binary}"
 
+        log_fh = await loop.run_in_executor(None, lambda: log_path.open("a"))
         proc = await asyncio.create_subprocess_exec(
             *args,
-            stdout=open(log_path, "a"),
-            stderr=open(log_path, "a"),
+            stdout=log_fh,
+            stderr=log_fh,
             cwd=str(_REPO_ROOT),
             start_new_session=True,
         )
@@ -658,7 +660,7 @@ async def _spawn_smith(client: str, source: str = "api") -> tuple[bool, int | st
         return False, "spawn failed"
 
 
-async def _mcp_sse_alive() -> bool:
+def _mcp_sse_alive() -> bool:
     """Quick liveness check on the MCP SSE server (port 7778).
 
     Used by the watchdog to skip restarts when MCP is dead — restarting
@@ -674,9 +676,43 @@ async def _mcp_sse_alive() -> bool:
         with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             sock.settimeout(0.8)
             return sock.connect_ex(("127.0.0.1", 7778)) == 0
-    except (OSError, socket.gaierror) as e:
+    except OSError as e:
         _log.debug("mcp_sse_alive check failed: %s", e)
         return False
+
+
+async def _watchdog_tick(now: float) -> None:
+    """Single watchdog tick: restart Smith if all guard conditions pass."""
+    global _watchdog_last_restart_ts
+    session_data = _read_json(_SESSION_FILE)
+    if session_data.get("status") != "running":
+        return
+    if (session_data.get("intervention") or {}).get("code"):
+        return
+    if _smith_running():
+        return
+    if not _mcp_sse_alive():
+        _log.warning("watchdog suppressed: MCP SSE server unreachable on 127.0.0.1:7778")
+        return
+    if now - _watchdog_last_restart_ts < _WATCHDOG_MIN_GAP_SECONDS:
+        return
+    _watchdog_restart_count_window[:] = [
+        t for t in _watchdog_restart_count_window if now - t < 3600
+    ]
+    if len(_watchdog_restart_count_window) >= _WATCHDOG_MAX_PER_HOUR:
+        _log.warning(
+            "watchdog suppressed: %d restarts in last hour exceeds cap %d",
+            len(_watchdog_restart_count_window), _WATCHDOG_MAX_PER_HOUR,
+        )
+        return
+    client = _detect_active_client()
+    safe_client = client if client in ("claude", "opencode") else "unknown"
+    _log.info("watchdog: smith stopped while scan running — auto-restart (%s)", safe_client)
+    ok, result = await _spawn_smith(client, source="watchdog")
+    if ok:
+        _watchdog_last_restart_ts = now
+        _watchdog_restart_count_window.append(now)
+        _log.info("watchdog: spawned pid=%s", result)
 
 
 async def _smith_watchdog_loop() -> None:
@@ -693,48 +729,13 @@ async def _smith_watchdog_loop() -> None:
     as the dashboard process lives. Safety cap prevents storms when Smith
     dies immediately on startup repeatedly (e.g. config error).
     """
-    global _watchdog_last_restart_ts
     import time as _time
     while True:
         try:
             await asyncio.sleep(_WATCHDOG_POLL_SECONDS)
-            session_data = _read_json(_SESSION_FILE)
-            if session_data.get("status") != "running":
-                continue
-            if (session_data.get("intervention") or {}).get("code"):
-                continue
-            if _smith_running():
-                continue
-            # Gate on MCP SSE health. Without MCP, restarted Smith burns a turn
-            # bouncing off "Invalid request parameters" and producing a text
-            # response that ends the opencode -p run — causing the watchdog to
-            # respawn into the same wall every minute.
-            if not await _mcp_sse_alive():
-                _log.warning("watchdog suppressed: MCP SSE server unreachable on 127.0.0.1:7778")
-                continue
-            now = _time.time()
-            if now - _watchdog_last_restart_ts < _WATCHDOG_MIN_GAP_SECONDS:
-                continue
-            # Prune restarts older than 1h
-            _watchdog_restart_count_window[:] = [
-                t for t in _watchdog_restart_count_window if now - t < 3600
-            ]
-            if len(_watchdog_restart_count_window) >= _WATCHDOG_MAX_PER_HOUR:
-                _log.warning(
-                    "watchdog suppressed: %d restarts in last hour exceeds cap %d",
-                    len(_watchdog_restart_count_window), _WATCHDOG_MAX_PER_HOUR,
-                )
-                continue
-
-            client = _detect_active_client()
-            _log.info("watchdog: smith stopped while scan running — auto-restart (%s)", client)
-            ok, result = await _spawn_smith(client, source="watchdog")
-            if ok:
-                _watchdog_last_restart_ts = now
-                _watchdog_restart_count_window.append(now)
-                _log.info("watchdog: spawned pid=%s", result)
+            await _watchdog_tick(_time.time())
         except asyncio.CancelledError:
-            return
+            raise
         except Exception:
             _log.exception("watchdog loop error (continuing)")
 

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -401,7 +401,7 @@ def _validate_auth_response(
         if artifact_file.stat().st_size > _MAX_ARTIFACT_BYTES:
             return ""  # too big to safely parse; let the cell close
         data = json.loads(artifact_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, ValueError):
+    except (OSError, ValueError):
         return ""
     response_status = data.get("status")
     if response_status not in (401, 403):
@@ -475,7 +475,7 @@ async def update_cell(
     return False
 
 
-def _apply_bulk_cell(cell: dict, upd: dict, warnings: list[str], ep_path: str = "?") -> None:
+def _apply_bulk_cell(cell: dict, upd: dict, warnings: list[str]) -> None:
     """Apply one bulk-update entry to a cell in-place, appending any warnings.
 
     Caller is expected to have already vetted the (artifact, auth, finding-link)
@@ -513,7 +513,6 @@ async def bulk_update(updates: list[dict]) -> dict:
     async with _lock:
         data = _load()
         cell_map = {c["id"]: c for c in data["matrix"]}
-        ep_map = {ep["id"]: ep.get("path", "?") for ep in data.get("endpoints", [])}
         count = 0
         rejected = 0
         warnings: list[str] = []
@@ -542,8 +541,7 @@ async def bulk_update(updates: list[dict]) -> dict:
                     warnings.append(f"REJECTED cell {cid}: {link_reject}")
                     rejected += 1
                     continue
-            ep_path = ep_map.get(cell_map[cid].get("endpoint_id", ""), "?")
-            _apply_bulk_cell(cell_map[cid], upd, warnings, ep_path)
+            _apply_bulk_cell(cell_map[cid], upd, warnings)
             count += 1
         _recount(data)
         _save(data)

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -741,7 +741,7 @@ def _check_target_unreachable(entries: list[dict]) -> dict | None:
             "WAIT: Target may be temporarily down — tell me how long to wait before retrying",
             "ROTATE: Provide an alternative IP, proxy, or User-Agent to bypass the block",
             "SKIP_TARGET: Mark this target as unreachable and continue with remaining scope",
-            "ABORT: Stop the scan",
+            _ABORT_OPTION,
         ],
     )
     return {
@@ -810,6 +810,7 @@ def _check_exploit_escalation(entries: list[dict], findings_data: dict, session_
 # therefore have NO Docker dependency. Failure modes here are network /
 # target / DNS / SSL, not container infrastructure.
 _PYTHON_NATIVE_TOOLS = {"http_request", "spider"}
+_ABORT_OPTION = "ABORT: Stop the scan"
 
 
 def _check_repeated_tool_failure(entries: list[dict]) -> dict | None:
@@ -846,7 +847,7 @@ def _check_repeated_tool_failure(entries: list[dict]) -> dict | None:
             "VERIFY: Confirm the target URL is correct (DNS, port, scheme) and I will retry",
             "ROTATE: Provide an alternative proxy / User-Agent / endpoint to bypass blocks",
             "SKIP_TOOL: Stop using this tool and rely on alternatives for the rest of the scan",
-            "ABORT: Stop the scan",
+            _ABORT_OPTION,
         ]
         message = (
             f"Tool '{broken_tool}' failed 3 times in a row — target reachability / network suspected"
@@ -860,7 +861,7 @@ def _check_repeated_tool_failure(entries: list[dict]) -> dict | None:
             "RESTART_INFRA: I will run session(action='start_kali') to restart the Kali container and retry",
             "SKIP_TOOL: Tell me to avoid this tool for the rest of the scan and use alternatives",
             "INVESTIGATE: Check the logs — run `docker ps` to verify containers are healthy",
-            "ABORT: Stop the scan",
+            _ABORT_OPTION,
         ]
         message = (
             f"Tool '{broken_tool}' failed 3 times in a row — infrastructure issue suspected"

--- a/mcp_server/scan_engine/envelope.py
+++ b/mcp_server/scan_engine/envelope.py
@@ -49,6 +49,58 @@ class Envelope:
         return json.dumps(asdict(self), indent=2)
 
 
+def _check_scan_gate(tool: str) -> str | None:
+    """Return a blocking JSON string if this tool call should be short-circuited, else None.
+
+    Checks (in order):
+    1. Scan is paused for human intervention — all tools except session() blocked.
+    2. Scan reached a terminal state — all tools except session() blocked.
+    """
+    if tool == "session":
+        return None
+    try:
+        from core import session as _sess
+        iv = _sess.get_intervention()
+        if iv:
+            return json.dumps({
+                "status": "HUMAN_INTERVENTION_REQUIRED",
+                "code":   iv.get("code", "HIR_UNKNOWN"),
+                "situation": iv.get("situation", ""),
+                "options":   iv.get("options", []),
+                "scan_paused": True,
+                "how_to_respond": (
+                    "The scan is paused. Respond via the dashboard 'Send to Smith' panel, "
+                    "or call: session(action='resume', options={choice: '...', message: '...'})"
+                ),
+            }, indent=2)
+    except (ImportError, AttributeError, OSError) as e:
+        _log.warning("intervention check failed: %s", e)
+    try:
+        from core import session as _sess
+        current = _sess.get() or {}
+        scan_status = current.get("status", "")
+        if scan_status in (
+            "complete", "incomplete_with_unresolved_blockers", "limit_reached",
+        ):
+            return json.dumps({
+                "status": "SCAN_COMPLETED",
+                "scan_status": scan_status,
+                "message": (
+                    f"This scan has been marked '{scan_status}' by the human operator "
+                    "via the dashboard (or a budget/time limit was reached). Stop "
+                    "calling tools. Write one final brief summary message — "
+                    "do NOT make any further tool calls — and end your turn."
+                ),
+                "how_to_resume": (
+                    "If the human wants more testing they will start a fresh scan via "
+                    "session(action='start') — do not call that yourself."
+                ),
+            }, indent=2)
+    except (ImportError, AttributeError, OSError) as e:
+        _log.warning("terminal-status check failed: %s", e)
+    return None
+
+
 def wrap(tool: str, raw_output: str, context: dict | None = None) -> str:
     """Central entry point: raw tool output in, canonical envelope JSON out.
 
@@ -60,59 +112,9 @@ def wrap(tool: str, raw_output: str, context: dict | None = None) -> str:
     Returns:
         JSON string of the canonical envelope
     """
-    # Block all tool calls while scan is paused for human intervention.
-    # session() calls are exempt so the agent can call session(action='resume').
-    if tool != "session":
-        try:
-            from core import session as _sess
-            iv = _sess.get_intervention()
-            if iv:
-                return json.dumps({
-                    "status": "HUMAN_INTERVENTION_REQUIRED",
-                    "code":   iv.get("code", "HIR_UNKNOWN"),
-                    "situation": iv.get("situation", ""),
-                    "options":   iv.get("options", []),
-                    "scan_paused": True,
-                    "how_to_respond": (
-                        "The scan is paused. Respond via the dashboard 'Send to Smith' panel, "
-                        "or call: session(action='resume', options={choice: '...', message: '...'})"
-                    ),
-                }, indent=2)
-        except (ImportError, AttributeError, OSError) as e:
-            # We never want a session-read error to break tool dispatch — but
-            # we log so the failure isn't silent.
-            _log.warning("intervention check failed: %s", e)
-
-    # Block all tool calls when the scan reached a terminal state
-    # (human clicked Complete Scan, cost/time/call limit hit, etc.).
-    # session() is exempt so Smith can still call session(action='status')
-    # to confirm what happened — but every scan-progressing tool returns a
-    # stop signal so opencode -p exits via Smith's final summary response.
-    if tool != "session":
-        try:
-            from core import session as _sess
-            current = _sess.get() or {}
-            scan_status = current.get("status", "")
-            if scan_status in (
-                "complete", "incomplete_with_unresolved_blockers", "limit_reached",
-            ):
-                return json.dumps({
-                    "status": "SCAN_COMPLETED",
-                    "scan_status": scan_status,
-                    "message": (
-                        f"This scan has been marked '{scan_status}' by the human operator "
-                        "via the dashboard (or a budget/time limit was reached). Stop "
-                        "calling tools. Write one final brief summary message — "
-                        "do NOT make any further tool calls — and end your turn."
-                    ),
-                    "how_to_resume": (
-                        "If the human wants more testing they will start a fresh scan via "
-                        "session(action='start') — do not call that yourself."
-                    ),
-                }, indent=2)
-        except (ImportError, AttributeError, OSError) as e:
-            # Same narrow swallow as the intervention check — surface via log.
-            _log.warning("terminal-status check failed: %s", e)
+    blocked = _check_scan_gate(tool)
+    if blocked:
+        return blocked
 
     ctx = context or {}
 
@@ -246,6 +248,49 @@ _JWT_RE = __import__("re").compile(r"eyJ[A-Za-z0-9_-]{4,}\.eyJ[A-Za-z0-9_-]{4,}\
 _AUTH_PATH_HINTS = ("login", "signin", "auth", "token", "session")
 
 
+def _update_jwt_tokens(scan_session: Any, req_headers: dict, body_prev: str, url: str) -> None:
+    """Scan response body + auth-y request headers for JWT strings and persist any found."""
+    from datetime import datetime, timezone
+    haystack = body_prev
+    for k, v in req_headers.items():
+        if isinstance(v, str) and "auth" in k.lower():
+            haystack += " " + v
+    tokens = [
+        {"type": "jwt", "value": m,
+         "obtained_at": datetime.now(timezone.utc).isoformat(), "source_url": url}
+        for m in _JWT_RE.findall(haystack)
+    ]
+    if tokens:
+        scan_session.update_known_assets("auth_tokens", tokens)
+
+
+def _update_credentials(
+    scan_session: Any, url: str, method: str, status: int, req_body: str
+) -> None:
+    """Persist credentials and auth endpoint when a POST login succeeds."""
+    import json
+    if not (method == "POST" and 200 <= status < 300
+            and any(h in url.lower() for h in _AUTH_PATH_HINTS) and req_body):
+        return
+    try:
+        req_data = json.loads(req_body) if req_body.lstrip().startswith("{") else None
+    except Exception:
+        req_data = None
+    if not isinstance(req_data, dict):
+        return
+    uname = req_data.get("username") or req_data.get("user") or req_data.get("email")
+    pword = req_data.get("password") or req_data.get("pass") or req_data.get("pwd")
+    if uname and pword:
+        scan_session.update_known_assets("credentials", [{
+            "username": str(uname), "password": str(pword),
+            "source": f"login_success {url}",
+        }])
+        scan_session.update_known_assets("auth_endpoints", [{
+            "path": url, "method": method,
+            "body_template": {"username": "$USERNAME", "password": "$PASSWORD"},
+        }])
+
+
 def _persist_http_auth_assets(scan_session: Any, evidence: dict, ctx: dict) -> None:
     """Extract JWTs, credentials, and auth endpoints from an http_request.
 
@@ -256,54 +301,15 @@ def _persist_http_auth_assets(scan_session: Any, evidence: dict, ctx: dict) -> N
         contained username/password adds the credentials to known_assets.credentials
         AND registers the auth endpoint in known_assets.auth_endpoints.
     """
-    import json
-    from datetime import datetime, timezone
-
-    status     = evidence.get("status", 0)
-    body_prev  = evidence.get("body_preview", "")
-    url        = ctx.get("url", "")
-    method     = (ctx.get("method") or "GET").upper()
-    req_body   = ctx.get("body", "") or ""
+    status      = evidence.get("status", 0)
+    body_prev   = evidence.get("body_preview", "")
+    url         = ctx.get("url", "")
+    method      = (ctx.get("method") or "GET").upper()
+    req_body    = ctx.get("body", "") or ""
     req_headers = ctx.get("headers") or {}
 
-    # 1. JWT extraction — search response body and any Authorization-like input
-    haystack = body_prev
-    for k, v in req_headers.items():
-        if isinstance(v, str) and "auth" in k.lower():
-            haystack += " " + v
-    tokens = []
-    for m in _JWT_RE.findall(haystack):
-        tokens.append({
-            "type":        "jwt",
-            "value":       m,
-            "obtained_at": datetime.now(timezone.utc).isoformat(),
-            "source_url":  url,
-        })
-    if tokens:
-        scan_session.update_known_assets("auth_tokens", tokens)
-
-    # 2. Credential + auth_endpoint extraction — POST to auth-y path with 2xx
-    path_lower = url.lower()
-    is_auth_path = any(h in path_lower for h in _AUTH_PATH_HINTS)
-    if method == "POST" and 200 <= status < 300 and is_auth_path and req_body:
-        try:
-            req_data = json.loads(req_body) if req_body.lstrip().startswith("{") else None
-        except Exception:
-            req_data = None
-        if isinstance(req_data, dict):
-            uname = req_data.get("username") or req_data.get("user") or req_data.get("email")
-            pword = req_data.get("password") or req_data.get("pass") or req_data.get("pwd")
-            if uname and pword:
-                scan_session.update_known_assets("credentials", [{
-                    "username": str(uname),
-                    "password": str(pword),
-                    "source":   f"login_success {url}",
-                }])
-                scan_session.update_known_assets("auth_endpoints", [{
-                    "path":         url,
-                    "method":       method,
-                    "body_template": {"username": "$USERNAME", "password": "$PASSWORD"},
-                }])
+    _update_jwt_tokens(scan_session, req_headers, body_prev, url)
+    _update_credentials(scan_session, url, method, status, req_body)
 
 
 def _extract_and_persist_assets(tool: str, result: Any, ctx: dict) -> None:
@@ -732,7 +738,6 @@ def _is_auth_attempt(ctx: dict) -> bool:
     """
     body  = (ctx.get("body") or "")
     query = (ctx.get("query") or "")
-    headers = ctx.get("headers") or {}
     haystack = body + " " + query
     # Auth-bearing request headers should NOT trigger this (we're sending auth, not testing it)
     if _AUTH_FIELD_RE.search(haystack):
@@ -767,39 +772,35 @@ def _build_quick_log_entry(
         }
 
     entry: dict = {"type": "TOOL", "name": tool, "target": target}
-    # Enrich http_request entries with status_code for auth failure detection
-    if result is not None and tool == "http_request":
-        ev = result.evidence or {}
-        sc = ev.get("status", 0)
-        if sc:
-            entry["status_code"] = int(sc)
-        # Flag credential-validation attempts so the QA daemon can exclude
-        # them from its "session expired" detection. A 401 to /login with
-        # a password is a wrong-creds test, not a sign that auth broke.
-        if ctx and _is_auth_attempt(ctx):
-            entry["auth_attempt"] = True
-    # Mark a tool call as a failure ONLY when the call itself did not produce
-    # a real response. Two narrow signals:
-    #   1. The tool wrapper set evidence.error (aiohttp exception, Docker
-    #      container missing, kali server unreachable, etc.) — set by the
-    #      *tool*, not by the summarizer.
-    #   2. http_request returned status == 0 — no HTTP response received.
-    # We deliberately DO NOT scan result.anomalies for "error"/"timeout"/
-    # "unreachable" keywords: those describe what was *found* in the response
-    # body (SQL error messages, target reporting a timeout, etc.) and are
-    # findings, not tool failures. The old keyword scan caused 53% of
-    # successful http_request entries to be falsely flagged error=True,
-    # which in turn fired spurious HIR_TOOL_FAILURE alerts whenever Smith
-    # was actually finding bugs.
-    if result is not None:
-        ev = result.evidence or {}
-        is_error = bool(
-            ev.get("error")
-            or (tool == "http_request" and _is_zero_status(ev.get("status")))
-        )
-        if is_error:
-            entry["error"] = True
+    _enrich_http_request_entry(entry, tool, result, ctx)
+    _mark_tool_error(entry, tool, result)
     return entry
+
+
+def _enrich_http_request_entry(
+    entry: dict, tool: str, result: Any, ctx: dict | None
+) -> None:
+    """Add status_code and auth_attempt fields to http_request log entries."""
+    if result is None or tool != "http_request":
+        return
+    ev = result.evidence or {}
+    sc = ev.get("status", 0)
+    if sc:
+        entry["status_code"] = int(sc)
+    if ctx and _is_auth_attempt(ctx):
+        entry["auth_attempt"] = True
+
+
+def _mark_tool_error(entry: dict, tool: str, result: Any) -> None:
+    """Set entry["error"] = True when the tool call itself produced no real response.
+
+    Only two narrow signals qualify (see _build_quick_log_entry for rationale).
+    """
+    if result is None:
+        return
+    ev = result.evidence or {}
+    if ev.get("error") or (tool == "http_request" and _is_zero_status(ev.get("status"))):
+        entry["error"] = True
 
 
 def _quick_log_tool(tool: str, ctx: dict, summarizer_summary: str, result: Any = None) -> None:

--- a/mcp_server/scan_engine/summarizers.py
+++ b/mcp_server/scan_engine/summarizers.py
@@ -85,37 +85,22 @@ def _build_httpx_facts(result: SummaryResult, status: Any, server: str, content_
         result.facts.append(f"CDN/WAF: {cdn_or_waf}")
 
 
-def _summarize_httpx(raw: str, ctx: dict) -> SummaryResult:
-    """Parse httpx output to extract tech stack, status, WAF, headers."""
-    result = SummaryResult()
-    lines = raw.strip().splitlines()
-
-    parsed: dict | None = None
-    url = ctx.get("url", "")
-
+def _find_parsed_httpx_line(lines: list[str], url: str) -> dict | None:
+    """Return the first successfully parsed line from httpx output, or None."""
     for line in lines:
         line = line.strip()
-        if line.startswith("{"):
-            parsed = _parse_httpx_json_line(line, url)
-            if parsed:
-                break
-        else:
-            parsed = _parse_httpx_text_line(line, url)
-            if parsed:
-                break
+        parsed = (
+            _parse_httpx_json_line(line, url)
+            if line.startswith("{")
+            else _parse_httpx_text_line(line, url)
+        )
+        if parsed:
+            return parsed
+    return None
 
-    if parsed:
-        status = parsed["status"]
-        url = parsed["url"]
-        server = parsed["server"]
-        tech = parsed["tech"]
-        content_type = parsed["content_type"]
-        title = parsed["title"]
-        cdn_or_waf = parsed["cdn_or_waf"]
-    else:
-        status = None
-        server = tech = content_type = title = cdn_or_waf = ""
 
+def _build_httpx_summary(result: "SummaryResult", url: str, status: object, server: str) -> None:
+    """Populate result.summary and anomalies based on parsed httpx status."""
     if status:
         result.summary = f"{url} is live (HTTP {status})"
         if server:
@@ -124,6 +109,26 @@ def _summarize_httpx(raw: str, ctx: dict) -> SummaryResult:
         result.summary = f"httpx scan of {url} — could not parse status"
         result.anomalies.append("Could not parse httpx output format")
 
+
+def _summarize_httpx(raw: str, ctx: dict) -> SummaryResult:
+    """Parse httpx output to extract tech stack, status, WAF, headers."""
+    result = SummaryResult()
+    url = ctx.get("url", "")
+    parsed = _find_parsed_httpx_line(raw.strip().splitlines(), url)
+
+    if parsed:
+        status       = parsed["status"]
+        url          = parsed["url"]
+        server       = parsed["server"]
+        tech         = parsed["tech"]
+        content_type = parsed["content_type"]
+        title        = parsed["title"]
+        cdn_or_waf   = parsed["cdn_or_waf"]
+    else:
+        status = None
+        server = tech = content_type = title = cdn_or_waf = ""
+
+    _build_httpx_summary(result, url, status, server)
     _build_httpx_facts(result, status, server, content_type, title, tech, cdn_or_waf)
 
     result.evidence = {

--- a/mcp_server/scan_tools.py
+++ b/mcp_server/scan_tools.py
@@ -109,6 +109,7 @@ async def _handle_ffuf(target, flags, options):
 
 async def _run_spider_thorough(target: str, flags: str, cookies: dict, depth: str, max_pages: str, timeout: int) -> str:
     """Run katana + playwright + ZAP AJAX spider in thorough mode and return merged raw output."""
+    import asyncio as _asyncio
     from tools import kali_runner
     import json as _json
 
@@ -142,7 +143,8 @@ async def _run_spider_thorough(target: str, flags: str, cookies: dict, depth: st
         ("=== playwright ===", playwright_cmd, per_subtool),
         ("=== zap-ajax ===", zap_cmd, per_subtool),
     ]:
-        out = _clip(await kali_runner.exec_command(cmd, timeout=t), 4_000)
+        async with _asyncio.timeout(t):
+            out = _clip(await kali_runner.exec_command(cmd), 4_000)
         parts.append(f"{label}\n{out}")
 
     return "\n\n".join(parts)
@@ -150,6 +152,7 @@ async def _run_spider_thorough(target: str, flags: str, cookies: dict, depth: st
 
 async def _run_spider_fast(target: str, flags: str, cookies: dict, depth: str, max_pages: str, mode: str, timeout: int) -> str:
     """Run the fast/playwright/deep spider mode and return raw output."""
+    import asyncio as _asyncio
     from tools import kali_runner
     import json as _json
 
@@ -173,7 +176,8 @@ async def _run_spider_fast(target: str, flags: str, cookies: dict, depth: str, m
         if safe_flags:
             cmd += f" {safe_flags}"
 
-    return _clip(await kali_runner.exec_command(cmd, timeout=timeout), 8_000)
+    async with _asyncio.timeout(timeout):
+        return _clip(await kali_runner.exec_command(cmd), 8_000)
 
 
 async def _handle_spider(target, flags, options):

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -589,7 +589,6 @@ def _deepen_brief_whitebox(analysis_pass: int) -> str:
     findings = data.get("findings", [])
     criticals = [f for f in findings if f.get("severity") == "critical"]
     highs = [f for f in findings if f.get("severity") == "high"]
-    current = scan_session.get() or {}
     finding_summary = f"{len(findings)} findings ({len(criticals)} critical, {len(highs)} high)"
 
     steps: list[str] = []
@@ -717,7 +716,7 @@ def _deepen_brief_whitebox(analysis_pass: int) -> str:
 
 
 def _deepen_steps_pass1(
-    criticals: list, has_ai_ep: bool, skills_run: set, unchained: list
+    has_ai_ep: bool, skills_run: set, unchained: list
 ) -> list[str]:
     steps: list[str] = []
     steps.append(
@@ -850,7 +849,7 @@ def _deepen_brief(iteration: int) -> str:
 
     # ── Build the ordered mandatory re-run list ─────────────────────────────────
     if iteration == 1:
-        steps = _deepen_steps_pass1(criticals, has_ai_ep, skills_run, unchained)
+        steps = _deepen_steps_pass1(has_ai_ep, skills_run, unchained)
         intro = (
             f"⛔ ITERATION GATE: Pass 1/{_THOROUGH_MIN_ITERATIONS} done — "
             "thorough depth requires {_THOROUGH_MIN_ITERATIONS} full passes. "
@@ -940,93 +939,101 @@ def _collect_completion_blockers(data: dict, effective: set) -> list[str]:
     return blockers
 
 
-def _do_complete(opts):
-    global _complete_attempts, _analysis_passes
-    _complete_attempts += 1
-    notes = opts.get("notes", "")
-
-    data = findings_store._load()
-
-    # Persist attempt counters to session.json so they survive context compaction.
+def _persist_completion_counters() -> dict:
+    """Flush attempt/pass counters to session.json and return current session."""
     current = scan_session.get() or {}
     if current:
         current["complete_attempts"] = _complete_attempts
         current["analysis_passes"] = _analysis_passes
         scan_session._flush()
+    return current
+
+
+def _apply_thorough_depth_gate(blockers: list, current: dict) -> list:
+    """Increment analysis pass counter when quality-clean and append iteration blocker if needed.
+
+    Returns the (possibly appended) blockers list.
+    """
+    global _analysis_passes
+    depth = (scan_session.get() or {}).get("depth", "")
+    if blockers or depth != "thorough":
+        return blockers
+    _analysis_passes += 1
+    if current:
+        current["analysis_passes"] = _analysis_passes
+        scan_session._flush()
+    if _analysis_passes < _THOROUGH_MIN_ITERATIONS:
+        brief = (
+            _deepen_brief_whitebox(_analysis_passes)
+            if _is_whitebox_scan()
+            else _deepen_brief(_analysis_passes)
+        )
+        blockers.append(brief)
+    return blockers
+
+
+def _build_blocker_response(blockers: list) -> str:
+    """Build the blocked-completion response string or HIR JSON."""
+    if _complete_attempts >= _MAX_COMPLETE_ATTEMPTS:
+        attempts = _complete_attempts
+        log.note(f"HIR triggered after {attempts} blocked complete() attempts. Blockers: {'; '.join(b[:80] for b in blockers)}")
+        scan_session.trigger_intervention(
+            code="HIR_FORCE_COMPLETE",
+            situation=(
+                f"{len(blockers)} completion blocker(s) could not be resolved after "
+                f"{attempts} attempts. The scan cannot complete automatically."
+            ),
+            tried=[f"complete() attempt {i+1}/{attempts}" for i in range(min(attempts, 5))],
+            options=[
+                "SKIP_CELLS: Tell me which specific cells or endpoint types to mark as skipped — I will document them and complete",
+                "REDUCE_SCOPE: Specify which checks to drop (e.g. 'skip all rate_limit cells', 'accept missing PoC for finding X')",
+                "ACCEPT_PARTIAL: I will complete with current coverage and flag all unresolved items in the report",
+                "CONTINUE: Provide specific instructions to resolve the remaining blockers and I will retry",
+            ],
+        )
+        return json.dumps({
+            "status": "HUMAN_INTERVENTION_REQUIRED",
+            "code": "HIR_FORCE_COMPLETE",
+            "situation": f"{len(blockers)} blocker(s) unresolved after {attempts} complete() attempts.",
+            "blockers": blockers[:5],
+            "options": [
+                "SKIP_CELLS — specify cells/endpoint types to skip",
+                "REDUCE_SCOPE — drop specific checks",
+                "ACCEPT_PARTIAL — complete with documented gaps",
+                "CONTINUE — give me instructions to fix the blockers",
+            ],
+            "how_to_respond": "Use the dashboard 'Send to Smith' panel, or call session(action='resume', options={choice: '...', message: '...'})",
+            "scan_paused": True,
+        }, indent=2)
+    depth = (scan_session.get() or {}).get("depth", "")
+    if depth == "thorough" and _analysis_passes < _THOROUGH_MIN_ITERATIONS:
+        header = (
+            f"complete BLOCKED — thorough scan requires {_THOROUGH_MIN_ITERATIONS} analysis passes "
+            f"(quality-clean passes: {_analysis_passes}/{_THOROUGH_MIN_ITERATIONS}):\n\n"
+        )
+    else:
+        header = f"complete BLOCKED (attempt {_complete_attempts}/{_MAX_COMPLETE_ATTEMPTS}) — fix the following first:\n\n"
+    msg = header + "\n\n".join(f"  [{i+1}] {b}" for i, b in enumerate(blockers))
+    log.note(
+        f"complete blocked (attempt {_complete_attempts}, analysis_passes={_analysis_passes}): "
+        f"{'; '.join(b[:80] for b in blockers)}"
+    )
+    return msg
+
+
+def _do_complete(opts):
+    global _complete_attempts, _analysis_passes
+    _complete_attempts += 1
+
+    data = findings_store._load()
+    current = _persist_completion_counters()
 
     effective = _effective_tools()
     blockers = _collect_completion_blockers(data, effective)
-
-    # ── Thorough-depth iteration gate ────────────────────────────────────────
-    # _analysis_passes counts complete() calls that had NO quality blockers — i.e. genuine
-    # analysis passes.  Quality-fix attempts (where the model only added missing PoC files or
-    # reproduction steps) do NOT increment this counter, so they cannot satisfy the gate.
-    # This prevents the bug where 2 quality-fix attempts consumed the entire 3-pass budget.
-    depth = (scan_session.get() or {}).get("depth", "")
-    if not blockers and depth == "thorough":
-        # This call is quality-clean: count it as a real analysis pass.
-        _analysis_passes += 1
-        if current:
-            current["analysis_passes"] = _analysis_passes
-            scan_session._flush()
-
-        if _analysis_passes < _THOROUGH_MIN_ITERATIONS:
-            brief = (
-                _deepen_brief_whitebox(_analysis_passes)
-                if _is_whitebox_scan()
-                else _deepen_brief(_analysis_passes)
-            )
-            blockers.append(brief)
+    blockers = _apply_thorough_depth_gate(blockers, current)
 
     if blockers:
-        # After max attempts, escalate to HUMAN INTERVENTION REQUIRED.
-        # The scan pauses — no tool calls execute while intervention_required.
-        # The human decides via dashboard or session(action='resume').
-        if _complete_attempts >= _MAX_COMPLETE_ATTEMPTS:
-            attempts = _complete_attempts
-            log.note(f"HIR triggered after {attempts} blocked complete() attempts. Blockers: {'; '.join(b[:80] for b in blockers)}")
-            scan_session.trigger_intervention(
-                code="HIR_FORCE_COMPLETE",
-                situation=(
-                    f"{len(blockers)} completion blocker(s) could not be resolved after "
-                    f"{attempts} attempts. The scan cannot complete automatically."
-                ),
-                tried=[f"complete() attempt {i+1}/{attempts}" for i in range(min(attempts, 5))],
-                options=[
-                    "SKIP_CELLS: Tell me which specific cells or endpoint types to mark as skipped — I will document them and complete",
-                    "REDUCE_SCOPE: Specify which checks to drop (e.g. 'skip all rate_limit cells', 'accept missing PoC for finding X')",
-                    "ACCEPT_PARTIAL: I will complete with current coverage and flag all unresolved items in the report",
-                    "CONTINUE: Provide specific instructions to resolve the remaining blockers and I will retry",
-                ],
-            )
-            return json.dumps({
-                "status": "HUMAN_INTERVENTION_REQUIRED",
-                "code": "HIR_FORCE_COMPLETE",
-                "situation": f"{len(blockers)} blocker(s) unresolved after {attempts} complete() attempts.",
-                "blockers": blockers[:5],
-                "options": [
-                    "SKIP_CELLS — specify cells/endpoint types to skip",
-                    "REDUCE_SCOPE — drop specific checks",
-                    "ACCEPT_PARTIAL — complete with documented gaps",
-                    "CONTINUE — give me instructions to fix the blockers",
-                ],
-                "how_to_respond": "Use the dashboard 'Send to Smith' panel, or call session(action='resume', options={choice: '...', message: '...'})",
-                "scan_paused": True,
-            }, indent=2)
-        depth = (scan_session.get() or {}).get("depth", "")
-        if depth == "thorough" and _analysis_passes < _THOROUGH_MIN_ITERATIONS:
-            header = (
-                f"complete BLOCKED — thorough scan requires {_THOROUGH_MIN_ITERATIONS} analysis passes "
-                f"(quality-clean passes: {_analysis_passes}/{_THOROUGH_MIN_ITERATIONS}):\n\n"
-            )
-        else:
-            header = f"complete BLOCKED (attempt {_complete_attempts}/{_MAX_COMPLETE_ATTEMPTS}) — fix the following first:\n\n"
-        msg = header + "\n\n".join(f"  [{i+1}] {b}" for i, b in enumerate(blockers))
-        log.note(
-            f"complete blocked (attempt {_complete_attempts}, analysis_passes={_analysis_passes}): "
-            f"{'; '.join(b[:80] for b in blockers)}"
-        )
-        return msg
+        return _build_blocker_response(blockers)
 
     # Only the human operator can mark a scan complete.
     # Smith passes all quality gates here — the scan is ready — but completion
@@ -1514,7 +1521,7 @@ def _do_recovery():
     next_call = _concrete_next_call(target, tools_run, in_progress_cells, pending_count)
 
     result = _build_recovery_result(
-        current, cov, data, in_progress_cells, pending_count, extra_cells,
+        current, cov, data, extra_cells,
         unsatisfied_gates, pending_escalations, integrity_warnings,
         target, tools_run, action_list, next_call, resume_step,
     )
@@ -1533,8 +1540,6 @@ def _build_recovery_result(
     current: dict,
     cov: dict,
     data: dict,
-    in_progress_cells: list,
-    pending_count: int,
     extra_cells: int,
     unsatisfied_gates: list,
     pending_escalations: list,

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -140,7 +140,7 @@ def _dispatch_sync_action(action: str, opts: dict) -> str:
     if action == "start":
         return _do_start(opts)
     if action == "complete":
-        return _do_complete(opts)
+        return _do_complete()
     if action == "status":
         return _do_status()
     if action == "set_skill":
@@ -1021,7 +1021,7 @@ def _build_blocker_response(blockers: list) -> str:
     return msg
 
 
-def _do_complete(opts):
+def _do_complete():
     global _complete_attempts, _analysis_passes
     _complete_attempts += 1
 

--- a/tests/test_api_smith_endpoints.py
+++ b/tests/test_api_smith_endpoints.py
@@ -322,36 +322,21 @@ class TestWatchdogStatus:
 class TestMcpSseAlive:
 
     def test_returns_false_when_port_closed(self):
-        # 127.0.0.1:1 is a reserved low port nobody listens on — connect_ex
-        # returns non-zero quickly.
-        with patch.dict("os.environ", {}, clear=False):
-            ok = asyncio.run(api._mcp_sse_alive())
         # Depending on the test host, MCP might actually be running on 7778.
         # We just need the function to return a bool without raising.
+        ok = api._mcp_sse_alive()
         assert isinstance(ok, bool)
 
     def test_handles_socket_oserror(self):
-        # We can't patch `socket.socket` globally without breaking asyncio's
-        # own internal use. Wrap the test in a custom loop and patch only
-        # the lookup-time `connect_ex` instead — same code path.
-        async def _run():
-            import socket
-            real_socket = socket.socket
+        import socket
+        real_socket = socket.socket
 
-            class _FailingSocket(real_socket):
-                def connect_ex(self, _addr):
-                    raise OSError("synthetic")
+        class _FailingSocket(real_socket):
+            def connect_ex(self, _addr):
+                raise OSError("synthetic")
 
-            with patch("socket.socket", _FailingSocket):
-                return await api._mcp_sse_alive()
-
-        # Use a fresh loop so the failing-socket patch only affects our
-        # `_mcp_sse_alive` call, not the loop setup that already happened.
-        loop = asyncio.new_event_loop()
-        try:
-            result = loop.run_until_complete(_run())
-        finally:
-            loop.close()
+        with patch("socket.socket", _FailingSocket):
+            result = api._mcp_sse_alive()
         assert result is False
 
 
@@ -363,7 +348,7 @@ class TestSmithWatchdogLoop:
 
     def _make_loop_runner(self, monkeypatch):
         """Patch asyncio.sleep so the watchdog loop body runs exactly once
-        then exits via CancelledError."""
+        then exits via CancelledError on the second sleep call."""
         ticks = {"n": 0}
 
         async def fake_sleep(_s):
@@ -374,20 +359,26 @@ class TestSmithWatchdogLoop:
         monkeypatch.setattr("asyncio.sleep", fake_sleep)
         return ticks
 
+    def _run_watchdog(self):
+        """Run the watchdog loop and absorb the expected CancelledError exit."""
+        import contextlib
+        with contextlib.suppress(asyncio.CancelledError):
+            asyncio.run(api._smith_watchdog_loop())
+
     def test_skips_when_session_not_running(self, sandbox_session, monkeypatch):
         self._make_loop_runner(monkeypatch)
         _write_session(sandbox_session, status="complete")
-        # Loop body should hit the early-`continue` for status != running
-        asyncio.run(api._smith_watchdog_loop())
+        # Loop body should hit the early-return for status != running
+        self._run_watchdog()
 
     def test_skips_when_mcp_unreachable(self, sandbox_session, sandbox_smith_files, monkeypatch):
         self._make_loop_runner(monkeypatch)
         _write_session(sandbox_session, status="running")
         spawn = AsyncMock()
         with patch.object(api, "_smith_running", return_value=False), \
-             patch.object(api, "_mcp_sse_alive", AsyncMock(return_value=False)), \
+             patch.object(api, "_mcp_sse_alive", return_value=False), \
              patch.object(api, "_spawn_smith", spawn):
-            asyncio.run(api._smith_watchdog_loop())
+            self._run_watchdog()
         # MCP-health gate must have prevented the spawn
         spawn.assert_not_awaited()
 
@@ -396,8 +387,8 @@ class TestSmithWatchdogLoop:
         _write_session(sandbox_session, status="running")
         spawn = AsyncMock(return_value=(True, 4242))
         with patch.object(api, "_smith_running", return_value=False), \
-             patch.object(api, "_mcp_sse_alive", AsyncMock(return_value=True)), \
+             patch.object(api, "_mcp_sse_alive", return_value=True), \
              patch.object(api, "_detect_active_client", return_value="opencode"), \
              patch.object(api, "_spawn_smith", spawn):
-            asyncio.run(api._smith_watchdog_loop())
+            self._run_watchdog()
         spawn.assert_awaited_once()

--- a/tests/test_api_smith_endpoints.py
+++ b/tests/test_api_smith_endpoints.py
@@ -392,3 +392,71 @@ class TestSmithWatchdogLoop:
              patch.object(api, "_spawn_smith", spawn):
             self._run_watchdog()
         spawn.assert_awaited_once()
+
+    def test_loop_continues_after_non_cancel_exception(self, sandbox_session, monkeypatch):
+        """Exception in tick body must not crash the loop — only CancelledError exits."""
+        ticks = {"n": 0}
+
+        async def fake_sleep(_s):
+            ticks["n"] += 1
+            if ticks["n"] > 1:
+                raise asyncio.CancelledError()
+
+        async def boom(_now):
+            raise RuntimeError("synthetic tick error")
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        monkeypatch.setattr(api, "_watchdog_tick", boom)
+        import contextlib
+        with contextlib.suppress(asyncio.CancelledError):
+            asyncio.run(api._smith_watchdog_loop())
+        assert ticks["n"] == 2  # second sleep fired → loop survived the exception
+
+
+# ---------------------------------------------------------------------------
+# _watchdog_tick — guard condition unit tests
+# ---------------------------------------------------------------------------
+
+class TestWatchdogTick:
+
+    def _run_tick(self, now=9999.0):
+        asyncio.run(api._watchdog_tick(now))
+
+    def test_skips_when_intervention_active(self, sandbox_session):
+        _write_session(sandbox_session, status="running",
+                       intervention={"code": "HIR_AUTH_FAILURE", "situation": ""})
+        spawn = AsyncMock()
+        with patch.object(api, "_spawn_smith", spawn):
+            self._run_tick()
+        spawn.assert_not_awaited()
+
+    def test_skips_when_smith_already_running(self, sandbox_session):
+        _write_session(sandbox_session, status="running")
+        spawn = AsyncMock()
+        with patch.object(api, "_smith_running", return_value=True), \
+             patch.object(api, "_spawn_smith", spawn):
+            self._run_tick()
+        spawn.assert_not_awaited()
+
+    def test_skips_when_min_gap_not_elapsed(self, sandbox_session):
+        _write_session(sandbox_session, status="running")
+        spawn = AsyncMock()
+        api._watchdog_last_restart_ts = 9000.0  # now=9999, gap=999 < MIN_GAP
+        with patch.object(api, "_smith_running", return_value=False), \
+             patch.object(api, "_mcp_sse_alive", return_value=True), \
+             patch.object(api, "_spawn_smith", spawn):
+            self._run_tick(now=9000.0 + api._WATCHDOG_MIN_GAP_SECONDS - 1)
+        spawn.assert_not_awaited()
+        api._watchdog_last_restart_ts = 0.0  # reset for other tests
+
+    def test_skips_when_hourly_cap_exceeded(self, sandbox_session):
+        _write_session(sandbox_session, status="running")
+        spawn = AsyncMock()
+        now = 9999.0
+        api._watchdog_restart_count_window[:] = [now - 10] * api._WATCHDOG_MAX_PER_HOUR
+        with patch.object(api, "_smith_running", return_value=False), \
+             patch.object(api, "_mcp_sse_alive", return_value=True), \
+             patch.object(api, "_spawn_smith", spawn):
+            self._run_tick(now=now)
+        spawn.assert_not_awaited()
+        api._watchdog_restart_count_window.clear()

--- a/tests/test_session_tools_helpers.py
+++ b/tests/test_session_tools_helpers.py
@@ -926,7 +926,7 @@ class TestDoComplete:
         with patch("mcp_server.session_tools._effective_tools", return_value=set()), \
              patch("mcp_server.session_tools._collect_completion_blockers",
                    return_value=["NO DIAGRAM: call report(action='diagram')"]):
-            result = _do_complete({"notes": "done"})
+            result = _do_complete()
         assert "complete BLOCKED" in result
         assert "NO DIAGRAM" in result
 
@@ -937,7 +937,7 @@ class TestDoComplete:
         with patch("mcp_server.session_tools._effective_tools", return_value=set()), \
              patch("mcp_server.session_tools._collect_completion_blockers",
                    return_value=["BLOCKER"]):
-            _do_complete({"notes": ""})
+            _do_complete()
         assert st._complete_attempts == initial + 1
 
     def test_no_blockers_standard_depth_marks_complete(self, tmp_path, monkeypatch):
@@ -945,7 +945,7 @@ class TestDoComplete:
         with patch("mcp_server.session_tools._effective_tools", return_value=set()), \
              patch("mcp_server.session_tools._collect_completion_blockers", return_value=[]), \
              patch("mcp_server.session_tools._record_metrics"):
-            result = _do_complete({"notes": "all done"})
+            result = _do_complete()
         assert "complete" in result.lower() or "Scan marked" in result
 
     def test_thorough_depth_no_blockers_adds_iteration_gate(self, tmp_path, monkeypatch):
@@ -956,7 +956,7 @@ class TestDoComplete:
              patch("mcp_server.session_tools._collect_completion_blockers", return_value=[]), \
              patch("mcp_server.session_tools._is_whitebox_scan", return_value=False), \
              patch("mcp_server.session_tools._deepen_brief", return_value="ITERATION GATE: pass 1"):
-            result = _do_complete({"notes": ""})
+            result = _do_complete()
         assert "ITERATION GATE" in result or "complete BLOCKED" in result
 
     def test_multiple_blockers_listed(self, tmp_path, monkeypatch):
@@ -964,7 +964,7 @@ class TestDoComplete:
         with patch("mcp_server.session_tools._effective_tools", return_value=set()), \
              patch("mcp_server.session_tools._collect_completion_blockers",
                    return_value=["NO DIAGRAM", "NO SPIDER", "NO POC"]):
-            result = _do_complete({"notes": ""})
+            result = _do_complete()
         assert "NO DIAGRAM" in result
         assert "NO SPIDER" in result
 

--- a/tests/test_session_tools_helpers.py
+++ b/tests/test_session_tools_helpers.py
@@ -495,7 +495,7 @@ class TestDeepenSteps:
 
     def test_pass1_returns_non_empty_list_of_strings(self):
         steps = _deepen_steps_pass1(
-            criticals=[], has_ai_ep=False, skills_run=set(), unchained=[]
+            has_ai_ep=False, skills_run=set(), unchained=[]
         )
         assert isinstance(steps, list)
         assert len(steps) > 0
@@ -503,20 +503,20 @@ class TestDeepenSteps:
 
     def test_pass1_includes_ai_redteam_step_when_ai_ep(self):
         steps = _deepen_steps_pass1(
-            criticals=[], has_ai_ep=True, skills_run=set(), unchained=[]
+            has_ai_ep=True, skills_run=set(), unchained=[]
         )
         assert any("ai-redteam" in s for s in steps)
 
     def test_pass1_excludes_ai_redteam_step_when_no_ai(self):
         steps = _deepen_steps_pass1(
-            criticals=[], has_ai_ep=False, skills_run=set(), unchained=[]
+            has_ai_ep=False, skills_run=set(), unchained=[]
         )
         assert not any("ai-redteam" in s for s in steps)
 
     def test_pass1_includes_unchained_step_when_unchained_present(self):
         unchained = [{"title": "SQL Injection on login", "escalation_leads": []}]
         steps = _deepen_steps_pass1(
-            criticals=unchained, has_ai_ep=False, skills_run=set(), unchained=unchained
+            has_ai_ep=False, skills_run=set(), unchained=unchained
         )
         assert any("unchained" in s.lower() or "chain" in s.lower() for s in steps)
 
@@ -610,8 +610,6 @@ class TestBuildRecoveryResult:
                      "status": "running", "skill_history": [], "known_assets": {}},
             cov={"meta": {"tested": 0, "total_cells": 0}, "endpoints": [], "matrix": []},
             data={"findings": [], "diagrams": []},
-            in_progress_cells=[],
-            pending_count=0,
             extra_cells=0,
             unsatisfied_gates=[],
             pending_escalations=[],
@@ -776,7 +774,7 @@ class TestDeepenStepsPass2SkillsRun:
     def test_pass1_includes_ai_redteam_when_in_skills_run(self):
         from mcp_server.session_tools import _deepen_steps_pass1
         steps = _deepen_steps_pass1(
-            criticals=[], has_ai_ep=False, skills_run={"ai-redteam"}, unchained=[]
+            has_ai_ep=False, skills_run={"ai-redteam"}, unchained=[]
         )
         assert any("ai-redteam" in s for s in steps)
 

--- a/tools/semgrep.py
+++ b/tools/semgrep.py
@@ -11,18 +11,19 @@ import json
 from tools.base import Tool
 
 _SEVERITY_MAP = {"ERROR": "high", "WARNING": "medium", "INFO": "info"}
+_TARGET_MOUNT = "/target"
 
 
 # ---------------------------------------------------------------------------
 # Arg builder
 # ---------------------------------------------------------------------------
 
-def _build_args(path: str = "/target", flags: str = "") -> list[str]:
-    # /target is the mount point inside the container (see needs_mount=True).
+def _build_args(path: str = _TARGET_MOUNT, flags: str = "") -> list[str]:
+    # _TARGET_MOUNT is the mount point inside the container (see needs_mount=True).
     # The semgrep/semgrep image has no ENTRYPOINT, so the binary name must lead.
-    # User-supplied host paths are remapped to /target since only the mount is visible inside the container.
-    if path != "/target" and not path.startswith("/target"):
-        path = "/target"
+    # User-supplied host paths are remapped to _TARGET_MOUNT since only the mount is visible inside the container.
+    if path != _TARGET_MOUNT and not path.startswith(_TARGET_MOUNT):
+        path = _TARGET_MOUNT
     args = ["semgrep", "--config=auto", "--json", "--metrics=off", path]
     if flags:
         args += flags.split()


### PR DESCRIPTION
- S8572: replace logging.error with logging.exception (3 sites)
- S1192: extract duplicated "Request failed" and "ABORT: Stop the scan" and "/target" literals into named constants
- S7493: wrap sync open() calls in async _spawn_smith via run_in_executor
- S7503: remove async keyword from _mcp_sse_alive (no awaits in body)
- S5713: remove redundant socket.gaierror (subclass of OSError) and json.JSONDecodeError (subclass of ValueError) from except clauses
- S7497: re-raise asyncio.CancelledError instead of swallowing with return
- S5145: sanitize user-controlled client value before logging
- S1172: remove unused parameters (ep_path, criticals, in_progress_cells, pending_count, criticals in deepen_steps)
- S1481: remove unused local variables (current, notes, headers)
- S3776: reduce cognitive complexity of wrap(), _persist_http_auth_assets, _build_quick_log_entry, _summarize_httpx, _smith_watchdog_loop, _do_complete by extracting logic into focused helper functions
- S7483: replace timeout= kwarg with asyncio.timeout() context manager in _run_spider_thorough and _run_spider_fast
- S107: reduce _build_recovery_result from 14 to 12 parameters by removing two unused params