### PR TITLE
fix(coverage): resolve completion deadlock — gate on artifact_id, not deprecated tested_by

### DIFF
--- a/core/coverage/__init__.py
+++ b/core/coverage/__init__.py
@@ -131,6 +131,7 @@ from .validation import (  # noqa: E402
     _validate_artifact,
     _validate_auth_response,
     _validate_finding_link,
+    cell_has_test_evidence,
 )
 from .operations import (  # noqa: E402
     _apply_bulk_cell,
@@ -154,4 +155,5 @@ __all__ = [
     "get_pending",
     "list_cells",
     "reset",
+    "cell_has_test_evidence",
 ]

--- a/core/coverage/validation.py
+++ b/core/coverage/validation.py
@@ -79,6 +79,26 @@ def _validate_artifact(artifact_id: str, status: str) -> str:
     return ""
 
 
+def cell_has_test_evidence(cell: dict) -> bool:
+    """True if a closed cell carries real test evidence.
+
+    ``artifact_id`` is THE enforcement mechanism — ``_validate_artifact``
+    rejects any tested_clean/vulnerable closure whose artifact doesn't exist
+    on disk, so a closed cell with an ``artifact_id`` provably ran a tool.
+    ``tested_by`` is retained only as human-readable context ("Free-text
+    tested_by is no longer accepted" — see ``_validate_artifact``).
+
+    A cell is evidenced if it has EITHER. The completion gates used to key on
+    ``tested_by`` alone, which made a cell closed with a real artifact but an
+    empty ``tested_by`` permanently un-completable: the proof was on disk, yet
+    the gate demanded the deprecated field. After a context compaction Smith
+    loses the cell IDs and can't backfill that field, so the whole scan
+    deadlocks short of completion. Gate on the artifact, with ``tested_by`` as
+    a back-compat fallback for older matrices.
+    """
+    return bool(cell.get("artifact_id") or cell.get("tested_by"))
+
+
 # Injection cell types where 401/403 is meaningless evidence of cleanliness —
 # the test payload was never evaluated because auth blocked the request first.
 # Excluded: auth/access-control cell types where 401/403 IS the finding signal.

--- a/core/qa_agent/checks_shortcuts.py
+++ b/core/qa_agent/checks_shortcuts.py
@@ -15,7 +15,7 @@ from ._util import _ts_age_secs
 
 
 def _check_bulk_marking(entries: list[dict]) -> dict | None:
-    """Block completion when >10 N/A cells have no tested_by tool."""
+    """Block completion when >10 N/A cells cite no test evidence (artifact_id)."""
     cov_entries = [e for e in entries if e.get("type") == "COVERAGE"]
     if not cov_entries:
         return None
@@ -24,12 +24,12 @@ def _check_bulk_marking(entries: list[dict]) -> dict | None:
         return None
     return {
         "code": "BULK_MARKING", "urgency": "high", "blocking": True,
-        "message": f"Bulk-marking detected: {na_untooled} N/A cells have no tested_by tool — run actual tools before marking N/A",
+        "message": f"Bulk-marking detected: {na_untooled} N/A cells cite no artifact_id — run actual tools and cite the artifact before marking N/A",
     }
 
 
 def _check_coverage_integrity(entries: list[dict]) -> dict | None:
-    """Block completion when tested/vulnerable cells have no tested_by tool."""
+    """Block completion when tested/vulnerable cells cite no test evidence (artifact_id)."""
     cov_entries = [e for e in entries if e.get("type") == "COVERAGE"]
     if not cov_entries:
         return None
@@ -38,7 +38,7 @@ def _check_coverage_integrity(entries: list[dict]) -> dict | None:
         return None
     return {
         "code": "COVERAGE_INTEGRITY", "urgency": "high", "blocking": True,
-        "message": f"Coverage integrity: {untooled} tested/vulnerable cells lack a tested_by tool — cite the artifact before closing",
+        "message": f"Coverage integrity: {untooled} tested/vulnerable cells cite no artifact_id — re-test and pass the artifact_id from the tool response",
     }
 
 

--- a/mcp_server/report_tools.py
+++ b/mcp_server/report_tools.py
@@ -817,6 +817,11 @@ async def _emit_coverage_event() -> None:
         matrix    = _cov.get_matrix()
         meta      = matrix.get("meta", {})
         all_cells = matrix.get("matrix", [])
+        # "Unevidenced" = closed without an artifact_id (the write-enforced proof
+        # a tool ran) AND without legacy tested_by. Keying these counts on
+        # artifact_id keeps the QA completion gates satisfiable: a cell closed
+        # with a real artifact but empty tested_by is evidenced, not orphaned.
+        from core.coverage import cell_has_test_evidence
         await _qlog.append({
             "type":           "COVERAGE",
             "registered":     len(matrix.get("endpoints", [])),
@@ -826,10 +831,11 @@ async def _emit_coverage_event() -> None:
             "not_applicable": sum(1 for c in all_cells if c["status"] == "not_applicable"),
             "skipped":        sum(1 for c in all_cells if c["status"] == "skipped"),
             "na_untooled":    sum(1 for c in all_cells
-                                  if c["status"] == "not_applicable" and not c.get("tested_by")),
+                                  if c["status"] == "not_applicable"
+                                  and not cell_has_test_evidence(c)),
             "untooled":       sum(1 for c in all_cells
                                   if c["status"] in ("tested_clean", "vulnerable")
-                                  and not c.get("tested_by")),
+                                  and not cell_has_test_evidence(c)),
         })
     except Exception:
         pass

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -604,12 +604,13 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
         blockers.append(low_cov)
 
     all_cells = cov.get("matrix", [])
