### PR TITLE
fix(scan): self-evidencing AUTH_MISSING hint + HIR burst dedup + escalation-lead guard

### DIFF
--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -324,30 +324,33 @@ def _check_stuck_on_target(entries: list[dict], findings_data: dict, previous_al
     )
 
     if was_flagged_before:
-        # Second consecutive cycle with the same target stuck — escalate to HIR
-        try:
-            from core import session as scan_session
-            iv = scan_session.get_intervention()
-            if not iv:  # Don't double-trigger if HIR is already active
-                scan_session.trigger_intervention(
-                    code="HIR_STUCK_ON_TARGET",
-                    situation=(
-                        f"Smith has made {hit_count} tool calls against '{stuck_target}' "
-                        f"in the last 30 min with no finding logged and no coverage progress. "
-                        "It appears to be stuck investigating something it cannot confirm or rule out."
-                    ),
-                    tried=[
-                        f"Ran {hit_count} tool calls against {stuck_target} without result"
-                    ],
-                    options=[
-                        "HINT: Share what you know about this target — give Smith a specific payload, endpoint, or technique to try next",
-                        "SKIP: Tell Smith to document what it observed, mark as informational, and move on",
-                        "DEEPER: Approve going further — e.g. manual SQLi, out-of-band callbacks, or Metasploit exploitation",
-                        "ABORT_TARGET: Drop this target entirely and continue with remaining coverage",
-                    ],
-                )
-        except Exception:
-            pass
+        # Second consecutive cycle with the same target stuck — escalate to HIR.
+        # Uses the _hir() helper instead of trigger_intervention() directly so:
+        #   (a) dedup goes through the same code path every HIR check uses,
+        #       which now force-reloads session.json mtime before reading
+        #       (avoids the stale-cache race the user hit where 5 HIRs fired
+        #       within 137ms because each call's get_intervention() read a
+        #       cached _current that hadn't seen the previous flush yet);
+        #   (b) the min-gap floor (_HIR_MIN_GAP_SECONDS) caps burst frequency
+        #       to one HIR-of-this-code per minute even if dedup were ever
+        #       defeated, so dashboard "Stuck Events" stops getting flooded.
+        _hir(
+            code="HIR_STUCK_ON_TARGET",
+            situation=(
+                f"Smith has made {hit_count} tool calls against '{stuck_target}' "
+                f"in the last 30 min with no finding logged and no coverage progress. "
+                "It appears to be stuck investigating something it cannot confirm or rule out."
+            ),
+            tried=[
+                f"Ran {hit_count} tool calls against {stuck_target} without result"
+            ],
+            options=[
+                "HINT: Share what you know about this target — give Smith a specific payload, endpoint, or technique to try next",
+                "SKIP: Tell Smith to document what it observed, mark as informational, and move on",
+                "DEEPER: Approve going further — e.g. manual SQLi, out-of-band callbacks, or Metasploit exploitation",
+                "ABORT_TARGET: Drop this target entirely and continue with remaining coverage",
+            ],
+        )
         return {
             "code": "STUCK_ON_TARGET", "urgency": "high", "blocking": False,
             "message": (
@@ -566,12 +569,40 @@ def _check_missing_skill(coverage_data: dict, session_data: dict) -> list[dict]:
 
 # ── HIR checks — conditions Smith cannot self-resolve ────────────────────────
 
+# Minimum seconds between two HIR triggers of the same code. Even if the
+# get_intervention() dedup fails (cross-process state desync, racy flush,
+# etc.), this caps the burst at one HIR per minute per code. The user
+# observed 5 HIR_STUCK_ON_TARGET events fire within 137ms — that's the
+# blast radius this floor closes.
+_HIR_MIN_GAP_SECONDS = 60
+_last_hir_trigger_ts: dict[str, float] = {}
+
+
 def _hir(code: str, situation: str, tried: list[str], options: list[str]) -> None:
-    """Trigger HIR if one is not already active. Always fires regardless of scan mode."""
+    """Trigger HIR if one is not already active. Always fires regardless of scan mode.
+
+    Two-layer dedup:
+
+      1. ``get_intervention()`` — primary check. Pre-fix this read a
+         cached ``_current`` and could miss a freshly-triggered HIR in
+         the same QA cycle when multiple checks fire back-to-back.
+         Post-fix it force-reloads session.json mtime first.
+
+      2. ``_HIR_MIN_GAP_SECONDS`` floor — backstop. Even if layer 1
+         were ever defeated again, this prevents the same HIR code from
+         re-triggering within 60s, which kills the "Stuck Events" dash
+         flood the user reported (5 HIRs in 137ms).
+    """
+    import time as _time
+    now = _time.time()
+    last = _last_hir_trigger_ts.get(code, 0.0)
+    if now - last < _HIR_MIN_GAP_SECONDS:
+        return
     try:
         from core import session as scan_session
         if not scan_session.get_intervention():
             scan_session.trigger_intervention(code, situation, tried, options)
+            _last_hir_trigger_ts[code] = now
     except Exception:
         pass
 

--- a/core/session.py
+++ b/core/session.py
@@ -906,7 +906,18 @@ def resolve_intervention(choice: str, message: str = "") -> dict:
 
 
 def get_intervention() -> dict | None:
-    """Return current intervention dict if scan is paused, else None."""
+    """Return current intervention dict if scan is paused, else None.
+
+    Reconciles against disk first because this is the dedup-check used by
+    every HIR-triggering path. If a previous HIR fired and flushed to disk
+    but our cached _current hasn't observed that flush yet (the dashboard
+    process and MCP server keep separate _current caches; same family of
+    cross-process desync we fixed for Clear All in PR #111), the dedup
+    check returns None and a duplicate HIR fires. _reconcile_if_external_write
+    only pays for a disk read when session.json's mtime is newer than our
+    last local write, so the steady-state cost is near zero.
+    """
+    _reconcile_if_external_write()
     if not _current or _current.get("status") != "intervention_required":
         return None
     return _current.get("intervention")

--- a/mcp_server/scan_engine/envelope.py
+++ b/mcp_server/scan_engine/envelope.py
@@ -568,23 +568,63 @@ def _inject_missing_auth_warning(env: Envelope, ctx: dict) -> None:
         return  # legitimate login attempt — 401 is the test signal
     try:
         from core import session as _sess
-        tokens = (_sess.get() or {}).get("known_assets", {}).get("auth_tokens", [])
+        sess_data    = _sess.get() or {}
+        known_assets = sess_data.get("known_assets", {})
+        tokens       = known_assets.get("auth_tokens", [])
         valid_tokens = [t for t in tokens if isinstance(t, dict) and t.get("value")]
         if not valid_tokens:
             return
-        latest_token = valid_tokens[-1].get("value", "")
-        url = ctx.get("url", "")
+        url    = ctx.get("url", "")
+        method = (ctx.get("method", "GET") or "GET").upper()
+
+        # Smaller models (the user hit this with Qwen3.6-35B-A3B) treat
+        # short "try header X" warnings as background noise and burn 7+
+        # tool calls retrying naked requests against the same endpoint.
+        # The fix is the same shape we used for the envelope budget
+        # truncation: embed the EXACT next tool call inline with the
+        # full token-reference path. The model can pattern-match on
+        # `EXECUTE NOW: http(...)` far more reliably than on a discursive
+        # "you should try X, or maybe Y" paragraph.
+        #
+        # The token reference is `known_assets.auth_tokens[-1].value`
+        # (not a truncated literal) because:
+        #   1. Models that DO read warnings can resolve the path from
+        #      session state directly without us inlining a 700-char JWT
+        #      that would blow the envelope budget.
+        #   2. The truncated form `eyJ0eXAiOiJK...` previously shown
+        #      reads like a complete token to less-careful models, which
+        #      then sent the truncated value verbatim and got 401 again.
+        creds = known_assets.get("credentials", [])
+        auth_endpoints = known_assets.get("auth_endpoints", [])
+        cred_hint = ""
+        if creds and auth_endpoints:
+            ep = auth_endpoints[0]
+            cred_hint = (
+                f" If the stored token has expired (still 401 after the "
+                f"retry above), mint a fresh one: "
+                f"http(action='request', method='{ep.get('method','POST')}', "
+                f"url='{ep.get('path','')}', "
+                f"body={{'username':'{creds[0].get('username','')}', "
+                f"'password':'{creds[0].get('password','')}'}}). "
+                f"Extract the new JWT from the response and retry."
+            )
         message = (
-            f"AUTH_MISSING: {url} returned HTTP {status} but the request carried "
-            f"NO authentication (no Authorization / Cookie / X-Api-Key / X-Auth-* "
-            f"header, no ?token= query). known_assets.auth_tokens has "
-            f"{len(valid_tokens)} valid token(s). "
-            f"RETRY with whatever auth form this app uses — try header "
-            f"'Authorization: Bearer {latest_token[:30]}...' first; if 401 persists "
-            f"the app may use a Cookie (re-login at the discovered auth_endpoint "
-            f"and reuse Set-Cookie) or a custom header (X-Api-Key / X-Auth-Token). "
-            f"401/403 with NO auth sent is NOT a test result — the server never "
-            f"evaluated your payload."
+            f"AUTH_MISSING: {method} {url} returned HTTP {status} with NO auth "
+            f"attached (no Authorization / Cookie / X-Api-Key / X-Auth-* / "
+            f"?token= query). 401/403 with no auth is NOT a test result — "
+            f"the server never evaluated your payload. "
+            f"EXECUTE NOW: retry the same request with the JWT attached: "
+            f"http(action='request', method='{method}', url='{url}', "
+            f"headers={{'Authorization': 'Bearer ' + "
+            f"known_assets.auth_tokens[-1].value}}). "
+            f"({len(valid_tokens)} valid token(s) available; "
+            f"newest source: {valid_tokens[-1].get('source_url','unknown')}). "
+            f"If 401 persists, the app may use Cookie auth (re-login + reuse "
+            f"Set-Cookie) or a custom header like X-Api-Key/X-Auth-Token — try "
+            f"those header names with the same JWT value."
+            f"{cred_hint}"
+            f" DO NOT retry the naked request — every naked retry will return "
+            f"401 and burns budget without producing a test result."
         )
         env.warnings.append(message)
         env.summary = f"⚠ {message}\n\n" + env.summary

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -536,7 +536,7 @@ def _escalation_lead_blockers(data: dict) -> list[str]:
     pending_leads: list[str] = []
     for f in data.get("findings", []):
         for lead in f.get("escalation_leads", []):
-            if lead.get("status") == "pending":
+            if isinstance(lead, dict) and lead.get("status") == "pending":
                 pending_leads.append(f"{f['title']}: {lead['lead']}")
     if not pending_leads:
         return []

--- a/tests/test_envelope_new_helpers.py
+++ b/tests/test_envelope_new_helpers.py
@@ -288,6 +288,107 @@ class TestInjectMissingAuthWarning:
         assert "AUTH_MISSING" not in env.summary
         scan_session._current = None
 
+    # ── Self-evidencing hint shape ─────────────────────────────────────────
+    #
+    # The user observed Smith (Qwen3.6-35B-A3B) burn 7+ tool calls retrying
+    # naked requests against an auth-gated endpoint despite this warning
+    # firing. The previous message ended with "try header 'Authorization:
+    # Bearer eyJ0eXAi...'" — a TRUNCATED token, no concrete retry call,
+    # no fallback path. Smaller models pattern-match on `EXECUTE NOW:
+    # http(...)` shape but ignore discursive "you should try" paragraphs.
+    # These tests pin the new shape so it can't regress quietly.
+
+    def test_warning_includes_execute_now_retry_call(self, tmp_path, monkeypatch):
+        """Warning must include an inline http(action='request', ...) call
+        with the exact method + url + the Authorization header line — that's
+        the literal next tool call Smith should make."""
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session._current = None
+        scan_session.start("http://x")
+        scan_session.update_known_assets("auth_tokens", [
+            {"value": "eyJ_realtoken_abc", "type": "jwt",
+             "source_url": "http://x/login"},
+        ])
+        env = self._make_env(401)
+        _inject_missing_auth_warning(env, {
+            "url": "http://x/api/widget",
+            "method": "POST",
+            "headers": {},
+        })
+        # The actionable retry call must be spelled out
+        assert "EXECUTE NOW" in env.summary
+        assert "http(action='request'" in env.summary
+        assert "method='POST'" in env.summary
+        assert "url='http://x/api/widget'" in env.summary
+        assert "Authorization" in env.summary
+        # The token reference is via known_assets.auth_tokens[-1].value
+        # (NOT the truncated 30-char prefix the old hint used), so the
+        # model resolves the full value from session state rather than
+        # sending a truncated literal.
+        assert "known_assets.auth_tokens[-1].value" in env.summary
+        scan_session._current = None
+
+    def test_warning_includes_mint_fresh_token_fallback(self, tmp_path, monkeypatch):
+        """When credentials AND an auth endpoint are known, the warning
+        must include a concrete 'mint a new token' call too — for the
+        case where the stored token has expired and even auth retry
+        gets 401. Otherwise Smith doesn't know how to recover."""
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session._current = None
+        scan_session.start("http://x")
+        scan_session.update_known_assets("auth_tokens",
+                                          [{"value": "old", "type": "jwt"}])
+        scan_session.update_known_assets("credentials",
+                                          [{"username": "alice", "password": "p@ss"}])
+        scan_session.update_known_assets("auth_endpoints",
+                                          [{"path": "http://x/login",
+                                            "method": "POST"}])
+        env = self._make_env(401)
+        _inject_missing_auth_warning(env, {
+            "url": "http://x/api/widget", "method": "GET", "headers": {},
+        })
+        assert "mint a fresh one" in env.summary
+        assert "alice" in env.summary
+        assert "http://x/login" in env.summary
+        scan_session._current = None
+
+    def test_warning_omits_mint_call_when_no_credentials_known(
+        self, tmp_path, monkeypatch,
+    ):
+        """Inverse: no credentials → no mint-fresh-token suggestion (we
+        can't tell Smith how to re-auth). Token-retry call still appears
+        because that's always possible with existing tokens."""
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session._current = None
+        scan_session.start("http://x")
+        scan_session.update_known_assets("auth_tokens",
+                                          [{"value": "t", "type": "jwt"}])
+        env = self._make_env(401)
+        _inject_missing_auth_warning(env, {
+            "url": "http://x/api/widget", "method": "GET", "headers": {},
+        })
+        assert "mint a fresh one" not in env.summary
+        # But the primary retry call must still appear
+        assert "EXECUTE NOW" in env.summary
+        scan_session._current = None
+
+    def test_warning_warns_against_naked_retry(self, tmp_path, monkeypatch):
+        """The previous message left "should I retry" ambiguous —
+        smaller models retried naked anyway. New message must explicitly
+        say DO NOT retry without auth, so even a model that ignores the
+        EXECUTE NOW pattern picks up the negative directive."""
+        monkeypatch.setattr(scan_session, "_SESSION_FILE", tmp_path / "session.json")
+        scan_session._current = None
+        scan_session.start("http://x")
+        scan_session.update_known_assets("auth_tokens",
+                                          [{"value": "t", "type": "jwt"}])
+        env = self._make_env(401)
+        _inject_missing_auth_warning(env, {
+            "url": "http://x/api/widget", "method": "GET", "headers": {},
+        })
+        assert "DO NOT retry the naked request" in env.summary
+        scan_session._current = None
+
 
 # ---------------------------------------------------------------------------
 # wrap() — terminal status + intervention guards

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -1012,8 +1012,13 @@ def test_stuck_on_target_second_detection_triggers_hir(tmp_path, monkeypatch):
         assert alert is not None
         assert alert["code"] == "STUCK_ON_TARGET"
         mock_trigger.assert_called_once()
-        call_kwargs = mock_trigger.call_args
-        assert call_kwargs[1]["code"] == "HIR_STUCK_ON_TARGET" or call_kwargs[0][0] == "HIR_STUCK_ON_TARGET"
+        # Accept either calling convention — the dedup refactor moved the call
+        # site to _hir() which forwards positional args; the previous direct
+        # trigger_intervention call used kwargs. Using .get() instead of [] so
+        # the short-circuit OR works (the kwargs path no longer has 'code').
+        call_args = mock_trigger.call_args
+        code = call_args.kwargs.get("code") or (call_args.args[0] if call_args.args else None)
+        assert code == "HIR_STUCK_ON_TARGET"
 
 
 def test_stuck_on_target_no_double_hir(tmp_path, monkeypatch):
@@ -1303,6 +1308,53 @@ def test_hir_swallows_exceptions():
     with patch("core.session.get_intervention", side_effect=RuntimeError("boom")):
         # Should not raise
         _hir("TEST_CODE", "situation", ["tried"], ["option1"])
+
+
+# ---------------------------------------------------------------------------
+# _hir min-gap backstop — prevents the burst the user observed (5 HIR_STUCK_ON_TARGET
+# events fired within 137ms because get_intervention() read a stale cache).
+# Even if dedup were defeated, this floor caps to 1 HIR per code per minute.
+# ---------------------------------------------------------------------------
+
+def test_hir_min_gap_blocks_second_trigger_within_window(monkeypatch):
+    """Two _hir() calls for the same code inside the gap window must
+    result in exactly ONE trigger_intervention. Simulates the QA-cycle
+    race where get_intervention() returns None twice in a row before
+    the first trigger's flush is observed by the second's read."""
+    import core.qa_agent as qa_mod
+    # Force a clean ledger so prior tests don't poison this one
+    monkeypatch.setattr(qa_mod, "_last_hir_trigger_ts", {})
+    with patch("core.session.get_intervention", return_value=None), \
+         patch("core.session.trigger_intervention") as mock_trigger:
+        qa_mod._hir("BURST_CODE", "s", [], [])
+        qa_mod._hir("BURST_CODE", "s", [], [])  # within gap — must be blocked
+        assert mock_trigger.call_count == 1
+
+
+def test_hir_min_gap_allows_different_codes(monkeypatch):
+    """The gap is PER CODE — an unrelated HIR (e.g. HIR_AUTH_FAILURE)
+    must still fire even if HIR_STUCK_ON_TARGET just fired. Otherwise
+    one burst-blocked code would suppress all other QA checks for 60s."""
+    import core.qa_agent as qa_mod
+    monkeypatch.setattr(qa_mod, "_last_hir_trigger_ts", {})
+    with patch("core.session.get_intervention", return_value=None), \
+         patch("core.session.trigger_intervention") as mock_trigger:
+        qa_mod._hir("CODE_A", "s", [], [])
+        qa_mod._hir("CODE_B", "s", [], [])  # different code, allowed
+        assert mock_trigger.call_count == 2
+
+
+def test_hir_min_gap_allows_retrigger_after_window(monkeypatch):
+    """After _HIR_MIN_GAP_SECONDS has elapsed, the same code is allowed
+    to re-fire. Tested by overriding the ledger entry to simulate a
+    past trigger past the gap."""
+    import core.qa_agent as qa_mod
+    monkeypatch.setattr(qa_mod, "_last_hir_trigger_ts",
+                        {"OLD_CODE": 0.0})  # epoch-1970 → way past the gap
+    with patch("core.session.get_intervention", return_value=None), \
+         patch("core.session.trigger_intervention") as mock_trigger:
+        qa_mod._hir("OLD_CODE", "s", [], [])
+        assert mock_trigger.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -737,3 +737,59 @@ def test_remaining_returns_none_for_unlimited_cost_time(coverage_file):
     assert r["cost_pct"] == 0
     assert r["time_pct"] == 0
     assert r["calls_remaining"] == -1  # 0 = unlimited → -1
+
+
+# ---------------------------------------------------------------------------
+# get_intervention — force-reload from disk before reading cache
+#
+# The user observed 5 HIR_STUCK_ON_TARGET events fire within 137ms because
+# get_intervention() (used as the dedup check by every HIR-triggering path)
+# read from a cached _current that hadn't observed the previous trigger's
+# flush yet. _reconcile_if_external_write() runs first now so the dedup
+# sees fresh state — same family of cross-process desync we fixed for the
+# Clear All path in PR #111.
+# ---------------------------------------------------------------------------
+
+def test_get_intervention_reloads_external_trigger_from_disk(tmp_path, monkeypatch):
+    """A peer process (the QA daemon in the dashboard) wrote an active
+    intervention to session.json. Our in-memory _current still says
+    status='running'. get_intervention() must see the disk reality
+    and return the intervention dict, not None — otherwise the dedup
+    check passes and a duplicate HIR fires."""
+    import json
+    import core.session as scan_session
+    session_file = tmp_path / "session.json"
+    monkeypatch.setattr(scan_session, "_SESSION_FILE", session_file)
+    # Set up in-memory state as 'running' (no intervention)
+    scan_session.start("https://example.com")
+    assert scan_session.get_intervention() is None
+    # Peer process writes an intervention directly to disk
+    current_disk = json.loads(session_file.read_text())
+    current_disk["status"] = "intervention_required"
+    current_disk["intervention"] = {
+        "code": "HIR_STUCK_ON_TARGET",
+        "situation": "stuck",
+        "tried": [],
+        "options": [],
+        "triggered_at": "2026-06-12T20:00:00+00:00",
+    }
+    session_file.write_text(json.dumps(current_disk))
+    # Bump mtime so the reconcile check fires (otherwise mtime equality
+    # short-circuits the reload — that's the desired steady-state perf)
+    new_mtime = session_file.stat().st_mtime + 10
+    import os
+    os.utime(session_file, (new_mtime, new_mtime))
+    # The next get_intervention() must reflect disk reality
+    iv = scan_session.get_intervention()
+    assert iv is not None
+    assert iv["code"] == "HIR_STUCK_ON_TARGET"
+
+
+def test_get_intervention_returns_none_when_no_intervention(tmp_path, monkeypatch):
+    """Negative case: status is 'running' on disk → no intervention.
+    The force-reload must NOT spuriously surface anything."""
+    import core.session as scan_session
+    session_file = tmp_path / "session.json"
+    monkeypatch.setattr(scan_session, "_SESSION_FILE", session_file)
+    scan_session.start("https://example.com")
+    assert scan_session.get_intervention() is None


### PR DESCRIPTION
## Summary

Three fixes surfaced during a live `notingbank.org` scan where Smith (Qwen3.6-35B-A3B) got stuck on an auth-gated endpoint and the dashboard flooded with duplicate stuck-target alerts.

### Fix A — Self-evidencing `AUTH_MISSING` hint
Smith burned 7+ tool calls retrying naked POSTs against `/api/virtual-cards/create` (returning `{"error":"Token is missing"}`) **despite having 19 valid JWTs + 7 working credentials** in `known_assets`. The old hint ended with a discursive "try header `Authorization: Bearer eyJ0eXAi...`" — a truncated token, no concrete retry call. Smaller models treated it as noise.

New message embeds the **exact** next tool call:
- `EXECUTE NOW: http(action='request', ..., headers={'Authorization': 'Bearer ' + known_assets.auth_tokens[-1].value})`
- token referenced by **path** not truncated literal (the old prefix read like a complete token → models sent it verbatim → 401 again)
- concrete **mint-a-fresh-token** `http()` call with real credentials when an auth endpoint is known (handles expiry)
- explicit **"DO NOT retry the naked request"** negative directive

### Fix B — HIR burst dedup
5 identical `HIR_STUCK_ON_TARGET` events fired within **137ms**. `_check_stuck_on_target` called `trigger_intervention()` directly; its inline `get_intervention()` dedup read a **stale cache** (same cross-process desync family as the Clear All bug in #111), so concurrent QA/dashboard evaluations both fired.

- `_check_stuck_on_target` now routes through the shared `_hir()` helper
- `_hir()` gains a `_HIR_MIN_GAP_SECONDS=60` floor **per HIR code** — backstop even if dedup is ever defeated again
- `get_intervention()` now `_reconcile_if_external_write()`s before reading, so dedup sees fresh disk state (mtime-guarded → ~zero steady-state cost)

### Fix C — `escalation_lead` crash guard (drive-by)
`_escalation_lead_blockers()` called `lead.get("status")` unconditionally; a bare-string entry raised `AttributeError` mid-completion-check and aborted the whole blocker pass. Added an `isinstance(lead, dict)` guard.

## Testing
- **9 new tests** across `test_envelope_new_helpers.py` (4), `test_qa_agent.py` (3 + 1 updated), `test_session.py` (2)
- Full suite: **1083 passed, 1 skipped**

## Not included here
A separate robustness gap was diagnosed in the same session: `_spawn_smith` passes no `--model`, so the autonomous Smith inherits the operator's interactive Claude Code model pick. When that became `claude-fable-5[1m]` (since deprecated/unavailable), **every** spawn died instantly. Tracked for a follow-up PR (`fix/spawn-explicit-model`) — pass `--model` explicitly from `.env` + surface fast-exit stderr to the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)