### PR TITLE
feat(graph): thin Cypher-ish path finder over the in-memory world model

### DIFF
--- a/core/graph/__init__.py
+++ b/core/graph/__init__.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 from .build import build_graph
 from .chains import candidate_chains
 from .model import Edge, Graph, Node
+from .paths import Match, NodeM, Rel, match_chain, reachable, render_path, shortest_path
 from .views import coverage_view, next_targets, rank_findings
 
 __all__ = ["build_graph", "candidate_chains", "coverage_view", "next_targets",
-           "rank_findings", "Graph", "Node", "Edge"]
+           "rank_findings", "Graph", "Node", "Edge",
+           "match_chain", "reachable", "shortest_path", "render_path",
+           "NodeM", "Rel", "Match"]

--- a/core/graph/paths.py
+++ b/core/graph/paths.py
@@ -1,0 +1,239 @@
+"""A thin, Cypher-ish path finder over the in-memory world-model Graph (AR-B3+).
+
+Attack-chaining is a graph-path problem. Rather than hand-code each chain shape in
+``chains.py`` (imperative traversal), this exposes a small declarative matcher so a
+pattern is *data*, not code — the 80% of Neo4j/Cypher's value with none of the
+operational cost (no service, no persistence, no drift; the matrix stays
+authoritative and the graph is still projected on demand).
+
+Two primitives, plus helpers:
+
+  match_chain(g, pattern)   fixed-length node–rel–node patterns. The Cypher
+                            (a:Finding)-[:LEAKS]->(:Host)<-[:FOUND_ON]-(b:Finding)
+                            becomes
+                            [NodeM("finding", var="a"), Rel(LEAKS),
+                             NodeM("host"), Rel(FOUND_ON, "in"),
+                             NodeM("finding", var="b")]
+
+  reachable(g, src, target) variable-length reachability — the Cypher
+                            (src)-[:kind*1..4]->(target) "what can I reach in ≤N
+                            hops" query that is painful to hand-roll each time.
+
+Pure, no I/O. Simple paths only (a node is never revisited within one path), so
+results are finite and cycle-safe. Bounded by `limit` and `max_hops`.
+"""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+from .model import Edge, Graph, Node
+
+_DIRECTIONS = ("out", "in", "any")
+
+
+@dataclass
+class NodeM:
+    """A node matcher. ``kind`` filters by node kind (None = any); ``where`` is an
+    optional predicate on the Node; ``var`` binds the matched node in the result."""
+    kind: str | None = None
+    where: Callable[[Node], bool] | None = None
+    var: str | None = None
+
+    def matches(self, node: Node) -> bool:
+        if self.kind is not None and node.kind != self.kind:
+            return False
+        return self.where is None or bool(self.where(node))
+
+
+@dataclass
+class Rel:
+    """A relationship matcher for a single hop. ``kind`` filters by edge kind
+    (None = any); ``direction`` is 'out' (src→dst), 'in' (dst→src), or 'any'."""
+    kind: str | None = None
+    direction: str = "out"
+
+    def __post_init__(self) -> None:
+        if self.direction not in _DIRECTIONS:
+            raise ValueError(f"direction must be one of {_DIRECTIONS}, got {self.direction!r}")
+
+
+@dataclass
+class Match:
+    """One matched path. ``nodes`` are the pattern-position nodes in order;
+    ``vars`` binds the NodeM.var names; ``edges`` are the traversed edges."""
+    nodes: list[Node]
+    edges: list[Edge] = field(default_factory=list)
+    vars: dict[str, Node] = field(default_factory=dict)
+
+    @property
+    def node_ids(self) -> list[str]:
+        return [n.id for n in self.nodes]
+
+    def var(self, name: str) -> Node | None:
+        return self.vars.get(name)
+
+
+# ── adjacency (built once per query — the base Graph does O(E) edge scans) ──────
+
+def _adjacency(g: Graph) -> tuple[dict[str, list[Edge]], dict[str, list[Edge]]]:
+    out: dict[str, list[Edge]] = {}
+    inc: dict[str, list[Edge]] = {}
+    for e in g.edges:
+        out.setdefault(e.src, []).append(e)
+        inc.setdefault(e.dst, []).append(e)
+    return out, inc
+
+
+def _neighbors(out: dict, inc: dict, node_id: str, rel: Rel) -> list[tuple[Edge, str]]:
+    """(edge, other_node_id) pairs reachable from node_id via one hop matching rel."""
+    res: list[tuple[Edge, str]] = []
+    if rel.direction in ("out", "any"):
+        for e in out.get(node_id, []):
+            if rel.kind is None or e.kind == rel.kind:
+                res.append((e, e.dst))
+    if rel.direction in ("in", "any"):
+        for e in inc.get(node_id, []):
+            if rel.kind is None or e.kind == rel.kind:
+                res.append((e, e.src))
+    return res
+
+
+def _validate_pattern(pattern: list) -> None:
+    if not pattern or len(pattern) % 2 == 0:
+        raise ValueError("pattern must be a non-empty, odd-length list: NodeM, Rel, NodeM, ...")
+    for i, part in enumerate(pattern):
+        expect = NodeM if i % 2 == 0 else Rel
+        if not isinstance(part, expect):
+            raise ValueError(f"pattern[{i}] must be a {expect.__name__}, got {type(part).__name__}")
+
+
+# ── fixed-length pattern matching ───────────────────────────────────────────────
+
+def match_chain(g: Graph, pattern: list, limit: int = 200) -> list[Match]:
+    """Find every simple path matching a fixed node–rel–node pattern.
+
+    ``pattern`` alternates NodeM and Rel and must start and end with a NodeM, e.g.
+    ``[NodeM("finding", var="a"), Rel(LEAKS), NodeM("credential")]``. Each Rel is a
+    single hop. Returns up to ``limit`` Matches (deterministic order)."""
+    _validate_pattern(pattern)
+    out, inc = _adjacency(g)
+    node_specs = pattern[0::2]
+    rel_specs = pattern[1::2]
+    matches: list[Match] = []
+
+    def _extend(path_nodes: list[Node], path_edges: list[Edge], seen: set[str]) -> None:
+        pos = len(path_nodes) - 1
+        if len(matches) >= limit:
+            return
+        if pos == len(node_specs) - 1:
+            bindings = {s.var: n for s, n in zip(node_specs, path_nodes) if s.var}
+            matches.append(Match(nodes=list(path_nodes), edges=list(path_edges), vars=bindings))
+            return
+        rel = rel_specs[pos]
+        nxt_spec = node_specs[pos + 1]
+        for edge, nid in _neighbors(out, inc, path_nodes[-1].id, rel):
+            if nid in seen:  # simple path — no revisits
+                continue
+            nn = g.nodes.get(nid)
+            if nn is None or not nxt_spec.matches(nn):
+                continue
+            _extend(path_nodes + [nn], path_edges + [edge], seen | {nid})
+            if len(matches) >= limit:
+                return
+
+    for start in g.nodes.values():
+        if node_specs[0].matches(start):
+            _extend([start], [], {start.id})
+            if len(matches) >= limit:
+                break
+    return matches[:limit]
+
+
+# ── variable-length reachability ────────────────────────────────────────────────
+
+def _resolve_starts(g: Graph, src) -> list[Node]:
+    if isinstance(src, NodeM):
+        return [n for n in g.nodes.values() if src.matches(n)]
+    if isinstance(src, str):
+        n = g.nodes.get(src)
+        return [n] if n else []
+    raise TypeError("src must be a node id (str) or a NodeM")
+
+
+def reachable(g: Graph, src, target, edge_kinds: str | Iterable[str] | None = None,
+              direction: str = "out", min_hops: int = 1, max_hops: int = 4,
+              limit: int = 100) -> list[list[str]]:
+    """Variable-length reachability: the Cypher ``(src)-[:kinds*min..max]->(target)``.
+
+    ``src`` is a node id or a NodeM; ``target`` is a NodeM. ``edge_kinds`` limits
+    which edge kinds may be traversed (None = any). Returns simple paths (lists of
+    node ids, each of length in [min_hops, max_hops]) — the concrete route, not just
+    a yes/no — so a caller can turn a reachable pair into a proposed chain."""
+    if direction not in _DIRECTIONS:
+        raise ValueError(f"direction must be one of {_DIRECTIONS}")
+    if not isinstance(target, NodeM):
+        raise TypeError("target must be a NodeM")
+    kinds = {edge_kinds} if isinstance(edge_kinds, str) else (set(edge_kinds) if edge_kinds else None)
+    out, inc = _adjacency(g)
+    hop_rel = Rel(kind=None, direction=direction)
+
+    def _step(node_id: str) -> list[str]:
+        nbrs = _neighbors(out, inc, node_id, hop_rel)
+        return [nid for e, nid in nbrs if kinds is None or e.kind in kinds]
+
+    paths: list[list[str]] = []
+    # BFS by depth so shorter routes surface first; deque of (node_id, path).
+    for start in _resolve_starts(g, src):
+        frontier: deque[tuple[str, list[str]]] = deque([(start.id, [start.id])])
+        while frontier and len(paths) < limit:
+            cur, path = frontier.popleft()
+            depth = len(path) - 1
+            if depth >= min_hops and depth >= 1:
+                node = g.nodes.get(cur)
+                if node is not None and target.matches(node):
+                    paths.append(path)
+                    if len(paths) >= limit:
+                        break
+            if depth >= max_hops:
+                continue
+            for nid in _step(cur):
+                if nid in path or nid not in g.nodes:  # simple path
+                    continue
+                frontier.append((nid, path + [nid]))
+    return paths[:limit]
+
+
+def shortest_path(g: Graph, src_id: str, dst_id: str,
+                  edge_kinds: str | Iterable[str] | None = None,
+                  direction: str = "out", max_hops: int = 8) -> list[str] | None:
+    """BFS shortest simple path (node ids) from src_id to dst_id, or None."""
+    if src_id not in g.nodes or dst_id not in g.nodes:
+        return None
+    if src_id == dst_id:
+        return [src_id]
+    kinds = {edge_kinds} if isinstance(edge_kinds, str) else (set(edge_kinds) if edge_kinds else None)
+    out, inc = _adjacency(g)
+    hop_rel = Rel(kind=None, direction=direction)
+    frontier: deque[list[str]] = deque([[src_id]])
+    visited = {src_id}
+    while frontier:
+        path = frontier.popleft()
+        if len(path) - 1 >= max_hops:
+            continue
+        for edge, nid in _neighbors(out, inc, path[-1], hop_rel):
+            if kinds is not None and edge.kind not in kinds:
+                continue
+            if nid in visited:
+                continue
+            if nid == dst_id:
+                return path + [nid]
+            visited.add(nid)
+            frontier.append(path + [nid])
+    return None
+
+
+def render_path(g: Graph, node_ids: list[str]) -> str:
+    """Human-readable ``label -> label -> ...`` for a path of node ids."""
+    return " -> ".join(g.nodes[i].label if i in g.nodes else i for i in node_ids)

