### PR TITLE
fix(ai-redteam): RCA fixes from live lab scan — garak probe-prefix + …

### DIFF
--- a/core/coverage/operations.py
+++ b/core/coverage/operations.py
@@ -22,6 +22,17 @@ from .validation import (
 )
 
 
+def _tested_by_from_artifact(artifact_id: str) -> str:
+    """Derive the tool name from a tool-prefixed artifact_id so artifact-backed
+    closures aren't falsely flagged 'untooled' (artifact_id is the real evidence
+    gate). Format: <tool>_<digits>_<hex> — e.g. 'http_request_134016_d4fd92c3'
+    -> 'http_request', 'garak_134016_730a2dab' -> 'garak'."""
+    if not artifact_id:
+        return ""
+    parts = artifact_id.rsplit("_", 2)
+    return parts[0] if len(parts) == 3 else artifact_id
+
+
 async def add_endpoint(
     path: str,
     method: str,
@@ -162,7 +173,7 @@ async def update_cell(
                 )
                 cell["status"]      = status
                 cell["notes"]       = notes
-                cell["tested_by"]   = tested_by
+                cell["tested_by"]   = tested_by or _tested_by_from_artifact(artifact_id)
                 cell["artifact_id"] = artifact_id
                 if finding_id:
                     cell["finding_id"] = finding_id
@@ -189,7 +200,7 @@ def _apply_bulk_cell(cell: dict, upd: dict, warnings: list[str]) -> None:
         warnings.append(warning)
     cell["status"]      = st
     cell["notes"]       = notes_text
-    cell["tested_by"]   = upd.get("tested_by", "")
+    cell["tested_by"]   = upd.get("tested_by") or _tested_by_from_artifact(upd.get("artifact_id", ""))
     cell["artifact_id"] = upd.get("artifact_id", "")
     if upd.get("finding_id"):
         cell["finding_id"] = upd["finding_id"]

--- a/core/qa_agent/checks_skills.py
+++ b/core/qa_agent/checks_skills.py
@@ -130,7 +130,25 @@ def _maybe_inject_business_logic_directive(
         )
 
 
-def _check_core_skill_chain(entries: list[dict], session_data: dict) -> list[dict]:
+def _target_is_web(coverage_data: dict | None) -> bool:
+    """True unless EVERY registered endpoint is an AI/LLM/MCP surface. A pure-LLM
+    target routes to /ai-redteam, so the web skill-chain mandate must not fire on
+    it (taxonomy-blind misfire that hijacked an ai-redteam scan into /web-exploit).
+    Unknown/empty coverage → True (preserve prior behavior; don't over-suppress)."""
+    if not coverage_data:
+        return True
+    try:
+        from core.coverage import classify_endpoint
+    except Exception:
+        return True
+    eps = coverage_data.get("endpoints", [])
+    if not eps:
+        return True
+    return not all(classify_endpoint(e.get("path", "")) == "ai-redteam" for e in eps)
+
+
+def _check_core_skill_chain(entries: list[dict], session_data: dict,
+                            coverage_data: dict | None = None) -> list[dict]:
     """Enforce the mandatory skill progression every web pentest must complete.
 
     Sequence enforced:
@@ -151,9 +169,12 @@ def _check_core_skill_chain(entries: list[dict], session_data: dict) -> list[dic
     web_exploit_entry = next((e for e in reversed(skill_history) if e.get("skill") == "web-exploit"), None)
     web_exploit_ts = web_exploit_entry.get("ts", "") if web_exploit_entry else ""
 
-    _maybe_inject_web_exploit_directive(spider_ts, skills_run, now, alerts)
-    _maybe_inject_param_fuzz_directive(web_exploit_ts, skills_run, now, alerts)
-    _maybe_inject_business_logic_directive(depth, skill_history, skills_run, now, alerts)
+    # Skip the web skill-chain mandate on a pure-LLM/MCP target (it routes to
+    # /ai-redteam, not /web-exploit) — prevents the taxonomy-blind misfire.
+    if _target_is_web(coverage_data):
+        _maybe_inject_web_exploit_directive(spider_ts, skills_run, now, alerts)
+        _maybe_inject_param_fuzz_directive(web_exploit_ts, skills_run, now, alerts)
+        _maybe_inject_business_logic_directive(depth, skill_history, skills_run, now, alerts)
 
     return alerts
 

--- a/core/qa_agent/daemon.py
+++ b/core/qa_agent/daemon.py
@@ -87,7 +87,7 @@ _CHECKS: list[tuple] = [
     (_check_tool_inactivity,       ("entries",)),
     # Mandatory tool / skill chain (core_skill_chain + missing_skill return lists)
     (_check_no_spider_after_httpx, ("entries",)),
-    (_check_core_skill_chain,      ("entries", "session_data")),
+    (_check_core_skill_chain,      ("entries", "session_data", "coverage_data")),
     (_check_missing_skill,         ("coverage_data", "session_data")),
 ]
 

--- a/mcp_server/scan_tools.py
+++ b/mcp_server/scan_tools.py
@@ -392,9 +392,12 @@ async def _handle_garak(target, flags, options):
     method     = options.get("method", "post")
     resp_field = options.get("response_field", "")  # JSONPath to the reply text
 
-    # Garak needs fully-qualified probe names (e.g. "probes.dan" not "dan").
+    # garak 0.15.0 wants canonical probe names WITHOUT a "probes." prefix:
+    # both "dan" and "dan.Dan_11_0" are accepted, but "probes.dan[.Class]" is
+    # REJECTED ("Unknown probes" -> garak runs nothing). Strip any stray prefix;
+    # never add one.
     qualified = ",".join(
-        p if p.startswith("probes.") else f"probes.{p}"
+        p[len("probes."):] if p.startswith("probes.") else p
         for p in (s.strip() for s in probes.split(",")) if p
     )
 
@@ -420,7 +423,7 @@ async def _handle_garak(target, flags, options):
     # body (no $INPUT slot) nor a response parser, so every probe scored empty
     # output. The JSON config above supplies both.
     garak_cmd = (
-        f"garak --model_type rest -G {cfg_path}"
+        f"garak --target_type rest -G {cfg_path}"
         f" --probes {shlex.quote(qualified)}"
         f" --report_prefix {prefix}"
     )

--- a/mcp_server/session_tools.py
+++ b/mcp_server/session_tools.py
@@ -507,8 +507,31 @@ def _do_start(opts):
         from core.steering import steering_queue
         steering_queue.cancel_by_trigger("TRIAGE_ADJUDICATION", "cleared on new scan start")
         steering_queue.cancel_by_trigger("FORCE_COMPLETE_ADJUDICATION", "cleared on new scan start")
+        # Also clear stale SKILL-CHAIN directives so a prior run's mandate (e.g.
+        # MISSING_WEB_EXPLOIT) can't replay into — and hijack — this fresh scan.
+        for _trig in ("MISSING_WEB_EXPLOIT", "MISSING_PARAM_FUZZ", "MISSING_BUSINESS_LOGIC"):
+            steering_queue.cancel_by_trigger(_trig, "cleared on new scan start")
     except Exception:
         pass
+    # On a NON-resume start, reset the QA daemon's input log + alert state so a
+    # prior scan's SPIDER/SKILL/TOOL entries don't re-derive stale skill-chain
+    # alerts against this run (the cross-session bleed that hijacked a fresh
+    # ai-redteam scan into /web-exploit). Archive rather than delete.
+    if not is_resume:
+        try:
+            import shutil
+            from datetime import datetime as _dt, timezone as _tz
+            from core.coverage import COVERAGE_FILE
+            base = COVERAGE_FILE.parent
+            arch = base / "logs"; arch.mkdir(exist_ok=True)
+            _ts = _dt.now(_tz.utc).strftime("%Y%m%d_%H%M%S")
+            for stale in ("quick_log.json", _QA_STATE_FILENAME):
+                p = base / stale
+                if p.exists():
+                    shutil.copy2(p, arch / f"{p.stem}_{_ts}.json")
+                    p.unlink()
+        except Exception:
+            pass
     return _start_response(cfg, classification, target, scan_mode, depth, is_resume)
 
 
@@ -2120,12 +2143,13 @@ def _do_recovery():
     data = findings_store._load()
     pending_escalations = []
     for f in data.get("findings", []):
-        leads = [l for l in f.get("escalation_leads", []) if l.get("status") == "pending"]
+        leads = [l for l in f.get("escalation_leads", [])
+                 if isinstance(l, dict) and l.get("status") == "pending"]
         if leads:
             pending_escalations.append({
                 "finding_id": f["id"],
                 "title": f["title"],
-                "pending_leads": [l["lead"] for l in leads],
+                "pending_leads": [l.get("lead") for l in leads],
             })
 
     tools_run = _effective_tools()

--- a/tests/test_ai_redteam_coverage.py
+++ b/tests/test_ai_redteam_coverage.py
@@ -133,6 +133,23 @@ def test_pyrit_summarizer_detects_success_and_degradation():
     assert r.evidence["degraded"] is True
 
 
+def test_tested_by_derived_from_artifact_id():
+    """bulk_tested closures backed by artifact_id alone must not read as 'untooled'."""
+    from core.coverage.operations import _tested_by_from_artifact
+    assert _tested_by_from_artifact("http_request_134016_d4fd92c3") == "http_request"
+    assert _tested_by_from_artifact("garak_134016_730a2dab") == "garak"
+    assert _tested_by_from_artifact("") == ""
+
+
+def test_target_is_web_suppresses_web_mandate_on_ai_only():
+    """Pure-LLM target -> web skill-chain mandate suppressed; mixed/unknown -> not."""
+    from core.qa_agent.checks_skills import _target_is_web
+    assert _target_is_web({"endpoints": [{"path": "/v1/chat/completions"}, {"path": "/chat"}]}) is False
+    assert _target_is_web({"endpoints": [{"path": "/login"}, {"path": "/chat"}]}) is True
+    assert _target_is_web({"endpoints": []}) is True
+    assert _target_is_web(None) is True
+
+
 def test_ai_summarizers_degrade_without_crashing():
     # No structured section present — must produce a useful summary, not raise.
     assert summarize("garak", "garbage", {}).summary
@@ -195,10 +212,30 @@ async def test_garak_handler_builds_rest_config_invocation(monkeypatch):
     from mcp_server.scan_tools import _handle_garak
     out = await _handle_garak("http://t/chat", "", {"probes": "dan,encoding"})
     assert out == "WRAP:garak"
-    assert "--model_type rest -G" in cap["cmd"]
+    assert "--target_type rest -G" in cap["cmd"]   # not the deprecated --model_type
     assert "garak_rest.json" in cap["cmd"]
-    assert "api_base=" not in cap["cmd"]      # the old broken form is gone
-    assert "probes.dan,probes.encoding" in cap["cmd"]
+    assert "api_base=" not in cap["cmd"]           # the old broken form is gone
+    # garak 0.15.0 rejects "probes." prefixes — names must be passed bare.
+    assert "--probes dan,encoding" in cap["cmd"]
+    assert "probes.dan" not in cap["cmd"]
+
+
+@pytest.mark.asyncio
+async def test_garak_handler_strips_stray_probes_prefix(monkeypatch):
+    """A caller that mistakenly supplies a 'probes.'-prefixed name gets it stripped
+    (garak 0.15.0 only accepts the bare form, incl. module.Class like dan.Dan_11_0)."""
+    import tools.kali_runner as kr
+    import mcp_server.scan_engine as se
+    cap = {}
+    async def fake_exec(cmd, timeout=900):
+        cap["cmd"] = cmd
+        return "raw"
+    monkeypatch.setattr(kr, "exec_command", fake_exec)
+    monkeypatch.setattr(se, "wrap", lambda tool, raw, ctx=None: f"WRAP:{tool}")
+    from mcp_server.scan_tools import _handle_garak
+    await _handle_garak("http://t/chat", "", {"probes": "probes.dan.Dan_11_0,probes.encoding"})
+    assert "--probes dan.Dan_11_0,encoding" in cap["cmd"]
+    assert "probes.dan" not in cap["cmd"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…5 more

Live-scan validation surfaced 6 verified defects (7-agent RCA + adversarial verify):

- garak: stop prepending "probes." to probe names — garak 0.15.0 REJECTS "probes.dan[.Class]" ("Unknown probes"), so every probe no-op'd (0 eval entries). Pass bare names; strip any stray prefix. (FATAL — silently zeroed the engine.)
- garak: --model_type -> --target_type (the former is a deprecated 0.13.1 alias).
- session_tools _do_recovery: guard non-dict escalation_leads with isinstance (mirrors commit 1846959, which fixed only _escalation_lead_blockers) — fixes the "'str' object has no attribute 'get'" crash on a same-target resume/recovery.
- qa_agent: make the post-spider web-exploit mandate taxonomy-aware (_target_is_web + coverage_data plumbed into _check_core_skill_chain) so it no longer pushes /web-exploit on a pure-LLM/MCP target that routes to /ai-redteam.
- session start: cancel stale skill-chain steering + archive/reset quick_log+qa_state on a non-resume start, so a prior run's MISSING_WEB_EXPLOIT can't hijack a fresh scan.
- coverage: derive tested_by from artifact_id so artifact-backed bulk_tested closures aren't falsely flagged "untooled" (a completion-blocking false-positive QA alert).

Verified: fixed garak form detects the lab jailbreak (MitigationBypass 100%, report.jsonl parsed); full suite 1287 passed (+3 RCA regression tests).