+    from core.coverage import cell_has_test_evidence
     untooled = [c for c in all_cells
-                if c["status"] in ("tested_clean", "vulnerable") and not c.get("tested_by")]
+                if c["status"] in ("tested_clean", "vulnerable") and not cell_has_test_evidence(c)]
     if untooled:
         blockers.append(
-            f"INTEGRITY: {len(untooled)} cell(s) marked tested/vulnerable but have no "
-            f"tested_by tool. Re-test these cells or add the tested_by field."
+            f"INTEGRITY: {len(untooled)} cell(s) marked tested/vulnerable but cite no "
+            f"artifact_id. Re-test these cells and pass the artifact_id from the tool response."
         )
 
     suspect_na = _suspect_na_cells(all_cells, _BYPASS_REQUIRED_TYPES)
@@ -636,11 +637,12 @@ def _coverage_blockers(cov: dict, ctf_mode: bool = False) -> list[str]:
 
 
 def _na_untooled_blocker(cells: list[dict], bypass_types: dict) -> str | None:
-    """Return a blocker string if any bypass-type N/A cells lack a tested_by tool."""
+    """Return a blocker string if any bypass-type N/A cells cite no test evidence."""
+    from core.coverage import cell_has_test_evidence
     na_untooled = [
         c for c in cells
         if c["status"] == "not_applicable"
-        and not c.get("tested_by")
+        and not cell_has_test_evidence(c)
         and c.get("injection_type") in bypass_types
     ]
     if not na_untooled:
@@ -649,8 +651,8 @@ def _na_untooled_blocker(cells: list[dict], bypass_types: dict) -> str | None:
     if len(na_untooled) > 5:
         sample += f" ... ({len(na_untooled) - 5} more)"
     return (
-        f"INTEGRITY: {len(na_untooled)} injection-type N/A cell(s) have no tested_by tool "
-        f"recorded: {sample}. Run the bypass technique and record tested_by before marking N/A."
+        f"INTEGRITY: {len(na_untooled)} injection-type N/A cell(s) cite no artifact_id "
+        f"of a bypass attempt: {sample}. Run the bypass technique and pass its artifact_id before marking N/A."
     )
 
 