--- a/tests/test_graph_paths.py
+++ b/tests/test_graph_paths.py
@@ -1,0 +1,150 @@
+"""Tests for the Cypher-ish path finder over the world-model graph."""
+import pytest
+
+from core.graph import model as m
+from core.graph.paths import (
+    Match, NodeM, Rel, match_chain, reachable, render_path, shortest_path,
+)
+
+
+def _graph() -> m.Graph:
+    """A small world model:
+
+        host:h  --hosts-->  ep:login  --has_param-->  param:user
+        finding:leak --leaks--> cred:admin ; finding:leak --found_on--> host:h
+        finding:rce  --found_on--> host:h
+        finding:leak --escalates_to--> (self, lead)   (cycle-ish self edge)
+    """
+    g = m.Graph()
+    g.add_node("host:h", m.HOST, "h")
+    g.add_node("ep:login", m.ENDPOINT, "POST /login")
+    g.add_node("param:user", m.PARAM, "user")
+    g.add_node("cred:admin", m.CREDENTIAL, "admin")
+    g.add_node("finding:leak", m.FINDING, "cred leak", severity="high")
+    g.add_node("finding:rce", m.FINDING, "rce", severity="critical")
+    g.add_edge("host:h", "ep:login", m.HOSTS)
+    g.add_edge("ep:login", "param:user", m.HAS_PARAM)
+    g.add_edge("finding:leak", "cred:admin", m.LEAKS)
+    g.add_edge("finding:leak", "host:h", m.FOUND_ON)
+    g.add_edge("finding:rce", "host:h", m.FOUND_ON)
+    return g
+
+
+# ── match_chain ──────────────────────────────────────────────────────────────
+
+def test_match_chain_single_hop_by_kind():
+    g = _graph()
+    ms = match_chain(g, [NodeM(m.FINDING), Rel(m.LEAKS), NodeM(m.CREDENTIAL)])
+    assert len(ms) == 1
+    assert ms[0].node_ids == ["finding:leak", "cred:admin"]
+    assert ms[0].edges[0].kind == m.LEAKS
+
+
+def test_match_chain_binds_vars():
+    g = _graph()
+    ms = match_chain(g, [NodeM(m.HOST, var="h"), Rel(m.HOSTS), NodeM(m.ENDPOINT, var="e")])
+    assert len(ms) == 1
+    assert ms[0].var("h").id == "host:h"
+    assert ms[0].var("e").id == "ep:login"
+
+
+def test_match_chain_leak_then_other_finding_same_host():
+    """The classic chain: (leaker)-[:LEAKS]->cred ; and a second finding on the
+    SAME host, reached leaker-[:FOUND_ON]->host<-[:FOUND_ON]-other."""
+    g = _graph()
+    ms = match_chain(g, [
+        NodeM(m.FINDING, where=lambda n: bool(g.out_edges(n.id, m.LEAKS)), var="leak"),
+        Rel(m.FOUND_ON),
+        NodeM(m.HOST),
+        Rel(m.FOUND_ON, direction="in"),
+        NodeM(m.FINDING, var="other"),
+    ])
+    # leak reaches host:h, host:h has two incoming FOUND_ON (leak, rce); simple-path
+    # rule forbids revisiting finding:leak, so only finding:rce is a valid "other".
+    pairs = {(x.var("leak").id, x.var("other").id) for x in ms}
+    assert pairs == {("finding:leak", "finding:rce")}
+
+
+def test_match_chain_direction_in():
+    g = _graph()
+    ms = match_chain(g, [NodeM(m.CREDENTIAL), Rel(m.LEAKS, direction="in"), NodeM(m.FINDING)])
+    assert [x.node_ids for x in ms] == [["cred:admin", "finding:leak"]]
+
+
+def test_match_chain_no_match_returns_empty():
+    g = _graph()
+    assert match_chain(g, [NodeM(m.TOKEN), Rel(m.LEAKS), NodeM(m.CREDENTIAL)]) == []
+
+
+def test_match_chain_respects_limit():
+    g = _graph()
+    ms = match_chain(g, [NodeM(m.FINDING), Rel(m.FOUND_ON), NodeM(m.HOST)], limit=1)
+    assert len(ms) == 1
+
+
+def test_match_chain_rejects_bad_pattern():
+    g = _graph()
+    with pytest.raises(ValueError):
+        match_chain(g, [NodeM(m.HOST), Rel(m.HOSTS)])  # even length / ends on Rel
+    with pytest.raises(ValueError):
+        match_chain(g, [Rel(m.HOSTS)])  # starts with Rel
+
+
+# ── reachable (variable-length) ────────────────────────────────────────────────
+
+def test_reachable_multi_hop_host_to_param():
+    g = _graph()
+    paths = reachable(g, "host:h", NodeM(m.PARAM), max_hops=4)
+    assert ["host:h", "ep:login", "param:user"] in paths
+
+
+def test_reachable_respects_max_hops():
+    g = _graph()
+    # param is 2 hops from host; max_hops=1 must not reach it.
+    assert reachable(g, "host:h", NodeM(m.PARAM), max_hops=1) == []
+
+
+def test_reachable_edge_kind_filter():
+    g = _graph()
+    # Only HOSTS edges allowed → can reach the endpoint (1 hop) but not the param
+    # (needs a HAS_PARAM hop).
+    paths = reachable(g, "host:h", NodeM(kind=None), edge_kinds=m.HOSTS, max_hops=4)
+    reached = {p[-1] for p in paths}
+    assert "ep:login" in reached
+    assert "param:user" not in reached
+
+
+def test_reachable_from_nodem_start():
+    g = _graph()
+    paths = reachable(g, NodeM(m.HOST), NodeM(m.PARAM), max_hops=3)
+    assert paths and paths[0][0] == "host:h"
+
+
+def test_reachable_simple_path_no_cycle():
+    g = _graph()
+    # self-loop must not cause infinite traversal
+    g.add_edge("host:h", "host:h", m.RUNS)
+    paths = reachable(g, "host:h", NodeM(m.ENDPOINT), max_hops=5)
+    assert ["host:h", "ep:login"] in paths
+
+
+# ── shortest_path + render ─────────────────────────────────────────────────────
+
+def test_shortest_path():
+    g = _graph()
+    assert shortest_path(g, "host:h", "param:user") == ["host:h", "ep:login", "param:user"]
+
+
+def test_shortest_path_none_when_unreachable():
+    g = _graph()
+    assert shortest_path(g, "param:user", "host:h", direction="out") is None
+
+
+def test_shortest_path_same_node():
+    g = _graph()
+    assert shortest_path(g, "host:h", "host:h") == ["host:h"]
+
+
+def test_render_path():
+    g = _graph()
+    assert render_path(g, ["host:h", "ep:login"]) == "h -> POST /login"


