### PR TITLE
feat: OOB confirmation + exploit-chain target routing, exec sandbox (+ testing-hardening fixes)

### DIFF
--- a/core/api_server/smith.py
+++ b/core/api_server/smith.py
@@ -564,6 +564,32 @@ def _mcp_sse_alive() -> bool:
 _mcp_sse_last_restart_ts: float = 0.0
 _MCP_SSE_RESTART_MIN_GAP_SECONDS = 30
 
+# Canonical launchd label for the MCP SSE daemon — matches the plist
+# (installers/com.agent-smith.mcp-sse.plist) and install-launchd.sh.
+_MCP_LAUNCHD_LABEL = "com.agent-smith.mcp-sse"
+
+
+async def _launchd_supervises_mcp(label: str = _MCP_LAUNCHD_LABEL) -> bool:
+    """True when a loaded launchd job is already supervising the MCP SSE daemon.
+
+    macOS only — on Linux/Windows ``launchctl`` is absent and this returns False,
+    so the watchdog falls back to the launcher script. When launchd IS managing
+    the daemon we restart *through* it (kickstart) instead of spawning a second,
+    unsupervised process that would fight launchd for port 7778 and leave an
+    orphan blocking the next bootstrap.
+    """
+    import os
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "launchctl", "print", f"gui/{os.getuid()}/{label}",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=5)
+        return proc.returncode == 0
+    except Exception:
+        return False
+
 
 async def _ensure_mcp_sse_alive(now: float) -> None:
     """Cross-platform self-heal for the MCP SSE daemon (port 7778).
@@ -589,17 +615,29 @@ async def _ensure_mcp_sse_alive(now: float) -> None:
     _mcp_sse_last_restart_ts = now
 
     import os
-    if os.name == "nt":
+    # If launchd already supervises the daemon, restart THROUGH it — spawning a
+    # parallel start-mcp-server.sh races launchd's own KeepAlive restart for port
+    # 7778 and leaves an orphan that blocks the next bootstrap. kickstart -k
+    # force-restarts the supervised process with no competing launcher.
+    if os.name != "nt" and await _launchd_supervises_mcp():
+        cmd = ["launchctl", "kickstart", "-k", f"gui/{os.getuid()}/{_MCP_LAUNCHD_LABEL}"]
+        launcher_name = f"launchctl kickstart {_MCP_LAUNCHD_LABEL}"
+    elif os.name == "nt":
         launcher = _api._REPO_ROOT / "installers" / "start-mcp-server.ps1"
         cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File", str(launcher), "start"]
+        launcher_name = launcher.name
+        if not launcher.exists():
+            _log.warning("MCP SSE down but launcher missing: %s", launcher)
+            return
     else:
         launcher = _api._REPO_ROOT / "installers" / "start-mcp-server.sh"
         cmd = ["/bin/bash", str(launcher), "start"]
-    if not launcher.exists():
-        _log.warning("MCP SSE down but launcher missing: %s", launcher)
-        return
+        launcher_name = launcher.name
+        if not launcher.exists():
+            _log.warning("MCP SSE down but launcher missing: %s", launcher)
+            return
 
-    _log.warning("MCP SSE server down on 127.0.0.1:7778 — auto-restarting via %s", launcher.name)
+    _log.warning("MCP SSE server down on 127.0.0.1:7778 — auto-restarting via %s", launcher_name)
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,

--- a/core/session/process_detect.py
+++ b/core/session/process_detect.py
@@ -19,17 +19,41 @@ import core.session as _sess
 _MCP_SSE_PORT = 7778
 
 
-def _detect_smith_caller(port: int = _MCP_SSE_PORT) -> dict | None:
+def _connected_client_candidates(port: int) -> list[dict]:
+    """Connected PIDs that resolve to a known Smith client, in iteration order."""
+    out: list[dict] = []
+    for pid in _connected_pids(port):
+        client = _resolve_client_for_pid(pid)
+        if client:
+            out.append({"pid": pid, "client": client})
+    return out
+
+
+def _detect_smith_caller(port: int = _MCP_SSE_PORT, prefer_client: str | None = None) -> dict | None:
     """Identify the calling Smith client.
 
     Returns ``{"pid": int, "client": "claude" | "opencode" | "codex"}`` for
     the most likely caller, or ``None`` when nothing recognizable is connected.
     Never raises — failure to detect is a routine outcome, not an error.