@@ -1943,14 +1945,15 @@ def _check_coverage_integrity(matrix: list[dict], tools_run: set[str]) -> list[s
     """Cross-check coverage cell statuses against tools actually run."""
     warnings: list[str] = []
 
-    # Cells marked tested/vulnerable without a tested_by field
+    # Cells marked tested/vulnerable that cite no test evidence (artifact_id)
+    from core.coverage import cell_has_test_evidence
     by_type: dict[str, list[str]] = {}
     for c in matrix:
-        if c["status"] in ("tested_clean", "vulnerable") and not c.get("tested_by"):
+        if c["status"] in ("tested_clean", "vulnerable") and not cell_has_test_evidence(c):
             by_type.setdefault(c["injection_type"], []).append(c["id"])
     for inj, ids in by_type.items():
         warnings.append(
-            f"SUSPECT: {len(ids)} {inj} cell(s) marked tested but have no tested_by tool. "
+            f"SUSPECT: {len(ids)} {inj} cell(s) marked tested but cite no artifact_id. "
             f"Re-verify these cells with actual tool execution."
         )
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -406,6 +406,30 @@ async def test_meta_counters_accurate(coverage_file):
 
 
 # ---------------------------------------------------------------------------
+# cell_has_test_evidence — the completion-gate evidence predicate
+# ---------------------------------------------------------------------------
+
+def test_cell_evidence_artifact_only_is_evidenced():
+    # The deadlock fix: a cell closed with a real artifact_id but an empty
+    # tested_by IS evidenced. Keying the completion gates on tested_by alone
+    # made such cells permanently un-completable after a context compaction.
+    from core.coverage import cell_has_test_evidence
+    assert cell_has_test_evidence({"artifact_id": "http_request_120000_abcd1234", "tested_by": ""})
+
+
+def test_cell_evidence_tested_by_only_is_evidenced():
+    # Back-compat: older matrices recorded only the free-text tested_by.
+    from core.coverage import cell_has_test_evidence
+    assert cell_has_test_evidence({"artifact_id": "", "tested_by": "sqlmap"})
+
+
+def test_cell_evidence_neither_is_unevidenced():
+    from core.coverage import cell_has_test_evidence
+    assert not cell_has_test_evidence({"artifact_id": "", "tested_by": ""})
+    assert not cell_has_test_evidence({})
+
+
+# ---------------------------------------------------------------------------
 # Path normalization
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -621,7 +621,7 @@ def test_update_known_assets_multiple_types_independent():
 from mcp_server.session_tools import _injection_breadth_blocker, _na_untooled_blocker
 
 
-def _cell(ep_id, param, param_type, inj_type, status="pending", tested_by=""):
+def _cell(ep_id, param, param_type, inj_type, status="pending", tested_by="", artifact_id=""):
     return {
         "id": f"cell-{ep_id}-{param}-{inj_type}",
         "endpoint_id": ep_id,
@@ -630,6 +630,7 @@ def _cell(ep_id, param, param_type, inj_type, status="pending", tested_by=""):
         "injection_type": inj_type,
         "status": status,
         "tested_by": tested_by,
+        "artifact_id": artifact_id,
     }
 
 
@@ -676,15 +677,24 @@ def test_na_untooled_blocker_no_issue():
 
 
 def test_na_untooled_blocker_fires():
+    # N/A bypass-type cell with neither artifact_id nor tested_by → no evidence → blocks.
     cells = [_cell("ep1", "q", "query", "sqli", status="not_applicable", tested_by="")]
     result = _na_untooled_blocker(cells, {"sqli": "blind bypass"})
     assert result is not None
     assert "INTEGRITY" in result
-    assert "tested_by" in result
+    assert "artifact_id" in result
 
 
 def test_na_untooled_blocker_with_tested_by_ok():
     cells = [_cell("ep1", "q", "query", "sqli", status="not_applicable", tested_by="sqlmap")]
+    assert _na_untooled_blocker(cells, {"sqli": "blind bypass"}) is None
+
+
+def test_na_untooled_blocker_with_artifact_only_ok():
+    # artifact_id is the real evidence — a bypass-tested N/A cell that cites an
+    # artifact but left tested_by blank must NOT block completion (the deadlock fix).
+    cells = [_cell("ep1", "q", "query", "sqli", status="not_applicable",
+                   tested_by="", artifact_id="http_request_120000_abcd1234")]
     assert _na_untooled_blocker(cells, {"sqli": "blind bypass"}) is None
 
 

--- a/tests/test_session_tools_helpers.py
+++ b/tests/test_session_tools_helpers.py
@@ -946,7 +946,14 @@ class TestDoComplete:
              patch("mcp_server.session_tools._collect_completion_blockers", return_value=[]), \
              patch("mcp_server.session_tools._record_metrics"):
             result = _do_complete()
-        assert "complete" in result.lower() or "Scan marked" in result
+        # With no blockers the scan passes all quality gates and is HELD for
+        # human sign-off via the dashboard (finding-adjudication flow), rather
+        # than being auto-marked complete.
+        assert (
+            "completion held" in result.lower()
+            or "sign-off" in result.lower()
+            or "complete" in result.lower()
+        )
 
     def test_thorough_depth_no_blockers_adds_iteration_gate(self, tmp_path, monkeypatch):
         import mcp_server.session_tools as st


### PR DESCRIPTION
## The bug

A scan could **deadlock short of completion**, looping `complete → rejected → fix → rejected` until the watchdog gave up. Surfaced on a live black-box scan that had already produced 23 solid findings: **24 fully-evidenced coverage cells** (every one with a real `artifact_id`) were permanently blocking completion.

### Root cause: the gate and the write path disagreed
- `update_cell` / `bulk_update` enforce **`artifact_id`** for `tested_clean`/`vulnerable` closures — `_validate_artifact` rejects any closure whose artifact file isn't on disk. Its docstring is explicit: *"the legacy tested_by field … is no longer the enforcement mechanism — artifact_id is."*
- But the **completion blockers and QA integrity checks still demanded the deprecated free-text `tested_by`** (`not c.get("tested_by")`).

So a cell closed with a real artifact but an empty `tested_by` **passed the write yet could never satisfy `COVERAGE_INTEGRITY`**. And after a **context compaction** Smith loses the cell IDs, so it can't backfill the dead field — the deadlock becomes permanent, and the scan thrashes until the watchdog stops respawning it.

## The fix

Introduce one shared predicate and key every gate on it:

```python
def cell_has_test_evidence(cell) -> bool:
    # artifact_id is the write-validated proof a tool ran; tested_by is
    # back-compat context. Evidenced if EITHER is present.
    return bool(cell.get("artifact_id") or cell.get("tested_by"))
```

- **`core/coverage/validation.py`** — new `cell_has_test_evidence` (single source of truth)
- **`mcp_server/report_tools.py`** — `untooled` / `na_untooled` COVERAGE counts (these feed the QA `COVERAGE_INTEGRITY` / `BULK_MARKING` blockers)
- **`mcp_server/session_tools.py`** — `_coverage_blockers` untooled gate, `_na_untooled_blocker`, `_check_coverage_integrity` advisory
- **`core/qa_agent/checks_shortcuts.py`** — gate messages now say *"cite no artifact_id"*

`tested_by` is kept as a back-compat fallback so older matrices that recorded only the free-text field still count as evidenced. Since a `tested_clean`/`vulnerable` cell **always** has a write-enforced artifact, its integrity gate is now **always satisfiable**. The legitimate **low-coverage** block (genuinely untested cells remaining) is unchanged — only the un-satisfiable orphan-cell deadlock is removed.

Verified against the live stuck matrix: `untooled` **24 → 0**, deadlock cleared, with the low-coverage block correctly still in place.

## Tests
- `cell_has_test_evidence`: artifact-only ✓, tested_by-only ✓ (back-compat), neither ✗
- `_na_untooled_blocker`: artifact-only cell no longer blocks
- Fixed a **pre-existing** stale assertion in `test_no_blockers_standard_depth_marks_complete` (completion is now HELD for human sign-off, not auto-marked — unrelated to this fix, failed on a clean tree too)

Full suite: **1271 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)