### PR DESCRIPTION
Attack-chaining is a graph-path problem, but chains.py hand-codes each shape as imperative traversal. This adds a small declarative matcher so a pattern is data, not code — ~80% of Cypher's value with none of Neo4j's cost (no service, no persistence, no drift; the coverage matrix stays authoritative, the graph is still projected on demand). Pure BFS/DFS over the existing Graph, no new deps (pandas is the wrong shape — tabular self-joins model multi-hop traversal poorly; networkx would be a needless dep at a few-hundred-node scale).

core/graph/paths.py:
- NodeM(kind, where, var) + Rel(kind, direction) — the pattern-as-data DSL.
- match_chain(g, pattern): fixed node–rel–node patterns; binds vars. Cypher (a:Finding)-[:LEAKS]->(:Host)<-[:FOUND_ON]-(b:Finding) becomes a NodeM/Rel list.
- reachable(g, src, target, edge_kinds, min/max_hops): variable-length reachability — the (src)-[:kind*1..N]->(target) query that's painful to hand-roll; returns the concrete simple paths, not just yes/no.
- shortest_path(g, src, dst) BFS + render_path() for display.
- Simple-path (no revisits) → finite, cycle-safe; bounded by limit/max_hops; adjacency built once per query.

16 focused tests; full suite green (1626 passed). candidate_chains still uses its hand-coded heuristics — this is the substrate to migrate them onto next.