+
+    ``prefer_client`` is the client name from the MCP ``initialize`` handshake
+    (``clientInfo.name``) — authoritative and per-connection. When given, we
+    return the connected PID whose cmdline matches THAT client. This
+    disambiguates the case where several clients share the SSE server (e.g. a
+    dev Claude Code session alongside the opencode scanner), which otherwise
+    resolves to whichever PID ``process_iter`` yields first and silently
+    mislabels the scan. If no connected PID matches, we still trust the
+    handshake name and return ``pid=-1`` so the watchdog falls back to its
+    other liveness signals.
     """
-    for pid in _connected_pids(port):
-        client = _resolve_client_for_pid(pid)
-        if client:
-            return {"pid": pid, "client": client}
+    candidates = _connected_client_candidates(port)
+    if prefer_client:
+        for cand in candidates:
+            if cand["client"] == prefer_client:
+                return cand
+        return {"pid": -1, "client": prefer_client}
+    if candidates:
+        return candidates[0]
     # Stdio MCP fallback: the MCP server runs as a child of the client process.
     try:
         parent_pid = os.getppid()

--- a/mcp_server/scan_tools.py
+++ b/mcp_server/scan_tools.py
@@ -81,6 +81,12 @@ def _build_ffuf_cmd(
 ) -> list[str]:
     """Build the ffuf command parts. Pure function — no side effects, easy to test."""
     fuzz_url = f"{target.rstrip('/')}/FUZZ"
+    # Resolve a bare wordlist name (e.g. "common.txt" — the docs' wordlist=common.txt
+    # shorthand) to the seclists Web-Content dir. A relative name isn't present at the
+    # container CWD, so ffuf would error "wordlist not found" and dump its full usage
+    # instead of fuzzing.
+    if "/" not in wordlist:
+        wordlist = f"/usr/share/seclists/Discovery/Web-Content/{wordlist}"
     if "-rate" not in flags:
         flags = f"-rate 50 {flags}".strip()
     cmd_parts = ["ffuf", "-u", fuzz_url, "-w", wordlist, "-of", "json", "-s"]
@@ -133,9 +139,14 @@ async def _run_spider_thorough(target: str, flags: str, cookies: dict, depth: st
         f"--depth {depth} --max-pages {max_pages}"
     )
 
+    # Guard zap-cli: it isn't present in every Kali image build. Without this guard a
+    # missing binary leaks "zap-cli: command not found" into the merged spider output
+    # and muddies the result — skip the ZAP AJAX sub-tool cleanly instead.
     zap_cmd = (
+        f"if command -v zap-cli >/dev/null 2>&1; then "
         f"zap-cli --port 8090 --api-key zapscan quick-scan --spider --ajax-spider "
-        f"--start-options '-config api.key=zapscan -port 8090' {safe_url}"
+        f"--start-options '-config api.key=zapscan -port 8090' {safe_url}; "
+        f"else echo '[zap-ajax skipped: zap-cli not installed in the Kali image]'; fi"
     )
 
     parts = []
@@ -167,8 +178,10 @@ async def _run_spider_fast(target: str, flags: str, cookies: dict, depth: str, m
         )
     elif mode == "deep":
         cmd = (
+            f"if command -v zap-cli >/dev/null 2>&1; then "
             f"zap-cli --port 8090 --api-key zapscan quick-scan --spider --ajax-spider "
-            f"--start-options '-config api.key=zapscan -port 8090' {safe_url}"
+            f"--start-options '-config api.key=zapscan -port 8090' {safe_url}; "
+            f"else echo '[zap-ajax skipped: zap-cli not installed in the Kali image]'; fi"
         )
     else:
         safe_flags = shlex.join(shlex.split(flags)) if flags else ""

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -13,6 +13,7 @@ from core import logger as log
 from core import session as scan_session
 from core.taxonomy import BYPASS_REQUIRED_TYPES as _BYPASS_REQUIRED_TYPES
 from mcp_server._app import mcp, _ensure_dict, _session_tools_called
+from mcp.server.fastmcp import Context
 
 _background_tasks: set[asyncio.Task] = set()  # keeps fire-and-forget tasks alive
 
@@ -97,8 +98,40 @@ def _effective_tools() -> set[str]:
     return _session_tools_called | set(current.get("tools_called", []))
 
 
+def _client_from_ctx(ctx) -> str | None:
+    """Map the MCP ``initialize`` handshake's ``clientInfo.name`` to a canonical
+    Smith client (claude | opencode | codex). Per-connection and unambiguous —
+    unlike TCP/PID scanning it isn't confused by several clients sharing the SSE
+    server. Returns None when ctx/clientInfo is absent or unrecognized."""
+    try:
+        name = (ctx.session.client_params.clientInfo.name or "").lower()
+    except Exception:
+        return None
+    for key in ("opencode", "codex", "claude"):
+        if key in name:
+            return key
+    return None
+
+
+def _record_handshake_client(ctx) -> None:
+    """On session.start(), lock the session to the client the MCP handshake
+    names — authoritative, overriding the best-effort TCP/PID detection that
+    mislabels the scan when a dev Claude Code session shares the SSE server with
+    the opencode scanner. No-op when the handshake doesn't identify a client."""
+    name = _client_from_ctx(ctx)
+    if not name:
+        return
+    try:
+        from core.session.process_detect import _detect_smith_caller
+        caller = _detect_smith_caller(prefer_client=name)
+        scan_session.set_smith_proc(caller["pid"], name, "mcp_handshake")
+        log.note(f"client locked from MCP handshake: {name} (pid={caller['pid']})")
+    except Exception as e:
+        log.note(f"handshake client record failed: {e}")
+
+
 @mcp.tool()
-async def session(action: str, options: dict | None = None) -> str:
+async def session(action: str, options: dict | None = None, ctx: Context | None = None) -> str:
     """Scan lifecycle and infrastructure management.
 
     action  : start | complete | status | recovery | artifact | qa_reply | set_skill | set_step | wishlist_add | wishlist_list | start_kali | stop_kali | start_metasploit | stop_metasploit | pull_images | set_codebase
@@ -168,9 +201,13 @@ async def session(action: str, options: dict | None = None) -> str:
     # closes.
     scan_session.load_from_disk(force=True)
     result = await _dispatch_async_action(action, opts)
-    if result is not None:
-        return result
-    return _dispatch_sync_action(action, opts)
+    if result is None:
+        result = _dispatch_sync_action(action, opts)
+    if action == "start":
+        # Lock the session to the client named in the MCP initialize handshake
+        # (authoritative, per-connection) — overrides the ambiguous PID scan.
+        _record_handshake_client(ctx)
+    return result
 
 
 async def _dispatch_async_action(action: str, opts: dict) -> str | None:

--- a/tests/test_smith_caller_detection.py
+++ b/tests/test_smith_caller_detection.py
@@ -424,3 +424,52 @@ class TestStartIntegration:
         monkeypatch.setattr(scan_session, "_detect_smith_caller", lambda: None)
         cur = scan_session.start(target="http://x.test", depth="quick")
         assert "smith_proc" not in cur
+
+
+class TestPreferClientDisambiguation:
+    """When several clients share the SSE server (e.g. a dev Claude Code session
+    alongside the opencode scanner), _detect_smith_caller(prefer_client=...) must
+    return the handshake-named client's PID, not whichever process iterates first."""
+
+    def test_prefer_returns_matching_connected_pid(self):
+        import core.session.process_detect as pd
+        with patch.object(pd, "_connected_pids", return_value=[11, 22]), \
+             patch.object(pd, "_resolve_client_for_pid",
+                          side_effect=lambda p: {11: "claude", 22: "opencode"}[p]):
+            # plain detection picks the first-iterated client — the old ambiguity
+            assert pd._detect_smith_caller() == {"pid": 11, "client": "claude"}
+            # handshake says opencode -> opencode's PID, not claude's
+            assert pd._detect_smith_caller(prefer_client="opencode") == {"pid": 22, "client": "opencode"}
+
+    def test_prefer_unconnected_client_trusts_handshake_name(self):
+        import core.session.process_detect as pd
+        with patch.object(pd, "_connected_pids", return_value=[11]), \
+             patch.object(pd, "_resolve_client_for_pid", return_value="claude"):
+            # codex isn't connected, but the handshake name is authoritative
+            assert pd._detect_smith_caller(prefer_client="codex") == {"pid": -1, "client": "codex"}
+
+
+class TestClientFromHandshake:
+    """Map the MCP initialize handshake's clientInfo.name to a canonical client."""
+
+    @staticmethod
+    def _ctx(name):
+        return type("Ctx", (), {"session": type("S", (), {
+            "client_params": type("P", (), {
+                "clientInfo": type("I", (), {"name": name})})})})
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("opencode", "opencode"),
+        ("Claude Code", "claude"),
+        ("claude-code", "claude"),
+        ("codex", "codex"),
+        ("vscode", None),
+        ("", None),
+    ])
+    def test_maps_clientinfo_name(self, raw, expected):
+        import mcp_server.session_tools as st
+        assert st._client_from_ctx(self._ctx(raw)) == expected
+
+    def test_none_ctx_is_safe(self):
+        import mcp_server.session_tools as st
+        assert st._client_from_ctx(None) is None

--- a/tests/test_triage_postscan.py
+++ b/tests/test_triage_postscan.py
@@ -262,6 +262,7 @@ class TestEnsureMcpSseAlive:
         proc = MagicMock()
         proc.wait = AsyncMock(return_value=0)
         with patch.object(smith_mod, "_mcp_sse_alive", side_effect=lambda: next(alive_seq)), \
+             patch.object(smith_mod, "_launchd_supervises_mcp", new=AsyncMock(return_value=False)), \
              patch("asyncio.create_subprocess_exec",
                    new=AsyncMock(return_value=proc)) as spawn, \
              patch("core.notifiers.notify"):
@@ -272,6 +273,25 @@ class TestEnsureMcpSseAlive:
     async def test_no_restart_when_launcher_missing(self, tmp_path, monkeypatch):
         monkeypatch.setattr(api, "_REPO_ROOT", tmp_path)  # no installers/ dir
         with patch.object(smith_mod, "_mcp_sse_alive", return_value=False), \
+             patch.object(smith_mod, "_launchd_supervises_mcp", new=AsyncMock(return_value=False)), \
              patch("asyncio.create_subprocess_exec") as spawn:
             await api._ensure_mcp_sse_alive(time.time())
         spawn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restarts_via_launchd_when_supervised(self, monkeypatch):
+        # When launchd already supervises the daemon, restart THROUGH it
+        # (launchctl kickstart) — never spawn a second launcher that would
+        # race it for port 7778 and orphan a process.
+        alive_seq = iter([False, True])
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        with patch.object(smith_mod, "_mcp_sse_alive", side_effect=lambda: next(alive_seq)), \
+             patch.object(smith_mod, "_launchd_supervises_mcp", new=AsyncMock(return_value=True)), \
+             patch("asyncio.create_subprocess_exec",
+                   new=AsyncMock(return_value=proc)) as spawn, \
+             patch("core.notifiers.notify"):
+            await api._ensure_mcp_sse_alive(time.time())
+        spawn.assert_awaited_once()
+        argv = spawn.await_args.args
+        assert argv[0] == "launchctl" and "kickstart" in argv


### PR DESCRIPTION
## Summary

This branch delivers the OOB-confirmation / exploit-chain / target-routing feature work, **plus several fixes found while testing it end-to-end** (opencode → local DGX model → live target).

### Feature work (per branch commits)
- OOB confirmation + exploit-chain **target routing**
- **exec sandbox** (`tools/sandbox_runner.py`) — network on by default, opt-out for strict isolation
- findings hygiene, **wishlist** (agent→operator backlog), small-model profile scaling
- docs (README / MCP+API reference / `.env.example`), CI skill bumps, Sonar/CodeQL gate fixes

### Fixes found during testing (this work)
- **`fix(scan)`** — resolve bare ffuf wordlist names (`common.txt` → seclists path) so ffuf fuzzes instead of dumping usage; guard `zap-cli` in both spider modes so a missing binary doesn't leak `command not found`.
- **`fix(watchdog)`** — make the dashboard MCP self-heal **launchd-aware**: restart via `launchctl kickstart -k` when launchd supervises the daemon, instead of spawning a second `start-mcp-server.sh` that races for port 7778 and orphans a process. Falls back to the script on TCC folders / Linux / Windows.
- **`feat(session)`** — lock a scan to the client named in the **MCP `initialize` handshake** (`clientInfo.name`, per-connection & authoritative). Fixes the dashboard respawning the scan with the wrong runner (e.g. `claude` → "Credit balance is too low") when a dev Claude Code session shares the SSE server with the opencode scanner.

## Testing
- Full suite green; added tests for the watchdog launchd path, ffuf/zap-cli, the `prefer_client` disambiguation, and the `clientInfo`→client mapping.
- Exercised end-to-end via `opencode run` against a live target — **21 findings (6 critical, 13 high)** with no context overflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)