### PR TITLE
feat(dashboard): left-rail redesign + finding dossier + per-tab restyle

### DIFF
--- a/core/api_server/routes/dashboard_routes.py
+++ b/core/api_server/routes/dashboard_routes.py
@@ -18,6 +18,16 @@ async def dashboard_ui(request: Request):
     return _api.templates.TemplateResponse(request, "index.html")
 
 
+@router.get("/finding/{finding_id}")
+async def finding_detail(request: Request, finding_id: str):
+    """Standalone per-finding 'dossier' page, opened from a finding card.
+    finding.js reads the id from data-finding-id and fetches /api/findings/<id>.
+    Jinja autoescapes finding_id into the attribute."""
+    return _api.templates.TemplateResponse(
+        request, "finding.html", {"finding_id": finding_id}
+    )
+
+
 @router.get("/healthz")
 async def healthz() -> JSONResponse:
     """Unauthenticated liveness probe used by serve() to detect a healthy

--- a/core/api_server/routes/findings_routes.py
+++ b/core/api_server/routes/findings_routes.py
@@ -28,6 +28,41 @@ async def api_findings() -> JSONResponse:
     return JSONResponse(data)
 
 
+@router.get("/api/findings/{finding_id}")
+async def api_finding(finding_id: str) -> JSONResponse:
+    """One finding + any exploit chains that reference it — feeds the standalone
+    /finding/<id> detail page. Chain mermaid is pre-rendered server-side (same as
+    api_findings) so the dossier's kill-chain matches the topology theme. Falls
+    back to the archived list so a deleted finding's URL still resolves."""
+    data = _api._read_json(_api._FINDINGS_FILE)
+    finding = next((f for f in data.get("findings", []) if f.get("id") == finding_id), None)
+    archived = False
+    if finding is None:
+        finding = next((f for f in data.get("archived", []) if f.get("id") == finding_id), None)
+        archived = finding is not None
+    if finding is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    related = []
+    for c in data.get("chains", []):
+        steps = c.get("steps", []) or []
+        touches = any(
+            s.get("from_finding_id") == finding_id or s.get("to_finding_id") == finding_id
+            for s in steps
+        )
+        if not touches:
+            continue
+        if c.get("mermaid") and "svg" not in c:
+            wrapped = f"```mermaid\n{c['mermaid']}\n```"
+            svgs = _api._render_mermaid_svgs(wrapped)
+            c = {**c, "svg": svgs.get("0", "")}
+        related.append(c)
+
+    return JSONResponse(
+        {"finding": finding, "chains": related, "archived": archived, "meta": data.get("meta", {})}
+    )
+
+
 @router.get("/api/session")
 async def api_session() -> JSONResponse:
     data = _api._read_json(_api._SESSION_FILE)

--- a/dashboard/css/dashboard.css
+++ b/dashboard/css/dashboard.css
@@ -15,6 +15,32 @@
       --green-dim:      rgba(91,242,155,0.12);
       --purple-dim:     rgba(123,120,255,0.12);
       --green-glow:     rgba(91,242,155,0.15);
+
+      /* ── Severity tokens — single source of truth for list + dossier ── */
+      --sev-critical:   #ff4d4f;
+      --sev-high:       #fa8c16;
+      --sev-medium:     #faad14;
+      --sev-low:        var(--green);
+      --sev-info:       var(--purple);
+
+      /* ── Type scale (fonts unchanged: Chakra Petch / Outfit / IBM Plex Mono) ── */
+      --font-display:   'Chakra Petch', sans-serif;
+      --font-body:      'Outfit', -apple-system, sans-serif;
+      --font-mono:      'IBM Plex Mono', monospace;
+      --fs-page:        1.5rem;    /* page/brand title      */
+      --fs-section:     1.0rem;    /* section headers       */
+      --fs-title:       0.95rem;   /* card / finding titles */
+      --fs-body:        0.875rem;  /* body copy (was ~0.8)  */
+      --fs-label:       0.7rem;    /* mono eyebrows/labels  */
+      --fs-data:        0.8rem;    /* mono data/evidence    */
+
+      /* ── Spacing on a 4px grid ── */
+      --sp-1: 4px;  --sp-2: 8px;  --sp-3: 12px;
+      --sp-4: 16px; --sp-5: 20px; --sp-6: 24px;
+
+      /* ── Shell metrics ── */
+      --rail-w:         216px;
+      --rail-w-collapsed: 60px;
     }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -57,11 +83,9 @@
     .tunnel-btn:hover { color: var(--green); border-color: var(--green); }
 
     #status {
-      font-size: 0.76rem; color: var(--text-dim); margin-bottom: 1.1rem;
+      font-size: 0.76rem; color: var(--text-dim); margin-bottom: 0.75rem;
       font-family: 'IBM Plex Mono', monospace;
     }
-    /* Breathing room above the filter chips / tab content on non-overview tabs. */
-    #stats { margin-top: 0.25rem; }
     #status .dot {
       display: inline-block; width: 7px; height: 7px; border-radius: 50%;
       background: var(--green); margin-right: 5px; animation: blink 2s infinite;
@@ -374,58 +398,21 @@
       background: rgba(91,242,155,0.07); border-radius: 4px; line-height: 1.4;
     }
 
-    /* ── App shell: fixed sidebar + scrolling main ── */
-    .app-shell { display: flex; align-items: stretch; min-height: 100vh; }
-    .sidebar {
-      width: 208px; flex: 0 0 208px; box-sizing: border-box;
-      background: var(--bg-deep); border-right: 1px solid var(--border);
-      display: flex; flex-direction: column; padding: 1rem 0.6rem 0.8rem;
-      position: sticky; top: 0; height: 100vh; overflow-y: auto;
-    }
-    .sidebar-brand { display: flex; align-items: center; gap: 0.5rem; padding: 0 0.4rem 0.9rem; }
-    .sidebar-brand .header-logo { width: 26px; height: 26px; }
-    .sidebar-brand h1 { font-size: 1rem; margin: 0; line-height: 1.1; }
-    .main {
-      flex: 1 1 auto; min-width: 0; box-sizing: border-box;
-      padding: 1.75rem 2.25rem 2.5rem; max-width: 1500px;
-    }
-
-    /* ── Sidebar nav (grouped destinations) ── */
-    .side-nav { display: flex; flex-direction: column; gap: 0.15rem; flex: 1 1 auto; }
-    .nav-group { margin-top: 0.9rem; }
-    .nav-group-label {
-      font-family: 'IBM Plex Mono', monospace; font-size: 0.6rem; font-weight: 600;
-      letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim);
-      padding: 0 0.55rem 0.3rem;
+    /* ── Tab nav ── */
+    .tab-nav {
+      display: flex; gap: 0; margin-bottom: 1.25rem;
+      border-bottom: 1px solid var(--border);
     }
     .tab-btn {
-      display: block; width: 100%; text-align: left; background: none;
-      border: none; border-left: 2px solid transparent; border-radius: 0 4px 4px 0;
-      color: var(--text-muted); padding: 0.4rem 0.55rem; font-size: 0.8rem;
-      font-family: 'IBM Plex Mono', monospace; cursor: pointer;
-      transition: color .12s, background .12s;
+      background: none; border: none; border-bottom: 2px solid transparent;
+      color: var(--text-dim); padding: 0.5rem 1.1rem; font-size: 0.78rem;
+      font-family: 'IBM Plex Mono', monospace;
+      cursor: pointer; transition: color .15s; margin-bottom: -1px;
     }
-    .tab-btn:hover  { color: var(--text); background: var(--bg-card); }
-    .tab-btn.active {
-      color: var(--green); background: var(--bg-card);
-      border-left-color: var(--green); font-weight: 600;
-    }
-    .tab-btn-home { font-weight: 600; color: var(--text); margin-bottom: 0.2rem; }
-    .sidebar-footer { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 1rem;
-      padding-top: 0.8rem; border-top: 1px solid var(--border-subtle); }
-    .sidebar-footer button { width: 100%; }
+    .tab-btn:hover  { color: var(--text); }
+    .tab-btn.active { color: var(--green); border-bottom-color: var(--green); font-weight: 600; }
     .tab-content { display: none; }
     .tab-content.active { display: block; }
-
-    @media (max-width: 720px) {
-      .app-shell { flex-direction: column; }
-      .sidebar { width: 100%; flex-basis: auto; height: auto; position: static;
-        flex-direction: row; flex-wrap: wrap; align-items: center; overflow-x: auto; }
-      .side-nav { flex-direction: row; flex-wrap: wrap; }
-      .nav-group { margin-top: 0; display: flex; align-items: center; }
-      .nav-group-label { display: none; }
-      .sidebar-footer { flex-direction: row; margin-top: 0; padding-top: 0; border-top: none; margin-left: auto; }
-    }
 
     /* ── Stats bar ── */
     #stats { display: flex; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 0.6rem; }
@@ -598,50 +585,14 @@
     }
 
     /* ── Finding cards ── */
-    /* Severity-grouped sections, each a responsive grid of uniform cards. */
-    .finding-section { margin-bottom: 1.4rem; }
-    .finding-section-head {
-      display: flex; align-items: center; gap: 0.5rem; font-family: 'IBM Plex Mono', monospace;
-      font-size: 0.72rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;
-      color: var(--text-muted); margin: 0 0 0.6rem;
-    }
-    .finding-section-head .fs-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-dim); }
-    .finding-section-head.sev-critical .fs-dot { background: #ff4d4f; }
-    .finding-section-head.sev-high     .fs-dot { background: #fa8c16; }
-    .finding-section-head.sev-medium   .fs-dot { background: #faad14; }
-    .finding-section-head.sev-low      .fs-dot { background: var(--green); }
-    .finding-section-head.sev-info     .fs-dot { background: var(--purple); }
-    .finding-section-head .fs-count {
-      background: var(--bg-raised); color: var(--text-muted); border-radius: 10px;
-      padding: 0 0.5rem; font-size: 0.66rem; line-height: 1.4;
-    }
-    .finding-cards {
-      display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
-      gap: 0.8rem; align-items: stretch;
-    }
+    .finding-cards { display: flex; flex-direction: column; gap: 0.75rem; }
     .finding-card {
       background: linear-gradient(135deg, rgba(45,43,85,0.45), rgba(26,24,64,0.85));
       border: 1px solid var(--border); border-radius: 8px;
-      padding: 0.85rem 1rem; position: relative; overflow: hidden;
-      transition: border-color .2s, transform .1s; cursor: pointer;
-      display: flex; flex-direction: column; gap: 0.5rem; min-height: 150px;
+      padding: 1rem 1.15rem; position: relative; overflow: hidden;
+      transition: border-color .2s;
     }
-    .finding-card:hover { border-color: rgba(123,120,255,0.5); transform: translateY(-1px); }
-    .finding-card-top { display: flex; align-items: center; gap: 0.4rem; }
-    .finding-vs-right { margin-left: auto; }
-    .finding-card .finding-title {
-      font-size: 0.9rem; font-weight: 600; line-height: 1.3; color: var(--text);
-      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
-    }
-    .finding-card .finding-desc {
-      font-size: 0.76rem; color: var(--text-muted); line-height: 1.4; margin: 0;
-      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
-    }
-    .finding-card-foot {
-      display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap;
-      margin-top: auto; padding-top: 0.5rem; font-size: 0.68rem;
-    }
-    .finding-card-foot .finding-ts-meta { margin-left: auto; color: var(--text-dim); }
+    .finding-card:hover { border-color: rgba(123,120,255,0.45); }
     .finding-card.sev-critical { border-left: 3px solid #ff4d4f; }
     .finding-card.sev-high     { border-left: 3px solid #fa8c16; }
     .finding-card.sev-medium   { border-left: 3px solid #faad14; }
@@ -1059,143 +1010,815 @@
     .log-line.warning     { color: #faad14; }
     .log-line.error       { color: #ff4d4f; }
 
-/* ── World Model tab (Phase 2 knowledge graph) ─────────────────────────────── */
-.wm-stats { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; margin-bottom:0.9rem; }
-.wm-stat-total { font-family:'IBM Plex Mono',monospace; font-size:0.78rem; color:var(--text-muted); margin-right:0.4rem; }
-.wm-stat-chip { font-family:'IBM Plex Mono',monospace; font-size:0.66rem; padding:0.12rem 0.45rem; border-radius:3px;
-  background:var(--bg-raised); color:var(--text-muted); border:1px solid var(--border-subtle); text-transform:lowercase; }
-.wm-err { color:#f97316; font-size:0.72rem; margin-left:0.5rem; }
-.wm-grid { display:grid; grid-template-columns:1fr 1fr; gap:1rem; }
-@media (max-width:820px){ .wm-grid { grid-template-columns:1fr; } }
-.wm-panel { background:var(--bg-card); border:1px solid var(--border); border-radius:8px; padding:0.9rem 1rem; margin-bottom:1rem; }
-.wm-h { font-size:0.82rem; font-weight:600; color:var(--text); margin:0 0 0.6rem; }
-.wm-h-mt { margin-top:1rem; }
-.wm-sub { font-family:'IBM Plex Mono',monospace; font-size:0.62rem; color:var(--text-dim); font-weight:400; text-transform:uppercase; letter-spacing:0.06em; margin-left:0.4rem; }
-.wm-empty { color:var(--text-dim); font-size:0.76rem; padding:0.5rem 0; }
+    /* ══════════════════════════════════════════════════════════════════════════
+       REDESIGN — left-rail shell + sticky status. Rules below intentionally
+       override the legacy .tab-nav / .tab-btn / body layout via cascade order.
+       ══════════════════════════════════════════════════════════════════════════ */
 
-.wm-chain { display:flex; gap:0.6rem; padding:0.55rem 0; border-bottom:1px solid var(--border-subtle); }
-.wm-chain:last-child { border-bottom:none; }
-.wm-chain-body { flex:1; min-width:0; }
-.wm-steps { display:flex; flex-wrap:wrap; align-items:center; gap:0.3rem; }
-.wm-step { background:var(--bg-raised); border:1px solid var(--border-subtle); border-radius:4px; padding:0.1rem 0.45rem; font-size:0.72rem; color:var(--text); }
-.wm-arrow { color:var(--text-dim); font-size:0.8rem; }
-.wm-terminal { font-family:'IBM Plex Mono',monospace; font-size:0.66rem; color:var(--text-muted); margin-top:0.3rem; }
-.wm-rationale { font-size:0.7rem; color:var(--text-dim); margin-top:0.15rem; }
+    body { padding: 0; }
 
-.wm-sev { font-family:'IBM Plex Mono',monospace; font-size:0.6rem; font-weight:700; text-transform:uppercase;
-  padding:0.1rem 0.4rem; border-radius:3px; height:fit-content; white-space:nowrap; }
-.wm-sev-critical { background:#da3633; color:#fff; }
-.wm-sev-high     { background:#f97316; color:#000; }
-.wm-sev-medium   { background:#d29922; color:#000; }
-.wm-sev-low      { background:#3b82f6; color:#fff; }
-.wm-sev-info     { background:var(--bg-raised); color:var(--text-muted); }
+    .app-shell {
+      display: grid;
+      grid-template-columns: var(--rail-w) 1fr;
+      min-height: 100vh;
+      align-items: start;
+    }
 
-.wm-list { display:flex; flex-direction:column; gap:0.25rem; }
-.wm-row { display:flex; align-items:center; gap:0.5rem; font-size:0.74rem; padding:0.2rem 0; }
-.wm-row-label { color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.wm-why { color:var(--text-dim); font-size:0.66rem; margin-left:auto; white-space:nowrap; }
-.wm-pending { font-family:'IBM Plex Mono',monospace; font-size:0.64rem; background:var(--bg-raised); color:var(--text-muted);
-  border-radius:3px; padding:0.05rem 0.35rem; min-width:1.4rem; text-align:center; }
+    /* ── Left rail ── */
+    .rail {
+      position: sticky; top: 0; align-self: start;
+      height: 100vh; display: flex; flex-direction: column;
+      background: linear-gradient(180deg, var(--bg-card), var(--bg-deep));
+      border-right: 1px solid var(--border);
+      z-index: 20;
+    }
+    .rail-brand {
+      display: flex; align-items: center; gap: var(--sp-3);
+      padding: var(--sp-4) var(--sp-4) var(--sp-3);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+    .rail-logo {
+      height: 44px; width: auto; flex-shrink: 0;
+      filter: drop-shadow(0 0 8px var(--green-glow));
+    }
+    .rail-brand-text {
+      display: flex; flex-direction: column; line-height: 1.08;
+      font-family: var(--font-display); font-weight: 600; font-size: 1.05rem;
+      letter-spacing: 0.02em;
+    }
+    .rail-brand-line { color: #fff; }
+    .rail-brand-line.h1-accent { color: var(--green); }
 
-/* graph */
-.wm-graph { overflow-x:auto; }
-.wm-svg { min-width:1000px; font-family:'IBM Plex Mono',monospace; }
-.wm-col-title { fill:var(--text-dim); font-size:10px; text-transform:uppercase; letter-spacing:0.06em; }
-.wm-node rect { fill:var(--bg-raised); stroke:var(--border); stroke-width:1; }
-.wm-node text { fill:var(--text-muted); font-size:10px; }
-.wm-node-host rect { fill:#2d2b55; stroke:#7b78ff; }
-.wm-node-endpoint rect { fill:#1a1840; stroke:#4f8cff; }
-.wm-node-param rect { fill:#171533; stroke:var(--border-subtle); }
-.wm-node-credential rect, .wm-node-token rect { fill:#2a2118; stroke:#d29922; }
-.wm-node-tech rect { fill:#132a24; stroke:#12a5a0; }
-.wm-node-finding text, .wm-node text { fill:var(--text); }
-.wm-sevfill-critical rect { fill:#3a1414; stroke:#da3633; }
-.wm-sevfill-high rect { fill:#33220f; stroke:#f97316; }
-.wm-sevfill-medium rect { fill:#302713; stroke:#d29922; }
-.wm-sevfill-low rect { fill:#122033; stroke:#3b82f6; }
-.wm-sevfill-info rect { fill:var(--bg-raised); stroke:var(--border); }
-.wm-edge { stroke:var(--border-subtle); stroke-width:1; }
-.wm-edge-leaks { stroke:#d29922; stroke-width:1.5; }
-.wm-edge-escalates_to { stroke:#da3633; stroke-width:1.5; }
-.wm-edge-authenticates { stroke:#12a5a0; stroke-dasharray:3 2; }
-.wm-more { fill:var(--text-dim); font-size:10px; }
+    .rail-nav {
+      display: flex; flex-direction: column; gap: 2px;
+      padding: var(--sp-3) var(--sp-2); flex: 1; overflow-y: auto;
+    }
+    .rail-nav .tab-btn {
+      display: flex; align-items: center; gap: var(--sp-3);
+      width: 100%; text-align: left; margin: 0;
+      background: none; border: none; border-left: 2px solid transparent;
+      border-radius: 7px; color: var(--text-muted);
+      padding: 0.5rem 0.7rem; font-family: var(--font-body);
+      font-size: 0.84rem; font-weight: 500; letter-spacing: 0.01em;
+      cursor: pointer; white-space: nowrap;
+      transition: background .15s, color .15s, border-color .15s;
+    }
+        .rail-nav .tab-btn::before {
+      content: ""; width: 18px; height: 18px; flex-shrink: 0;
+      background-color: currentColor; opacity: 0.65;
+      -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
+      -webkit-mask-position: center; mask-position: center;
+      -webkit-mask-size: contain; mask-size: contain;
+      transition: opacity .15s;
+    }
+    .rail-nav .tab-btn:hover::before,
+    .rail-nav .tab-btn.active::before { opacity: 1; }
+    .rail-nav .tab-btn:hover  { background: rgba(123,120,255,0.08); color: var(--text); }
+    .rail-nav .tab-btn.active {
+      background: linear-gradient(90deg, rgba(91,242,155,0.12), transparent);
+      color: var(--green); border-left-color: var(--green); font-weight: 600;
+    }
+    .rail-nav .tab-btn.active::before { opacity: 1; }
 
-/* ── Finding detail view (card → click → correlated detail) ────────────────── */
-.fd-back { background:none; border:1px solid var(--border); color:var(--text-muted);
-  border-radius:5px; padding:0.3rem 0.7rem; font-family:'IBM Plex Mono',monospace;
-  font-size:0.74rem; cursor:pointer; margin-bottom:0.9rem; }
-.fd-back:hover { color:var(--text); border-color:var(--text-dim); }
-.fd-hero { background:var(--bg-card); border:1px solid var(--border); border-left-width:4px;
-  border-radius:8px; padding:1rem 1.2rem; margin-bottom:1.1rem; }
-.fd-hero.sev-critical { border-left-color:#da3633; }
-.fd-hero.sev-high     { border-left-color:#f97316; }
-.fd-hero.sev-medium   { border-left-color:#d29922; }
-.fd-hero.sev-low      { border-left-color:#3b82f6; }
-.fd-hero.sev-info     { border-left-color:var(--text-dim); }
-.fd-hero-badges { display:flex; gap:0.4rem; align-items:center; margin-bottom:0.5rem; }
-.fd-title { font-size:1.3rem; margin:0.2rem 0 0.5rem; line-height:1.2; }
-.fd-hero-meta { display:flex; gap:0.7rem; flex-wrap:wrap; align-items:center; font-size:0.74rem; }
-.fd-body { display:grid; grid-template-columns:1fr 320px; gap:1.2rem; align-items:start; }
-@media (max-width:900px){ .fd-body { grid-template-columns:1fr; } }
-.fd-sec-head { display:flex; align-items:center; gap:0.6rem; font-size:0.8rem; font-weight:600;
-  color:var(--text); margin:1rem 0 0.4rem; }
-.fd-sec-head:first-child { margin-top:0; }
-.fd-copy { margin-left:auto; background:var(--bg-raised); border:1px solid var(--border-subtle);
-  color:var(--text-muted); border-radius:4px; padding:0.12rem 0.5rem; font-family:'IBM Plex Mono',monospace;
-  font-size:0.64rem; cursor:pointer; }
-.fd-copy:hover { color:var(--text); }
-.fd-expected { font-family:'IBM Plex Mono',monospace; font-size:0.7rem; color:var(--text-dim); margin-top:0.3rem; }
-.fd-rail-box { background:var(--bg-card); border:1px solid var(--border); border-radius:8px;
-  padding:0.8rem 0.9rem; margin-bottom:0.9rem; }
-.fd-rail-grid { display:grid; grid-template-columns:auto 1fr; gap:0.4rem 0.8rem; align-items:baseline; }
-.fd-rail-k { font-family:'IBM Plex Mono',monospace; font-size:0.62rem; text-transform:uppercase;
-  letter-spacing:0.06em; color:var(--text-dim); }
-.fd-rail-v { font-size:0.74rem; color:var(--text); word-break:break-word; }
-.fd-rail-title { font-family:'IBM Plex Mono',monospace; font-size:0.62rem; text-transform:uppercase;
-  letter-spacing:0.06em; color:var(--text-dim); margin-bottom:0.5rem; }
-.fd-id { font-family:'IBM Plex Mono',monospace; font-size:0.68rem; color:#58a6ff; }
-.fd-poc { font-family:'IBM Plex Mono',monospace; font-size:0.66rem; color:#58a6ff; word-break:break-all; margin:0.2rem 0; }
-.fd-view .finding-adjudication { margin-top:0; }
+    #tab-btn-findings::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M12%2022s8-4%208-10V5l-8-3-8%203v7c0%206%208%2010%208%2010z'/%3E%3Cpath%20d='M12%208v4'/%3E%3Cpath%20d='M12%2016h.01'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M12%2022s8-4%208-10V5l-8-3-8%203v7c0%206%208%2010%208%2010z'/%3E%3Cpath%20d='M12%208v4'/%3E%3Cpath%20d='M12%2016h.01'/%3E%3C/svg%3E"); }
+    #tab-btn-topology::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Ccircle%20cx='18'%20cy='5'%20r='3'/%3E%3Ccircle%20cx='6'%20cy='12'%20r='3'/%3E%3Ccircle%20cx='18'%20cy='19'%20r='3'/%3E%3Cpath%20d='M8.6%2013.5l6.8%204'/%3E%3Cpath%20d='M15.4%206.5l-6.8%204'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Ccircle%20cx='18'%20cy='5'%20r='3'/%3E%3Ccircle%20cx='6'%20cy='12'%20r='3'/%3E%3Ccircle%20cx='18'%20cy='19'%20r='3'/%3E%3Cpath%20d='M8.6%2013.5l6.8%204'/%3E%3Cpath%20d='M15.4%206.5l-6.8%204'/%3E%3C/svg%3E"); }
+    #tab-btn-components::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Crect%20x='3'%20y='3'%20width='7'%20height='7'%20rx='1.2'/%3E%3Crect%20x='14'%20y='3'%20width='7'%20height='7'%20rx='1.2'/%3E%3Crect%20x='14'%20y='14'%20width='7'%20height='7'%20rx='1.2'/%3E%3Crect%20x='3'%20y='14'%20width='7'%20height='7'%20rx='1.2'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Crect%20x='3'%20y='3'%20width='7'%20height='7'%20rx='1.2'/%3E%3Crect%20x='14'%20y='3'%20width='7'%20height='7'%20rx='1.2'/%3E%3Crect%20x='14'%20y='14'%20width='7'%20height='7'%20rx='1.2'/%3E%3Crect%20x='3'%20y='14'%20width='7'%20height='7'%20rx='1.2'/%3E%3C/svg%3E"); }
+    #tab-btn-coverage::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Crect%20x='3'%20y='3'%20width='18'%20height='18'%20rx='2'/%3E%3Cpath%20d='M3%209h18'/%3E%3Cpath%20d='M3%2015h18'/%3E%3Cpath%20d='M9%203v18'/%3E%3Cpath%20d='M15%203v18'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Crect%20x='3'%20y='3'%20width='18'%20height='18'%20rx='2'/%3E%3Cpath%20d='M3%209h18'/%3E%3Cpath%20d='M3%2015h18'/%3E%3Cpath%20d='M9%203v18'/%3E%3Cpath%20d='M15%203v18'/%3E%3C/svg%3E"); }
+    #tab-btn-skills::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M13%202L3%2014h9l-1%208%2010-12h-9z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M13%202L3%2014h9l-1%208%2010-12h-9z'/%3E%3C/svg%3E"); }
+    #tab-btn-activity::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M22%2012h-4l-3%209L9%203l-3%209H2'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M22%2012h-4l-3%209L9%203l-3%209H2'/%3E%3C/svg%3E"); }
+    #tab-btn-threat-model::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Ccircle%20cx='12'%20cy='12'%20r='9'/%3E%3Cpath%20d='M21%2012h-3'/%3E%3Cpath%20d='M6%2012H3'/%3E%3Cpath%20d='M12%206V3'/%3E%3Cpath%20d='M12%2021v-3'/%3E%3Ccircle%20cx='12'%20cy='12'%20r='2.5'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Ccircle%20cx='12'%20cy='12'%20r='9'/%3E%3Cpath%20d='M21%2012h-3'/%3E%3Cpath%20d='M6%2012H3'/%3E%3Cpath%20d='M12%206V3'/%3E%3Cpath%20d='M12%2021v-3'/%3E%3Ccircle%20cx='12'%20cy='12'%20r='2.5'/%3E%3C/svg%3E"); }
+    #tab-btn-metrics::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M3%203v18h18'/%3E%3Cpath%20d='M18%2017V9'/%3E%3Cpath%20d='M13%2017V5'/%3E%3Cpath%20d='M8%2017v-3'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M3%203v18h18'/%3E%3Cpath%20d='M18%2017V9'/%3E%3Cpath%20d='M13%2017V5'/%3E%3Cpath%20d='M8%2017v-3'/%3E%3C/svg%3E"); }
+    #tab-btn-setup-gates::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M4%2021v-7'/%3E%3Cpath%20d='M4%2010V3'/%3E%3Cpath%20d='M12%2021v-9'/%3E%3Cpath%20d='M12%208V3'/%3E%3Cpath%20d='M20%2021v-5'/%3E%3Cpath%20d='M20%2012V3'/%3E%3Cpath%20d='M1%2014h6'/%3E%3Cpath%20d='M9%208h6'/%3E%3Cpath%20d='M17%2016h6'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M4%2021v-7'/%3E%3Cpath%20d='M4%2010V3'/%3E%3Cpath%20d='M12%2021v-9'/%3E%3Cpath%20d='M12%208V3'/%3E%3Cpath%20d='M20%2021v-5'/%3E%3Cpath%20d='M20%2012V3'/%3E%3Cpath%20d='M1%2014h6'/%3E%3Cpath%20d='M9%208h6'/%3E%3Cpath%20d='M17%2016h6'/%3E%3C/svg%3E"); }
+    #tab-btn-logs::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M8%206h13'/%3E%3Cpath%20d='M8%2012h13'/%3E%3Cpath%20d='M8%2018h13'/%3E%3Cpath%20d='M3%206h.01'/%3E%3Cpath%20d='M3%2012h.01'/%3E%3Cpath%20d='M3%2018h.01'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M8%206h13'/%3E%3Cpath%20d='M8%2012h13'/%3E%3Cpath%20d='M8%2018h13'/%3E%3Cpath%20d='M3%206h.01'/%3E%3Cpath%20d='M3%2012h.01'/%3E%3Cpath%20d='M3%2018h.01'/%3E%3C/svg%3E"); }
+    #tab-btn-world-model::before { -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Ccircle%20cx='12'%20cy='12'%20r='9'/%3E%3Cpath%20d='M3%2012h18'/%3E%3Cpath%20d='M12%203a14%2014%200%200%201%204%209%2014%2014%200%200%201-4%209%2014%2014%200%200%201-4-9%2014%2014%200%200%201%204-9z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='white'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Ccircle%20cx='12'%20cy='12'%20r='9'/%3E%3Cpath%20d='M3%2012h18'/%3E%3Cpath%20d='M12%203a14%2014%200%200%201%204%209%2014%2014%200%200%201-4%209%2014%2014%200%200%201-4-9%2014%2014%200%200%201%204-9z'/%3E%3C/svg%3E"); }
 
-/* ── Overview tab (at-a-glance landing) ────────────────────────────────────── */
-.ov-kpis { display: flex; flex-wrap: wrap; gap: 0.7rem; margin-bottom: 1.1rem; }
-.ov-kpi { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px;
-  padding: 0.7rem 0.9rem; min-width: 120px; flex: 1 1 120px; }
-.ov-kpi-val { font-size: 1.6rem; font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; color: var(--text); }
-.ov-kpi-frac { font-size: 0.72rem; font-weight: 400; color: var(--text-dim); }
-.ov-kpi-label { font-family: 'IBM Plex Mono', monospace; font-size: 0.62rem; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--text-dim); margin-top: 0.5rem; }
-.ov-kpi-crit .ov-kpi-val { color: #ff4d4f; }
-.ov-kpi-high .ov-kpi-val { color: #fa8c16; }
-.ov-kpi-status .ov-kpi-val { font-size: 1rem; text-transform: capitalize; }
-.ov-kpi-bar { height: 4px; background: var(--bg-deep); border-radius: 2px; margin-top: 0.5rem; overflow: hidden; }
-.ov-kpi-bar-fill { height: 100%; background: var(--green); border-radius: 2px; }
+    .rail-footer {
+      display: flex; flex-direction: column; gap: var(--sp-2);
+      padding: var(--sp-3) var(--sp-3) var(--sp-4);
+      border-top: 1px solid var(--border-subtle);
+    }
+    .rail-footer .tunnel-btn,
+    .rail-footer .clear-btn { width: 100%; text-align: center; }
 
-.ov-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
-@media (max-width: 900px) { .ov-grid { grid-template-columns: 1fr; } }
-.ov-panel { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 0.9rem 1.05rem; }
-.ov-h { font-size: 0.82rem; font-weight: 600; color: var(--text); margin: 0 0 0.7rem; }
-.ov-sub { font-family: 'IBM Plex Mono', monospace; font-size: 0.6rem; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--text-dim); font-weight: 400; margin-left: 0.4rem; }
-.ov-empty { color: var(--text-dim); font-size: 0.76rem; padding: 0.3rem 0; }
+    /* ── Main column + sticky status ── */
+    .main { min-width: 0; padding: 0 2rem 1.5rem; }
+    .main #status {
+      position: sticky; top: 0; z-index: 10;
+      background: var(--bg); margin-bottom: 0.4rem;
+      padding: 0.85rem 0 0.6rem;
+      border-bottom: 1px solid var(--border-subtle);
+    }
 
-.ov-attention { display: flex; flex-direction: column; gap: 0.4rem; }
-.ov-att { display: flex; align-items: center; gap: 0.55rem; font-size: 0.76rem; color: var(--text);
-  background: var(--bg-raised); border: 1px solid var(--border-subtle); border-left: 3px solid var(--text-dim);
-  border-radius: 5px; padding: 0.4rem 0.6rem; }
-.ov-att-icon { flex: 0 0 auto; }
-.ov-att-gate { border-left-color: #ff4d4f; }
-.ov-att-hir  { border-left-color: #f97316; }
-.ov-att-lead { border-left-color: #d29922; }
+    /* ── Responsive: collapse rail to an icon rail, then a top strip ── */
+    @media (max-width: 1100px) {
+      .app-shell { grid-template-columns: var(--rail-w-collapsed) 1fr; }
+      .rail-brand { justify-content: center; padding: var(--sp-4) 0 var(--sp-3); }
+      .rail-brand-text { display: none; }
+      .rail-nav { padding: var(--sp-3) var(--sp-1); }
+      .rail-nav .tab-btn { font-size: 0; gap: 0; justify-content: center; padding: 0.55rem 0; }
+      .rail-nav .tab-btn::before { width: 20px; height: 20px; }
+      .rail-footer .tunnel-btn,
+      .rail-footer .clear-btn { font-size: 0; padding: 0.45rem 0; }
+      .rail-footer .tunnel-btn::before { content: "\26A1"; font-size: 0.95rem; }  /* ⚡ */
+      .rail-footer .clear-btn::before  { content: "\2326"; font-size: 0.95rem; }  /* ⌦ */
+    }
+    @media (max-width: 720px) {
+      .app-shell { grid-template-columns: 1fr; }
+      .rail {
+        position: sticky; top: 0; height: auto; flex-direction: row;
+        align-items: center; overflow-x: auto;
+        border-right: none; border-bottom: 1px solid var(--border);
+      }
+      .rail-brand { border-bottom: none; padding: var(--sp-2) var(--sp-3); }
+      .rail-nav { flex-direction: row; padding: var(--sp-2); overflow: visible; }
+      .rail-nav .tab-btn { border-left: none; border-bottom: 2px solid transparent; border-radius: 6px; }
+      .rail-nav .tab-btn.active { border-left: none; border-bottom-color: var(--green); }
+      .rail-footer { flex-direction: row; border-top: none; padding: var(--sp-2); margin-left: auto; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      * { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; }
+    }
 
-.ov-chain { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0; border-bottom: 1px solid var(--border-subtle); }
-.ov-chain:last-child { border-bottom: none; }
-.ov-chain-steps { font-size: 0.74rem; color: var(--text); }
+    /* ── Findings list — clickable summary cards ── */
+    .finding-card {
+      cursor: pointer; padding: 0.85rem 1.1rem;
+      transition: border-color .18s, transform .15s, box-shadow .15s;
+    }
+    .finding-card:hover {
+      border-color: rgba(123,120,255,0.55);
+      transform: translateY(-1px);
+      box-shadow: 0 8px 24px rgba(0,0,0,0.28);
+    }
+    .finding-open-cue {
+      position: absolute; top: 0.55rem; right: 0.7rem;
+      color: var(--text-dim); font-size: 0.9rem; opacity: 0;
+      transition: opacity .15s, color .15s; pointer-events: none;
+    }
+    .finding-card:hover .finding-open-cue { opacity: 1; color: var(--green); }
+    .finding-title-link { text-decoration: none; display: inline-block; }
+    .finding-title-link:hover .finding-title { color: var(--green); }
+    .finding-desc-clamp {
+      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+      overflow: hidden; margin-bottom: 0.15rem;
+    }
+    .finding-footer { margin-top: 0.5rem; }
+    .detail-link {
+      margin-left: auto; font-family: var(--font-mono); font-size: 0.72rem;
+      color: var(--text-dim); text-decoration: none; white-space: nowrap;
+    }
+    .detail-link:hover { color: var(--green); }
 
-.ov-list { display: flex; flex-direction: column; gap: 0.2rem; }
-.ov-row { display: flex; align-items: center; gap: 0.5rem; font-size: 0.76rem; padding: 0.28rem 0.4rem;
-  border-radius: 4px; cursor: pointer; }
-.ov-row:hover { background: var(--bg-raised); }
-.ov-row-label { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ov-pending { font-family: 'IBM Plex Mono', monospace; font-size: 0.62rem; background: var(--bg-raised);
-  color: var(--text-muted); border-radius: 3px; padding: 0.05rem 0.35rem; min-width: 1.4rem; text-align: center; }
+    /* ══════════════════════════════════════════════════════════════════════════
+       FINDING DOSSIER — standalone /finding/<id> detail page
+       ══════════════════════════════════════════════════════════════════════════ */
+    body.dossier-page { padding: 0; }
+    .dossier-shell { max-width: 1180px; margin: 0 auto; padding: 0 2rem 3rem; }
+
+    .dossier-topbar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 1rem 0 0.85rem; margin-bottom: 0.4rem;
+      position: sticky; top: 0; z-index: 10; background: var(--bg);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+    .dossier-back {
+      font-family: var(--font-mono); font-size: 0.8rem; color: var(--text-muted);
+      text-decoration: none; padding: 0.3rem 0.6rem; border-radius: 5px;
+      border: 1px solid var(--border); transition: color .15s, border-color .15s;
+    }
+    .dossier-back:hover { color: var(--green); border-color: var(--green); }
+    .dossier-brand {
+      display: flex; align-items: center; gap: 0.6rem;
+      font-family: var(--font-display); font-weight: 600; font-size: 0.95rem; color: #fff;
+    }
+    .dossier-logo { height: 34px; width: auto; filter: drop-shadow(0 0 6px var(--green-glow)); }
+
+    .dossier-status {
+      font-family: var(--font-mono); font-size: var(--fs-label);
+      color: var(--text-dim); margin: 0.6rem 0 1rem;
+    }
+    .dossier-status .dot {
+      display: inline-block; width: 7px; height: 7px; border-radius: 50%;
+      background: var(--green); margin-right: 5px; box-shadow: 0 0 6px var(--green);
+      animation: blink 2s infinite;
+    }
+
+    /* ── Masthead ── */
+    .dossier-masthead {
+      background: linear-gradient(135deg, rgba(45,43,85,0.55), rgba(26,24,64,0.9));
+      border: 1px solid var(--border); border-left: 4px solid var(--purple);
+      border-radius: 10px; padding: 1.3rem 1.5rem; margin-bottom: 1.25rem;
+      position: relative; overflow: hidden;
+      animation: dossier-rise .35s ease both;
+    }
+    @keyframes dossier-rise { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+    .dossier-masthead::before {
+      content: ''; position: absolute; inset: 0 0 auto 0; height: 1px;
+      background: linear-gradient(90deg, transparent, var(--green) 30%, var(--purple) 70%, transparent);
+    }
+    .dossier-sev-critical { border-left-color: var(--sev-critical); }
+    .dossier-sev-high     { border-left-color: var(--sev-high); }
+    .dossier-sev-medium   { border-left-color: var(--sev-medium); }
+    .dossier-sev-low      { border-left-color: var(--sev-low); }
+    .dossier-sev-info     { border-left-color: var(--sev-info); }
+    .dossier-badges { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.7rem; }
+    .dossier-title {
+      font-family: var(--font-display); font-size: 1.45rem; font-weight: 600;
+      color: #fff; line-height: 1.25; letter-spacing: 0.01em; word-break: break-word;
+    }
+    .dossier-meta {
+      display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-top: 0.65rem;
+    }
+
+    /* ── Two-column grid ── */
+    .dossier-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr); gap: 1.5rem; align-items: start; }
+    .dossier-main { min-width: 0; }
+    .dossier-rail { display: flex; flex-direction: column; gap: 1rem; position: sticky; top: 4.5rem; }
+
+    .dossier-section { margin-bottom: 1.5rem; }
+    .dossier-section-title {
+      font-family: var(--font-display); font-size: var(--fs-section); font-weight: 600;
+      color: var(--text); letter-spacing: 0.02em;
+      padding-bottom: 0.4rem; margin-bottom: 0.7rem;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+    .dossier-text {
+      color: var(--text); font-size: var(--fs-body); line-height: 1.7;
+      white-space: pre-wrap; overflow-wrap: anywhere;
+    }
+    .dossier-evidence { max-height: 460px; }
+    .dossier-copy-row { display: flex; justify-content: flex-end; margin-bottom: 0.35rem; }
+    .dossier-copy {
+      background: none; border: 1px solid var(--border); border-radius: 5px;
+      color: var(--text-dim); font-family: var(--font-mono); font-size: 0.7rem;
+      padding: 0.2rem 0.55rem; cursor: pointer; transition: color .15s, border-color .15s;
+    }
+    .dossier-copy:hover  { color: var(--green); border-color: var(--green); }
+    .dossier-copy.copied { color: var(--green); border-color: var(--green); }
+
+    /* ── Metadata rail ── */
+    .dossier-rail-card {
+      background: linear-gradient(135deg, rgba(45,43,85,0.4), rgba(26,24,64,0.75));
+      border: 1px solid var(--border); border-radius: 8px; padding: 0.9rem 1rem;
+    }
+    .drail-heading {
+      font-family: var(--font-mono); font-size: var(--fs-label); font-weight: 700;
+      color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.08em;
+      margin-bottom: 0.5rem;
+    }
+    .drail-grid { display: grid; grid-template-columns: max-content 1fr; gap: 0.5rem 0.9rem; align-items: baseline; }
+    .drail-label {
+      font-family: var(--font-mono); font-size: var(--fs-label); color: var(--text-dim);
+      text-transform: uppercase; letter-spacing: 0.06em; white-space: nowrap;
+    }
+    .drail-value { font-size: 0.8rem; color: var(--text); overflow-wrap: anywhere; }
+    .drail-value .dossier-copy { margin-left: 0.35rem; padding: 0.05rem 0.4rem; font-size: 0.62rem; }
+    .mono-wrap { font-family: var(--font-mono); font-size: 0.76rem; color: var(--purple); overflow-wrap: anywhere; }
+    .drail-sev { font-family: var(--font-mono); font-weight: 700; text-transform: uppercase; font-size: 0.78rem; }
+    .drail-sev-critical { color: var(--sev-critical); }
+    .drail-sev-high     { color: var(--sev-high); }
+    .drail-sev-medium   { color: var(--sev-medium); }
+    .drail-sev-low      { color: var(--sev-low); }
+    .drail-sev-info     { color: var(--sev-info); }
+
+    /* ── Data-flow trace timeline ── */
+    .trace-timeline { list-style: none; margin: 0; padding: 0 0 0 0.4rem; position: relative; }
+    .trace-step { position: relative; padding: 0 0 1rem 1.6rem; }
+    .trace-step::before {
+      content: ''; position: absolute; left: 5px; top: 0.5rem; bottom: -0.1rem;
+      width: 2px; background: var(--border);
+    }
+    .trace-step:last-child::before { display: none; }
+    .trace-node {
+      position: absolute; left: 0; top: 0.35rem; width: 12px; height: 12px;
+      border-radius: 50%; background: var(--bg-raised); border: 2px solid var(--purple);
+    }
+    .trace-entrypoint .trace-node { border-color: var(--green); }
+    .trace-sink       .trace-node { border-color: var(--sev-critical); background: rgba(255,77,79,.25); }
+    .trace-head { display: flex; align-items: baseline; gap: 0.6rem; flex-wrap: wrap; }
+    .trace-kind {
+      font-family: var(--font-mono); font-size: 0.62rem; font-weight: 700;
+      letter-spacing: 0.08em; padding: 0.08rem 0.4rem; border-radius: 3px;
+      background: var(--purple-dim); color: var(--purple);
+    }
+    .trace-entrypoint .trace-kind { background: var(--green-dim); color: var(--green); }
+    .trace-sink       .trace-kind { background: rgba(255,77,79,.15); color: var(--sev-critical); }
+    .trace-loc   { font-family: var(--font-mono); font-size: 0.76rem; color: var(--text); }
+    .trace-scope { font-family: var(--font-mono); font-size: 0.7rem; color: var(--text-dim); }
+    .trace-desc  { color: var(--text-muted); font-size: var(--fs-body); line-height: 1.55; margin-top: 0.2rem; }
+
+    /* ── Remediation ── */
+    .rem-meta { margin: 0.4rem 0 0.6rem; display: flex; align-items: center; gap: 0.6rem; }
+    .rem-breaking { color: var(--sev-critical); font-size: 0.75rem; font-weight: 600; }
+    .rem-file { font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-dim); margin-bottom: 0.4rem; }
+    .rem-block { margin-top: 0.6rem; }
+    .rem-block strong { font-size: 0.78rem; color: var(--text-muted); }
+    .rem-before { color: var(--sev-critical) !important; }
+    .rem-after  { color: var(--green) !important; }
+    .rem-verify { color: var(--text); font-size: var(--fs-body); line-height: 1.6; margin-top: 0.2rem; }
+    .rem-refs { margin: 0.3rem 0 0 1.1rem; }
+    .rem-refs a { color: #58a6ff; word-break: break-all; }
+
+    .esc-leads { margin: 0 0 0 1.1rem; color: var(--text); font-size: var(--fs-body); line-height: 1.7; }
+    .esc-status {
+      font-family: var(--font-mono); font-size: 0.62rem; font-weight: 700; text-transform: uppercase;
+      padding: 0.05rem 0.35rem; border-radius: 3px; margin-right: 0.4rem;
+      background: var(--purple-dim); color: var(--purple);
+    }
+    .esc-done      { background: var(--green-dim); color: var(--green); }
+    .esc-dismissed { background: rgba(107,104,144,.2); color: var(--text-dim); }
+    .poc-list { list-style: none; margin: 0; padding: 0; }
+    .poc-list li { margin: 0.25rem 0; }
+    .poc-list code { font-family: var(--font-mono); font-size: 0.74rem; color: var(--green); word-break: break-all; }
+
+    /* ── Chain ── */
+    .dossier-chain { margin-bottom: 1rem; }
+    .dossier-chain-head { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.4rem; }
+    .dossier-chain-name { font-family: var(--font-display); font-size: 0.92rem; font-weight: 600; color: #fff; }
+
+    @media (max-width: 860px) {
+      .dossier-grid { grid-template-columns: 1fr; }
+      .dossier-rail { position: static; }
+      .dossier-shell { padding: 0 1.1rem 2.5rem; }
+    }
+
+    /* ══════════════════════════════════════════════════════════════════════════
+       CALM / REFINED DARK — flatten gradients, drop the neon glow + scanline,
+       soften borders to hairlines, add breathing room. Same purple/green brand.
+       This layer overrides the decorative treatments above via cascade order.
+       ══════════════════════════════════════════════════════════════════════════ */
+
+    :root {
+      --border:        rgba(123,120,255,0.14);   /* hairline */
+      --border-subtle: rgba(123,120,255,0.07);
+      --green-glow:    transparent;              /* kills logo drop-shadow glow */
+      --surface:       #191735;                  /* flat card surface */
+      --surface-2:     #211f45;                  /* flat raised surface */
+    }
+
+    /* Drop the scanline texture; crisp up the type. */
+    body {
+      background-image: none;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    /* Flat rail, no gradient. */
+    .rail { background: var(--bg-deep); }
+
+    /* Remove decorative gradient hairlines at the top of panels/cards. */
+    .cmd-status-row::before,
+    .finding-card::before,
+    .diagram-card::before,
+    .comp-card::before,
+    #threat-model-wrap::before,
+    .dossier-masthead::before { content: none; display: none; }
+
+    /* Flatten every gradient surface to a solid, calm fill. */
+    .cmd-status-row,
+    .cmd-smith-panel { background: var(--surface); }
+    #cmd-center      { border-color: var(--border); }
+    .finding-card,
+    .diagram-card,
+    .comp-card,
+    .skill-card,
+    #threat-model-wrap,
+    .dossier-masthead,
+    .dossier-rail-card { background: var(--surface); }
+
+    /* Kill the glows on live dots (keep the subtle blink). */
+    #status .dot,
+    .dossier-status .dot,
+    .cmd-smith-dot,
+    .qa-dot,
+    .activity-dot { box-shadow: none; }
+    .skill-card.invoked { box-shadow: none; }
+
+    /* Softer, thinner severity spine; calmer hover. */
+    .finding-card {
+      padding: 1rem 1.25rem; border-radius: 10px;
+      border-color: var(--border);
+    }
+    .finding-cards { gap: 0.7rem; }
+    .finding-card.sev-critical { border-left: 2px solid var(--sev-critical); }
+    .finding-card.sev-high     { border-left: 2px solid var(--sev-high); }
+    .finding-card.sev-medium   { border-left: 2px solid var(--sev-medium); }
+    .finding-card.sev-low      { border-left: 2px solid var(--sev-low); }
+    .finding-card.sev-info     { border-left: 2px solid var(--sev-info); }
+    .finding-card:hover {
+      border-color: rgba(123,120,255,0.32);
+      transform: none;
+      box-shadow: 0 2px 14px rgba(0,0,0,0.22);
+    }
+
+    /* Masthead: flat, thin spine, no decorative line. */
+    .dossier-masthead { border: 1px solid var(--border); border-left: 3px solid var(--purple); }
+    .dossier-sev-critical { border-left-color: var(--sev-critical); }
+    .dossier-sev-high     { border-left-color: var(--sev-high); }
+    .dossier-sev-medium   { border-left-color: var(--sev-medium); }
+    .dossier-sev-low      { border-left-color: var(--sev-low); }
+    .dossier-sev-info     { border-left-color: var(--sev-info); }
+
+    /* A touch more air in the main column and section rhythm. */
+    .main { padding: 0 2.25rem 2rem; }
+    .dossier-section { margin-bottom: 1.75rem; }
+
+    /* Badges: quieter, flatter fills. */
+    .badge { border: 1px solid transparent; }
+    .badge-critical { background: rgba(255,77,79,.12);  border-color: rgba(255,77,79,.28); }
+    .badge-high     { background: rgba(250,140,22,.12); border-color: rgba(250,140,22,.28); }
+    .badge-medium   { background: rgba(250,173,20,.12); border-color: rgba(250,173,20,.28); }
+    .badge-low      { background: rgba(91,242,155,.10); border-color: rgba(91,242,155,.26); }
+    .badge-info     { background: rgba(123,120,255,.10);border-color: rgba(123,120,255,.26); }
+
+    /* Filter pills: flat, restrained until active. */
+    .stat { border-radius: 6px; }
+    .stat.active { outline: none; border-width: 1px; box-shadow: inset 0 0 0 1px currentColor; }
+
+    /* ══════════════════════════════════════════════════════════════════════════
+       PRETTIER FINDINGS LIST — severity color-rhythm, cleaner header, chips.
+       ══════════════════════════════════════════════════════════════════════════ */
+
+    .finding-cards { gap: 0.75rem; }
+    .finding-card { padding: 0.95rem 1.2rem; }
+
+    /* Faint per-severity wash gives the stack colour rhythm without going neon. */
+    .finding-card.sev-critical { background: color-mix(in srgb, var(--sev-critical) 7%, var(--surface)); border-left: 3px solid var(--sev-critical); }
+    .finding-card.sev-high     { background: color-mix(in srgb, var(--sev-high)     7%, var(--surface)); border-left: 3px solid var(--sev-high); }
+    .finding-card.sev-medium   { background: color-mix(in srgb, var(--sev-medium)   6%, var(--surface)); border-left: 3px solid var(--sev-medium); }
+    .finding-card.sev-low      { background: color-mix(in srgb, var(--sev-low)      6%, var(--surface)); border-left: 3px solid var(--sev-low); }
+    .finding-card.sev-info     { background: color-mix(in srgb, var(--sev-info)     6%, var(--surface)); border-left: 3px solid var(--sev-info); }
+
+    /* Header: severity anchored left, verification/time/arrow grouped right. */
+    .fc-top { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; margin-bottom: 0.55rem; }
+    .fc-top-left  { display: flex; align-items: center; gap: 0.4rem; min-width: 0; }
+    .fc-top-right { display: flex; align-items: center; gap: 0.55rem; flex-shrink: 0; }
+    .fc-top-right .vbadge,
+    .fc-top-right .triaged-badge { margin-left: 0; }
+
+    .badge { display: inline-flex; align-items: center; }
+    .sev-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; margin-right: 6px; }
+
+    /* Title as the clear hero. */
+    .finding-title { margin: 0; font-size: 1.02rem; letter-spacing: 0.01em; }
+    .finding-title-link { display: block; }
+
+    /* Meta as tidy monospace chips. */
+    .finding-meta-row { gap: 0.4rem; margin-top: 0.55rem; margin-bottom: 0; }
+    .meta-chip {
+      display: inline-flex; align-items: center; max-width: 100%;
+      font-family: var(--font-mono); font-size: 0.7rem;
+      padding: 0.14rem 0.5rem; border-radius: 5px;
+      background: rgba(123,120,255,0.05); border: 1px solid var(--border-subtle);
+      color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .chip-target { color: var(--purple); max-width: 60ch; }
+    .chip-tool   { color: var(--text-dim); }
+    .chip-cve    { color: #f0b429; background: rgba(250,173,20,0.06); border-color: rgba(250,173,20,0.22); }
+
+    /* One scannable body line (impact preferred, else description). */
+    .fc-body {
+      font-size: var(--fs-body); color: var(--text-muted); line-height: 1.55; margin-top: 0.6rem;
+      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+    }
+    .fc-body-impact { color: #d7b487; }
+    .fc-impact-tag {
+      font-family: var(--font-mono); font-size: 0.62rem; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.06em; color: #f0b429; margin-right: 0.5rem;
+    }
+
+    /* Inline open-cue (was absolutely positioned). */
+    .finding-open-cue { position: static; top: auto; right: auto; opacity: 0.45; color: var(--text-dim); font-size: 0.95rem; }
+    .finding-card:hover .finding-open-cue { opacity: 1; color: var(--green); }
+
+    /* Footer separated by a hairline for structure. */
+    .finding-footer {
+      margin-top: 0.75rem; padding-top: 0.6rem;
+      border-top: 1px solid var(--border-subtle); gap: 0.45rem;
+    }
+
+    /* ══════════════════════════════════════════════════════════════════════════
+       MENU REFINE — consistent SVG icons (above), section grouping, cleaner items.
+       ══════════════════════════════════════════════════════════════════════════ */
+
+    /* Brand block. */
+    .rail-brand { padding: var(--sp-5) var(--sp-4) var(--sp-4); gap: 0.7rem; }
+    .rail-logo { height: 40px; }
+    .rail-brand-text { font-size: 1.08rem; letter-spacing: 0.03em; gap: 1px; }
+
+    /* Section labels between groups. */
+    .rail-nav { padding: var(--sp-3) var(--sp-3) var(--sp-4); gap: 2px; }
+    .rail-group {
+      font-family: var(--font-mono); font-size: 0.6rem; font-weight: 700;
+      letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim);
+      padding: 0.85rem 0.7rem 0.3rem;
+      user-select: none;
+    }
+    .rail-nav > .rail-group:first-child { padding-top: 0.2rem; }
+
+    /* Nav items: roomier, rounded, calm. */
+    .rail-nav .tab-btn {
+      padding: 0.52rem 0.7rem; gap: 0.7rem; font-size: 0.85rem;
+      color: var(--text-muted); border-radius: 8px; border-left: 0;
+      position: relative;
+    }
+    .rail-nav .tab-btn:hover { background: rgba(123,120,255,0.07); color: var(--text); }
+    /* Active = filled pill + a rounded left accent (via ::after, not a border). */
+    .rail-nav .tab-btn.active {
+      background: rgba(91,242,155,0.10); color: var(--green);
+      border-left: 0; font-weight: 600;
+    }
+    .rail-nav .tab-btn.active::after {
+      content: ""; position: absolute; left: 0; top: 50%; transform: translateY(-50%);
+      width: 3px; height: 1.05rem; border-radius: 2px; background: var(--green);
+    }
+
+    @media (max-width: 1100px) {
+      .rail-group { display: none; }
+      .rail-nav .tab-btn.active::after { display: none; }
+      .rail-nav .tab-btn.active { background: rgba(91,242,155,0.12); }
+    }
+
+    /* ══════════════════════════════════════════════════════════════════════════
+       FINDINGS HOME — severity overview bar + severity-grouped tile grid (board).
+       ══════════════════════════════════════════════════════════════════════════ */
+
+    /* Overview: count + slim severity-distribution bar. */
+    .fx-overview { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.9rem; }
+    .fx-ov-count { font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-dim); white-space: nowrap; }
+    .fx-ov-num   { color: var(--text); font-weight: 700; font-size: 0.95rem; }
+    .sevbar {
+      display: flex; flex: 1; height: 8px; gap: 2px;
+      border-radius: 5px; overflow: hidden; background: var(--surface-2);
+    }
+    .sevbar-seg { display: block; min-width: 4px; }
+    .sevbar-critical { background: var(--sev-critical); }
+    .sevbar-high     { background: var(--sev-high); }
+    .sevbar-medium   { background: var(--sev-medium); }
+    .sevbar-low      { background: var(--sev-low); }
+    .sevbar-info     { background: var(--sev-info); }
+
+    /* Severity section headers. */
+    .fx-section { margin-bottom: 1.4rem; }
+    .fx-section-head { display: flex; align-items: center; gap: 0.55rem; margin-bottom: 0.7rem; }
+    .fx-head-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-dim); }
+    .fx-head-name {
+      font-family: var(--font-display); font-size: 0.8rem; font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.08em; color: var(--text);
+    }
+    .fx-head-count {
+      font-family: var(--font-mono); font-size: 0.68rem; color: var(--text-dim);
+      background: var(--surface-2); border-radius: 10px; padding: 0.05rem 0.5rem;
+    }
+    .fx-head-critical .fx-head-dot { background: var(--sev-critical); }
+    .fx-head-critical .fx-head-name { color: var(--sev-critical); }
+    .fx-head-high     .fx-head-dot { background: var(--sev-high); }
+    .fx-head-high     .fx-head-name { color: var(--sev-high); }
+    .fx-head-medium   .fx-head-dot { background: var(--sev-medium); }
+    .fx-head-medium   .fx-head-name { color: var(--sev-medium); }
+    .fx-head-low      .fx-head-dot { background: var(--sev-low); }
+    .fx-head-low      .fx-head-name { color: var(--sev-low); }
+    .fx-head-info     .fx-head-dot { background: var(--sev-info); }
+    .fx-head-info     .fx-head-name { color: var(--sev-info); }
+
+    /* Tile grid. */
+    .fx-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr)); gap: 0.7rem; }
+    .fx-tile {
+      display: flex; flex-direction: column; gap: 0.5rem; overflow: hidden;
+      text-decoration: none; color: inherit;
+      background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--border);
+      border-radius: 10px; padding: 0.85rem 0.95rem;
+      transition: border-color .15s, transform .12s, box-shadow .15s;
+    }
+    .fx-tile:hover { border-color: rgba(123,120,255,0.42); transform: translateY(-1px); box-shadow: 0 2px 14px rgba(0,0,0,0.22); }
+    .fx-tile.sev-critical { border-left-color: var(--sev-critical); background: color-mix(in srgb, var(--sev-critical) 6%, var(--surface)); }
+    .fx-tile.sev-high     { border-left-color: var(--sev-high);     background: color-mix(in srgb, var(--sev-high)     6%, var(--surface)); }
+    .fx-tile.sev-medium   { border-left-color: var(--sev-medium);   background: color-mix(in srgb, var(--sev-medium)   5%, var(--surface)); }
+    .fx-tile.sev-low      { border-left-color: var(--sev-low);      background: color-mix(in srgb, var(--sev-low)      5%, var(--surface)); }
+    .fx-tile.sev-info     { border-left-color: var(--sev-info);     background: color-mix(in srgb, var(--sev-info)     5%, var(--surface)); }
+
+    .fx-tile-top { display: flex; align-items: center; gap: 0.4rem; }
+    .fx-grow { flex: 1; }
+    .fx-tile-top .vbadge { margin-left: 0; }
+    .fx-tile-title {
+      font-family: var(--font-display); font-size: 0.94rem; font-weight: 600; color: #fff; line-height: 1.3;
+      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+      transition: color .15s;
+    }
+    .fx-tile:hover .fx-tile-title { color: var(--green); }
+    .fx-tile-line {
+      font-size: 0.8rem; color: var(--text-muted); line-height: 1.5;
+      display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+    }
+    .fx-tile-foot { display: flex; align-items: center; gap: 0.35rem; flex-wrap: wrap; min-width: 0; }
+    .fx-tile-foot .meta-chip { max-width: 100%; }
+    .fx-time { font-family: var(--font-mono); font-size: 0.68rem; color: var(--text-dim); }
+    .fx-triaged { color: #e3a000; font-size: 0.85rem; }
+
+    /* ══════════════════════════════════════════════════════════════════════════
+       WORLD MODEL tab styles — ported from the graph PR so the kept World Model
+       tab renders correctly on top of our restored dashboard design.
+       ══════════════════════════════════════════════════════════════════════════ */
+/* ── World Model tab — redesigned to match the dashboard system ────────────── */
+    .wm-stats { display:flex; flex-wrap:wrap; gap:0.4rem; align-items:center; margin-bottom:1rem; }
+    .wm-stat-total { font-family:var(--font-mono); font-size:0.8rem; color:var(--text); font-weight:600; margin-right:0.5rem; }
+    .wm-stat-chip { font-family:var(--font-mono); font-size:0.66rem; padding:0.14rem 0.5rem; border-radius:5px;
+      background:rgba(123,120,255,0.06); color:var(--text-muted); border:1px solid var(--border-subtle); }
+    .wm-err { color:var(--sev-high); font-size:0.72rem; margin-left:0.5rem; }
+
+    .wm-grid { display:grid; grid-template-columns:1fr 1fr; gap:1rem; }
+    @media (max-width:900px){ .wm-grid { grid-template-columns:1fr; } }
+    .wm-panel { background:var(--surface); border:1px solid var(--border); border-radius:10px; padding:1rem 1.15rem; margin-bottom:1rem; }
+    .wm-h { font-family:var(--font-display); font-size:var(--fs-section); font-weight:600; color:var(--text);
+      letter-spacing:0.02em; margin:0 0 0.8rem; padding-bottom:0.5rem; border-bottom:1px solid var(--border-subtle);
+      display:flex; align-items:baseline; gap:0.5rem; flex-wrap:wrap; }
+    .wm-h-mt { margin-top:1.25rem; }
+    .wm-sub { font-family:var(--font-mono); font-size:0.6rem; color:var(--text-dim); font-weight:400;
+      text-transform:uppercase; letter-spacing:0.08em; }
+    .wm-empty { color:var(--text-dim); font-size:0.8rem; padding:0.7rem 0; line-height:1.5; }
+
+    /* severity badge — aligned to the dashboard severity tokens */
+    .wm-sev { font-family:var(--font-mono); font-size:0.6rem; font-weight:700; text-transform:uppercase;
+      padding:0.14rem 0.45rem; border-radius:4px; height:fit-content; white-space:nowrap; border:1px solid transparent; }
+    .wm-sev-critical { background:rgba(255,77,79,.14);  color:var(--sev-critical); border-color:rgba(255,77,79,.30); }
+    .wm-sev-high     { background:rgba(250,140,22,.14); color:var(--sev-high);     border-color:rgba(250,140,22,.30); }
+    .wm-sev-medium   { background:rgba(250,173,20,.14); color:var(--sev-medium);   border-color:rgba(250,173,20,.30); }
+    .wm-sev-low      { background:rgba(91,242,155,.12); color:var(--sev-low);      border-color:rgba(91,242,155,.28); }
+    .wm-sev-info     { background:rgba(123,120,255,.12);color:var(--sev-info);     border-color:rgba(123,120,255,.28); }
+
+    /* kill-chains — each a card with a severity spine + readable steps */
+    .wm-chains { display:flex; flex-direction:column; gap:0.6rem; }
+    .wm-chain { display:flex; gap:0.75rem; align-items:flex-start; padding:0.8rem 0.9rem;
+      background:var(--surface-2); border:1px solid var(--border-subtle); border-left:3px solid var(--border); border-radius:8px; }
+    .wm-chain:has(.wm-sev-critical){ border-left-color:var(--sev-critical); }
+    .wm-chain:has(.wm-sev-high){ border-left-color:var(--sev-high); }
+    .wm-chain:has(.wm-sev-medium){ border-left-color:var(--sev-medium); }
+    .wm-chain:has(.wm-sev-low){ border-left-color:var(--sev-low); }
+    .wm-chain-body { flex:1; min-width:0; }
+    .wm-steps { display:flex; flex-wrap:wrap; align-items:center; gap:0.35rem; }
+    .wm-step { background:var(--bg-deep); border:1px solid var(--border-subtle); border-radius:5px;
+      padding:0.2rem 0.55rem; font-family:var(--font-mono); font-size:0.72rem; color:var(--text); }
+    .wm-arrow { color:var(--purple); font-size:0.85rem; }
+    .wm-terminal { font-family:var(--font-mono); font-size:0.68rem; color:var(--text-muted); margin-top:0.55rem; }
+    .wm-rationale { font-size:0.8rem; color:var(--text-muted); line-height:1.55; margin-top:0.3rem; }
+
+    /* ranking rows */
+    .wm-list { display:flex; flex-direction:column; gap:0.1rem; }
+    .wm-row { display:flex; align-items:center; gap:0.6rem; font-size:0.8rem; padding:0.4rem 0.5rem; border-radius:6px; }
+    .wm-row:hover { background:rgba(123,120,255,0.06); }
+    .wm-row-label { color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+    .wm-why { color:var(--text-dim); font-size:0.7rem; margin-left:auto; white-space:nowrap; }
+    .wm-pending { font-family:var(--font-mono); font-size:0.66rem; background:var(--purple-dim); color:var(--purple);
+      border:1px solid rgba(123,120,255,.28); border-radius:5px; padding:0.08rem 0.4rem; min-width:1.6rem; text-align:center; }
+
+    /* graph */
+    .wm-graph { overflow-x:auto; padding-top:0.3rem; }
+    .wm-svg { min-width:1040px; font-family:var(--font-mono); }
+    .wm-col-title { fill:var(--text-dim); font-size:11px; text-transform:uppercase; letter-spacing:0.08em; font-weight:600; }
+    .wm-node rect { fill:var(--surface-2); stroke:var(--border); stroke-width:1; }
+    .wm-node text { fill:var(--text); font-size:11px; }
+    .wm-node-host rect { fill:color-mix(in srgb, var(--purple) 16%, var(--surface)); stroke:var(--purple); }
+    .wm-node-endpoint rect { fill:color-mix(in srgb, #4f8cff 14%, var(--surface)); stroke:#4f8cff; }
+    .wm-node-param rect { fill:var(--surface-2); stroke:var(--border-subtle); }
+    .wm-node-credential rect, .wm-node-token rect { fill:color-mix(in srgb, var(--sev-medium) 16%, var(--surface)); stroke:var(--sev-medium); }
+    .wm-node-tech rect { fill:color-mix(in srgb, var(--green) 14%, var(--surface)); stroke:var(--green); }
+    .wm-sevfill-critical rect { fill:color-mix(in srgb, var(--sev-critical) 20%, var(--surface)); stroke:var(--sev-critical); }
+    .wm-sevfill-high rect { fill:color-mix(in srgb, var(--sev-high) 18%, var(--surface)); stroke:var(--sev-high); }
+    .wm-sevfill-medium rect { fill:color-mix(in srgb, var(--sev-medium) 18%, var(--surface)); stroke:var(--sev-medium); }
+    .wm-sevfill-low rect { fill:color-mix(in srgb, var(--sev-low) 14%, var(--surface)); stroke:var(--sev-low); }
+    .wm-sevfill-info rect { fill:var(--surface-2); stroke:var(--border); }
+    .wm-edge { stroke:var(--border); stroke-width:1; opacity:0.6; }
+    .wm-edge-leaks { stroke:var(--sev-medium); stroke-width:1.5; opacity:1; }
+    .wm-edge-escalates_to { stroke:var(--sev-critical); stroke-width:1.5; opacity:1; }
+    .wm-edge-authenticates { stroke:var(--green); stroke-dasharray:3 2; opacity:1; }
+    .wm-more { fill:var(--text-dim); font-size:11px; }
+
+    /* ══════════════════════════════════════════════════════════════════════════
+       TAB REDESIGN — every non-Findings tab brought to one readable, pretty system.
+       CSS + presentation-only headers; no JS logic / data flow touched.
+       ══════════════════════════════════════════════════════════════════════════ */
+
+    /* ── Consistent tab header (title + subtitle) ── */
+    .tab-head { margin: 0 0 1.15rem; }
+    .tab-head h2 {
+      font-family: var(--font-display); font-size: 1.3rem; font-weight: 600;
+      color: #fff; letter-spacing: 0.02em; margin: 0; line-height: 1.2;
+    }
+    .tab-head p, .tab-head .tab-sub {
+      font-size: 0.82rem; color: var(--text-dim); margin: 0.3rem 0 0; line-height: 1.5;
+    }
+    .section-title {
+      font-family: var(--font-display); font-size: 1.3rem; font-weight: 600;
+      color: #fff; letter-spacing: 0.02em; margin: 0 0 0.35rem;
+    }
+
+    /* ── Shared primitives ── */
+    .empty-placeholder {
+      padding: 2.6rem 2rem; border: 1px dashed var(--border); border-radius: 12px;
+      background: rgba(123,120,255,0.02); color: var(--text-dim);
+      font-size: 0.85rem; line-height: 1.6;
+    }
+    .tab-note, .skills-intro {
+      font-size: 0.82rem; color: var(--text-muted); line-height: 1.6;
+      background: var(--surface); border: 1px solid var(--border-subtle);
+      border-left: 2px solid var(--purple); border-radius: 8px;
+      padding: 0.75rem 0.95rem; margin: 0 0 1.15rem;
+    }
+    .tab-note strong, .skills-intro strong { color: var(--text); }
+    .tab-note code, .skills-intro code {
+      font-family: var(--font-mono); font-size: 0.78em; color: var(--green);
+      background: var(--surface-2); border: 1px solid var(--border-subtle);
+      border-radius: 4px; padding: 0.05rem 0.35rem;
+    }
+
+    /* ── Topology ── */
+    .diagram-card { border-radius: 12px; padding: 1.1rem 1.25rem; background: var(--surface); margin-bottom: 1rem; }
+    .diagram-card h3 {
+      font-family: var(--font-display); font-size: var(--fs-section); color: var(--text);
+      border-bottom: 1px solid var(--border-subtle); padding-bottom: 0.55rem; margin-bottom: 0.85rem;
+    }
+
+    /* ── Components ── */
+    .comp-grid { grid-template-columns: repeat(auto-fill, minmax(min(320px,100%),1fr)); gap: 0.8rem; }
+    .comp-card { background: var(--surface); border-radius: 12px; padding: 1rem 1.1rem;
+      transition: border-color .15s, transform .12s, box-shadow .15s; }
+    .comp-card:hover { border-color: rgba(123,120,255,0.4); transform: translateY(-1px); box-shadow: 0 3px 16px rgba(0,0,0,0.24); }
+    .comp-header { padding-bottom: 0.6rem; margin-bottom: 0.5rem; border-bottom: 1px solid var(--border-subtle); }
+    .comp-icon { font-size: 1.05rem; }
+    .comp-name { font-family: var(--font-display); font-size: 0.95rem; color: #fff; }
+    .comp-count { font-family: var(--font-mono); font-size: 0.66rem; color: var(--text-dim);
+      background: var(--surface-2); border-radius: 10px; padding: 0.08rem 0.5rem; }
+    .comp-vuln { font-size: 0.82rem; line-height: 1.5; padding: 0.45rem 0; border-top: 1px solid var(--border-subtle); }
+    .comp-vuln:first-of-type { border-top: none; }
+
+    /* ── Coverage — clear summary pills + readable, sticky matrix ── */
+    #coverage-summary { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
+    .cov-stat { padding: 0.32rem 0.7rem; border-radius: 7px; font-family: var(--font-mono);
+      font-size: 0.72rem; font-weight: 700; letter-spacing: 0.04em; }
+    .cov-tested     { background: var(--purple-dim);   border-color: var(--purple);      color: var(--purple); }
+    .cov-vulnerable { background: rgba(255,77,79,.14);  border-color: var(--sev-critical); color: var(--sev-critical); }
+    .cov-na         { background: rgba(107,104,144,.14);border-color: var(--text-dim);    color: var(--text-dim); }
+    .cov-skipped    { background: rgba(250,173,20,.14); border-color: var(--sev-medium);  color: var(--sev-medium); }
+    .cov-pending    { background: var(--surface-2);     border-color: var(--border);      color: var(--text-muted); }
+
+    .cov-matrix { font-size: 0.78rem; }
+    .cov-matrix thead th { background: var(--surface-2); position: sticky; top: 0; z-index: 3; padding: 0.5rem 0.35rem; }
+    .cov-matrix thead th:first-child { left: 0; z-index: 4; text-align: left; }
+    .cov-matrix td:first-child { position: sticky; left: 0; z-index: 2; background: var(--bg);
+      white-space: nowrap; padding: 0.45rem 0.75rem 0.45rem 0.4rem; }
+    .cov-ep-header td:first-child { background: var(--surface); color: #fff; }
+    .cov-ep-header:hover td:first-child { background: var(--surface-2); }
+    .cov-matrix tbody tr:hover td { background: rgba(123,120,255,0.04); }
+    .cov-matrix tbody tr { border-bottom: 1px solid var(--border-subtle); }
+    .cov-cell { width: 18px; height: 18px; border-radius: 4px; }
+    .cov-cell:hover { outline: 2px solid var(--purple); outline-offset: 1px; opacity: 1; }
+    .cov-cell.pending       { background: var(--surface-2); border: 1px solid var(--border); }
+    .cov-cell.tested_clean  { background: var(--green); }
+    .cov-cell.vulnerable    { background: var(--sev-critical); }
+    .cov-cell.not_applicable{ background: var(--text-dim); }
+    .cov-cell.skipped       { background: var(--sev-medium); }
+    .cov-col-header { color: var(--text-dim); }
+
+    /* ── Skills ── */
+    .skills-summary { gap: 0.5rem; margin-bottom: 1.1rem; }
+    .skills-grid { grid-template-columns: repeat(auto-fill, minmax(min(320px,100%),1fr)); gap: 0.7rem; }
+    .skill-card { background: var(--surface); border-radius: 12px; padding: 0.85rem 1rem;
+      transition: border-color .2s, box-shadow .2s, transform .12s; }
+    .skill-card:hover { transform: translateY(-1px); border-color: rgba(123,120,255,0.4); }
+    .skill-card.invoked { border-color: var(--green); box-shadow: none; }
+    .skill-name { font-family: var(--font-mono); }
+    .skills-group-header { font-family: var(--font-mono); color: var(--text-dim); }
+
+    /* ── Activity — chunked, readable feed ── */
+    .activity-section { margin-bottom: 1.9rem; }
+    .activity-section-header { margin-bottom: 0.85rem; padding-bottom: 0.55rem; }
+    .activity-section-title { font-family: var(--font-display); font-size: 1rem; color: #fff; }
+    .stuck-entry, .qa-alert { background: var(--surface); border-radius: 10px; }
+    .qa-alert { border: 1px solid var(--border-subtle); border-left-width: 3px; padding: 0.7rem 0.95rem; }
+    .ql-entry { border-radius: 6px; padding: 0.32rem 0.5rem; }
+    .chat-bubble { border-radius: 12px; }
+    .qa-divider { color: var(--text-dim); }
+
+    /* ── Threat Model ── */
+    #threat-model-wrap { background: var(--surface); border-radius: 12px; padding: 1.5rem 1.75rem; }
+    #tm-content h1, #tm-content h2, #tm-content h3 { font-family: var(--font-display); }
+    #tm-content code {
+      font-family: var(--font-mono); background: var(--surface-2);
+      border: 1px solid var(--border-subtle); border-radius: 4px; color: var(--green);
+    }
+    #tm-content pre { background: var(--bg-deep); border-radius: 8px; }
+    #tm-content th { background: var(--surface-2); }
+
+    /* ── Metrics ── */
+    .qa-label { font-family: var(--font-display); font-size: 1.05rem; }
+    .metrics-table { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; font-size: 0.78rem; }
+    .metrics-table thead th { background: var(--surface-2); padding: 0.5rem 0.65rem; }
+    .metrics-table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.015); }
+    .metrics-table tbody tr:hover td, .metrics-table tr:hover td { background: rgba(123,120,255,0.06); }
+
+    /* ── Logs — code console ── */
+    #log-output {
+      background: var(--bg-deep); border: 1px solid var(--border-subtle);
+      border-radius: 12px; font-size: 0.78rem; line-height: 1.65; padding: 0.9rem 1.1rem;
+    }
+    #log-filter { border-radius: 6px; }
+    #log-filter:focus { outline: none; border-color: var(--green); }

--- a/dashboard/finding.html
+++ b/dashboard/finding.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Same defense-in-depth CSP as the dashboard shell. -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'">
+  <title>Finding · Pentest Dashboard</title>
+  <link rel="icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@9/marked.min.js"></script>
+  <link rel="stylesheet" href="/static/css/dashboard.css?v=10">
+</head>
+<body class="dossier-page">
+
+<div class="dossier-shell" data-finding-id="{{ finding_id }}">
+  <header class="dossier-topbar">
+    <a class="dossier-back" href="/">&#8592; All findings</a>
+    <div class="dossier-brand">
+      <img class="dossier-logo" src="/logo.png" alt="NullPointer Studio" onerror="this.style.display='none'">
+      <span>Pentest <span class="h1-accent">Dashboard</span></span>
+    </div>
+  </header>
+
+  <div id="dossier-status" class="dossier-status"><span class="dot"></span>Loading finding…</div>
+  <div id="dossier-root"></div>
+</div>
+
+<script src="/static/js/shared.js"></script>
+<script src="/static/js/finding.js"></script>
+</body>
+</html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -15,181 +15,172 @@
   <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="/favicon.ico">
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@9/marked.min.js"></script>
-  <link rel="stylesheet" href="/static/css/dashboard.css?v=3">
+  <link rel="stylesheet" href="/static/css/dashboard.css?v=10">
 </head>
 <body>
-
 <div class="app-shell">
-  <!-- ── Sidebar: brand · grouped nav · footer ─────────────────────────────── -->
-  <aside class="sidebar">
-    <div class="sidebar-brand">
-      <img class="header-logo" src="/logo.png" alt="NullPointer Studio" onerror="this.style.display='none'">
-      <h1>Pentest <span class="h1-accent">Dashboard</span></h1>
+
+<!-- ── Left rail: brand + navigation ─────────────────────────────────────── -->
+<aside class="rail" id="rail">
+  <div class="rail-brand">
+    <img class="rail-logo" src="/logo.png" alt="NullPointer Studio" onerror="this.style.display='none'">
+    <div class="rail-brand-text">
+      <span class="rail-brand-line">Pentest</span>
+      <span class="rail-brand-line h1-accent">Dashboard</span>
     </div>
+  </div>
 
-    <!-- The .tab-btn DOM order below MUST match TAB_NAMES in common.js
-         (switchTab maps by index). -->
-    <nav class="side-nav">
-      <button class="tab-btn tab-btn-home active" onclick="switchTab('overview')">Overview</button>
+  <nav class="rail-nav" aria-label="Sections">
+    <div class="rail-group">Results</div>
+    <button class="tab-btn active" id="tab-btn-findings"     onclick="switchTab('findings')">Findings</button>
+    <button class="tab-btn"        id="tab-btn-topology"     onclick="switchTab('topology')">Topology</button>
+    <button class="tab-btn"        id="tab-btn-components"   onclick="switchTab('components')">Components</button>
+    <div class="rail-group">Progress</div>
+    <button class="tab-btn"        id="tab-btn-coverage"     onclick="switchTab('coverage')">Coverage</button>
+    <button class="tab-btn"        id="tab-btn-skills"       onclick="switchTab('skills')">Skills</button>
+    <button class="tab-btn"        id="tab-btn-activity"     onclick="switchTab('activity')">Activity</button>
+    <div class="rail-group">Analysis</div>
+    <button class="tab-btn"        id="tab-btn-world-model"  onclick="switchTab('world-model')">World Model</button>
+    <button class="tab-btn"        id="tab-btn-threat-model" onclick="switchTab('threat-model')">Threat Model</button>
+    <button class="tab-btn"        id="tab-btn-metrics"      onclick="switchTab('metrics')">Metrics</button>
+    <div class="rail-group">System</div>
+    <button class="tab-btn"        id="tab-btn-setup-gates"  onclick="switchTab('setup-gates')">Setup Gates</button>
+    <button class="tab-btn"        id="tab-btn-logs"         onclick="switchTab('logs')">Logs</button>
+  </nav>
 
-      <div class="nav-group">
-        <div class="nav-group-label">Results</div>
-        <button class="tab-btn" onclick="switchTab('findings')">Findings</button>
-        <button class="tab-btn" onclick="switchTab('topology')">Topology</button>
-        <button class="tab-btn" onclick="switchTab('components')">Components</button>
-      </div>
-      <div class="nav-group">
-        <div class="nav-group-label">Progress</div>
-        <button class="tab-btn" onclick="switchTab('coverage')" id="tab-btn-coverage">Coverage</button>
-        <button class="tab-btn" onclick="switchTab('skills')" id="tab-btn-skills">Skills</button>
-        <button class="tab-btn" onclick="switchTab('activity')" id="tab-btn-activity">Activity</button>
-      </div>
-      <div class="nav-group">
-        <div class="nav-group-label">Analysis</div>
-        <button class="tab-btn" onclick="switchTab('world-model')" id="tab-btn-world-model">World Model</button>
-        <button class="tab-btn" onclick="switchTab('threat-model')" id="tab-btn-threat-model">Threat Model</button>
-        <button class="tab-btn" onclick="switchTab('metrics')" id="tab-btn-metrics">Metrics</button>
-      </div>
-      <div class="nav-group">
-        <div class="nav-group-label">System</div>
-        <button class="tab-btn" onclick="switchTab('setup-gates')" id="tab-btn-setup-gates">Setup Gates</button>
-        <button class="tab-btn" onclick="switchTab('logs')">Logs</button>
-      </div>
-    </nav>
+  <div class="rail-footer">
+    <button class="tunnel-btn" onclick="cleanupTunnels()" title="Kill chisel tunnels and Meterpreter sessions">Cleanup Tunnels</button>
+    <button class="clear-btn" onclick="clearFindings()" title="Wipe all scan data — findings, session, coverage, logs, QA state">Clear All</button>
+  </div>
+</aside>
 
-    <div class="sidebar-footer">
-      <button class="tunnel-btn" onclick="cleanupTunnels()" title="Kill chisel tunnels and Meterpreter sessions">Cleanup Tunnels</button>
-      <button class="clear-btn" onclick="clearFindings()" title="Wipe all scan data — findings, session, coverage, logs, QA state">Clear All</button>
+<!-- ── Main column ───────────────────────────────────────────────────────── -->
+<main class="main">
+<div id="status"><span class="dot"></span>Connecting…</div>
+
+<!-- ── HIR panel — visible only during intervention_required ─────────────── -->
+<div id="hir-panel">
+  <div class="hir-header">
+    <div class="hir-badge">SCAN PAUSED</div>
+    <div class="hir-code" id="hir-code">HIR_UNKNOWN</div>
+    <div class="hir-dismiss" onclick="dismissHir()" title="Dismiss (scan stays paused)">✕ dismiss view</div>
+  </div>
+  <div class="hir-body">
+    <div class="hir-situation" id="hir-situation"></div>
+    <div id="hir-tried-wrap" style="display:none">
+      <div class="hir-section-label">What Smith already tried</div>
+      <div class="hir-tried" id="hir-tried"></div>
     </div>
-  </aside>
-
-  <!-- ── Main column ───────────────────────────────────────────────────────── -->
-  <main class="main">
-    <div id="status"><span class="dot"></span>Connecting…</div>
-
-    <!-- HIR panel — visible only during intervention_required -->
-    <div id="hir-panel">
-      <div class="hir-header">
-        <div class="hir-badge">SCAN PAUSED</div>
-        <div class="hir-code" id="hir-code">HIR_UNKNOWN</div>
-        <div class="hir-dismiss" onclick="dismissHir()" title="Dismiss (scan stays paused)">✕ dismiss view</div>
-      </div>
-      <div class="hir-body">
-        <div class="hir-situation" id="hir-situation"></div>
-        <div id="hir-tried-wrap" style="display:none">
-          <div class="hir-section-label">What Smith already tried</div>
-          <div class="hir-tried" id="hir-tried"></div>
-        </div>
-        <div class="hir-section-label">Choose how to respond — click to select, then Send</div>
-        <div class="hir-options" id="hir-options"></div>
-        <div class="hir-section-label">Optional message to Smith (add context or override)</div>
-        <div class="hir-input-row">
-          <textarea id="hir-message" placeholder="Type your instruction… (or click a quick option above)"></textarea>
-          <button class="hir-send-btn" id="hir-send-btn" onclick="sendHirResponse()">Send Response</button>
-        </div>
-      </div>
+    <div class="hir-section-label">Choose how to respond — click to select, then Send</div>
+    <div class="hir-options" id="hir-options"></div>
+    <div class="hir-section-label">Optional message to Smith (add context or override)</div>
+    <div class="hir-input-row">
+      <textarea id="hir-message" placeholder="Type your instruction… (or click a quick option above)"></textarea>
+      <button class="hir-send-btn" id="hir-send-btn" onclick="sendHirResponse()">Send Response</button>
     </div>
-
-    <!-- Status + Command Center -->
-    <div id="cmd-center">
-      <div id="cmd-status-row" class="cmd-status-row">
-        <div class="cmd-status-left">
-          <span class="cmd-target-label">Target</span>
-          <span class="cmd-target-val" id="cmd-target">—</span>
-          <div id="cmd-phase-pill" class="cmd-phase-pill" style="display:none">
-            <span id="cmd-phase-text" class="cmd-phase-active">recon</span>
-            <span id="cmd-phase-skill-sep" style="display:none"> › </span>
-            <span id="cmd-phase-skill" class="cmd-skill-name" style="display:none"></span>
-          </div>
-          <div id="cmd-benchmark-badge" style="display:none;margin-left:8px;background:#f59e0b;color:#000;font-size:10px;font-weight:700;letter-spacing:.08em;padding:2px 7px;border-radius:3px;">BENCHMARK</div>
-        </div>
-        <div class="cmd-status-mid" id="cmd-status-mid">
-          <div id="cmd-cov-group" class="cmd-cov-group" style="display:none">
-            <span class="cmd-dim">cov</span>
-            <div class="cmd-cov-track"><div class="cmd-cov-bar" id="cmd-cov-bar" style="width:0%"></div></div>
-            <span id="cmd-cov-txt" class="cmd-dim">0/0</span>
-          </div>
-          <div id="cmd-gates-alert" style="display:none">
-            <span class="cmd-gates-txt">⚠ <span id="cmd-gates-count"></span></span>
-          </div>
-          <div id="cmd-cost-group" style="display:none">
-            <span class="cmd-dim">cost</span>
-            <span id="cmd-cost-val" class="cmd-val">—</span>
-          </div>
-        </div>
-        <div class="cmd-status-right">
-          <span class="cmd-dim">scan </span>
-          <strong id="cmd-scan-status" class="cmd-scan-status">—</strong>
-          <span class="cmd-status-sep">·</span>
-          <span class="cmd-dim">smith </span>
-          <strong id="cmd-smith-process-status" class="cmd-smith-process-status cmd-smith-process-unknown">—</strong>
-        </div>
-      </div>
-      <div class="cmd-smith-panel">
-        <div class="cmd-smith-header">
-          <span class="cmd-smith-dot" id="cmd-smith-dot"></span>
-          <span class="cmd-smith-label" id="cmd-smith-label">Instruct Smith</span>
-          <span id="cmd-smith-hint" class="cmd-smith-hint"></span>
-        </div>
-        <div class="cmd-smith-row">
-          <textarea id="cmd-smith-input" class="cmd-smith-input"
-            placeholder="Type a steering instruction… (e.g. 'focus on /api/users', 'skip rate_limit cells', 'the JWT secret is HS256')"></textarea>
-          <button class="cmd-smith-send" id="cmd-smith-send-btn" onclick="sendCmdSmith()">Send</button>
-        </div>
-        <div class="cmd-quick-chips">
-          <span class="cmd-chip" onclick="setSmithChip('What are you currently doing and what cells are next?')">Status check</span>
-          <span class="cmd-chip" onclick="setSmithChip('Focus on the most critical untested endpoints and parameters')">Focus critical</span>
-          <span class="cmd-chip" onclick="setSmithChip('Skip the current cell and move to the next pending one')">Skip cell</span>
-          <span class="cmd-chip" onclick="setSmithChip('Summarize all findings discovered so far')">Summarize findings</span>
-        </div>
-        <div id="cmd-smith-feedback" class="cmd-smith-feedback"></div>
-        <div class="cmd-smith-complete-row">
-          <button class="cmd-smith-restart-btn" id="cmd-restart-btn" onclick="restartSmith()" style="display:none">
-            &#9654; <span id="cmd-restart-label">Restart Smith</span>
-          </button>
-          <button class="cmd-smith-triage-btn" id="cmd-triage-btn" onclick="triageFindings()" style="display:none">
-            &#9878; Triage findings
-          </button>
-          <button class="cmd-smith-complete-btn" id="cmd-complete-btn" onclick="completeScan()">
-            &#10003; Complete Scan
-          </button>
-          <button class="cmd-smith-complete-btn" id="cmd-force-stop-btn" onclick="forceStop()" style="background:#da3633;color:#fff" title="Kill Smith now and end the scan — skips the adjudication relaunch (findings are kept)">
-            &#10005; Force stop
-          </button>
-          <span class="cmd-smith-complete-hint" id="cmd-smith-status-hint">Only you can end the scan — Smith will keep testing until you do. Triage runs after the scan stops.</span>
-        </div>
-        <div id="adjudication-banner" style="display:none" class="adjudication-banner">
-          <span id="adjudication-banner-msg">&#9203; Triage in progress — Smith is recording verdicts&hellip;</span>
-          <span class="adjudication-banner-actions">
-            <button class="adj-banner-btn" onclick="reNudgeTriage()">Re-nudge Smith</button>
-            <button class="adj-banner-btn adj-banner-dismiss" onclick="cancelTriage()">Dismiss</button>
-          </span>
-        </div>
-      </div>
-    </div>
-
-    {% include 'tabs/overview.html' %}
-    {% include 'tabs/findings.html' %}
-    {% include 'tabs/topology.html' %}
-    {% include 'tabs/components.html' %}
-    {% include 'tabs/coverage.html' %}
-    {% include 'tabs/skills.html' %}
-    {% include 'tabs/activity.html' %}
-    {% include 'tabs/world-model.html' %}
-    {% include 'tabs/threat-model.html' %}
-    {% include 'tabs/metrics.html' %}
-    {% include 'tabs/setup-gates.html' %}
-    {% include 'tabs/logs.html' %}
-  </main>
+  </div>
 </div>
 
+<!-- ── Status + Command Center ──────────────────────────────────────────── -->
+<div id="cmd-center">
+  <div id="cmd-status-row" class="cmd-status-row">
+    <div class="cmd-status-left">
+      <span class="cmd-target-label">Target</span>
+      <span class="cmd-target-val" id="cmd-target">—</span>
+      <div id="cmd-phase-pill" class="cmd-phase-pill" style="display:none">
+        <span id="cmd-phase-text" class="cmd-phase-active">recon</span>
+        <span id="cmd-phase-skill-sep" style="display:none"> › </span>
+        <span id="cmd-phase-skill" class="cmd-skill-name" style="display:none"></span>
+      </div>
+      <div id="cmd-benchmark-badge" style="display:none;margin-left:8px;background:#f59e0b;color:#000;font-size:10px;font-weight:700;letter-spacing:.08em;padding:2px 7px;border-radius:3px;">BENCHMARK</div>
+    </div>
+    <div class="cmd-status-mid" id="cmd-status-mid">
+      <div id="cmd-cov-group" class="cmd-cov-group" style="display:none">
+        <span class="cmd-dim">cov</span>
+        <div class="cmd-cov-track"><div class="cmd-cov-bar" id="cmd-cov-bar" style="width:0%"></div></div>
+        <span id="cmd-cov-txt" class="cmd-dim">0/0</span>
+      </div>
+      <div id="cmd-gates-alert" style="display:none">
+        <span class="cmd-gates-txt">⚠ <span id="cmd-gates-count"></span></span>
+      </div>
+      <div id="cmd-cost-group" style="display:none">
+        <span class="cmd-dim">cost</span>
+        <span id="cmd-cost-val" class="cmd-val">—</span>
+      </div>
+    </div>
+    <div class="cmd-status-right">
+      <span class="cmd-dim">scan </span>
+      <strong id="cmd-scan-status" class="cmd-scan-status">—</strong>
+      <span class="cmd-status-sep">·</span>
+      <span class="cmd-dim">smith </span>
+      <strong id="cmd-smith-process-status" class="cmd-smith-process-status cmd-smith-process-unknown">—</strong>
+    </div>
+  </div>
+  <div class="cmd-smith-panel">
+    <div class="cmd-smith-header">
+      <span class="cmd-smith-dot" id="cmd-smith-dot"></span>
+      <span class="cmd-smith-label" id="cmd-smith-label">Instruct Smith</span>
+      <span id="cmd-smith-hint" class="cmd-smith-hint"></span>
+    </div>
+    <div class="cmd-smith-row">
+      <textarea id="cmd-smith-input" class="cmd-smith-input"
+        placeholder="Type a steering instruction… (e.g. 'focus on /api/users', 'skip rate_limit cells', 'the JWT secret is HS256')"></textarea>
+      <button class="cmd-smith-send" id="cmd-smith-send-btn" onclick="sendCmdSmith()">Send</button>
+    </div>
+    <div class="cmd-quick-chips">
+      <span class="cmd-chip" onclick="setSmithChip('What are you currently doing and what cells are next?')">Status check</span>
+      <span class="cmd-chip" onclick="setSmithChip('Focus on the most critical untested endpoints and parameters')">Focus critical</span>
+      <span class="cmd-chip" onclick="setSmithChip('Skip the current cell and move to the next pending one')">Skip cell</span>
+      <span class="cmd-chip" onclick="setSmithChip('Summarize all findings discovered so far')">Summarize findings</span>
+    </div>
+    <div id="cmd-smith-feedback" class="cmd-smith-feedback"></div>
+    <div class="cmd-smith-complete-row">
+      <button class="cmd-smith-restart-btn" id="cmd-restart-btn" onclick="restartSmith()" style="display:none">
+        &#9654; <span id="cmd-restart-label">Restart Smith</span>
+      </button>
+      <button class="cmd-smith-triage-btn" id="cmd-triage-btn" onclick="triageFindings()" style="display:none">
+        &#9878; Triage findings
+      </button>
+      <button class="cmd-smith-complete-btn" id="cmd-complete-btn" onclick="completeScan()">
+        &#10003; Complete Scan
+      </button>
+      <button class="cmd-smith-complete-btn" id="cmd-force-stop-btn" onclick="forceStop()" style="background:#da3633;color:#fff" title="Kill Smith now and end the scan — skips the adjudication relaunch (findings are kept)">
+        &#10005; Force stop
+      </button>
+      <span class="cmd-smith-complete-hint" id="cmd-smith-status-hint">Only you can end the scan — Smith will keep testing until you do. Triage runs after the scan stops.</span>
+    </div>
+    <div id="adjudication-banner" style="display:none" class="adjudication-banner">
+      <span id="adjudication-banner-msg">&#9203; Triage in progress — Smith is recording verdicts&hellip;</span>
+      <span class="adjudication-banner-actions">
+        <button class="adj-banner-btn" onclick="reNudgeTriage()">Re-nudge Smith</button>
+        <button class="adj-banner-btn adj-banner-dismiss" onclick="cancelTriage()">Dismiss</button>
+      </span>
+    </div>
+  </div>
+</div>
+
+{% include 'tabs/findings.html' %}
+{% include 'tabs/topology.html' %}
+{% include 'tabs/components.html' %}
+{% include 'tabs/coverage.html' %}
+{% include 'tabs/skills.html' %}
+{% include 'tabs/activity.html' %}
+{% include 'tabs/world-model.html' %}
+{% include 'tabs/threat-model.html' %}
+{% include 'tabs/metrics.html' %}
+{% include 'tabs/setup-gates.html' %}
+{% include 'tabs/logs.html' %}
+
+</main>
+</div>
+
+<script src="/static/js/shared.js"></script>
 <script src="/static/js/common.js"></script>
-<script src="/static/js/overview.js"></script>
-<script src="/static/js/findings.js"></script>
+<script src="/static/js/findings.js?v=3"></script>
 <script src="/static/js/topology.js?v=2"></script>
 <script src="/static/js/components.js"></script>
 <script src="/static/js/coverage.js"></script>
-<script src="/static/js/world-model.js"></script>
+<script src="/static/js/world-model.js?v=2"></script>
 <script src="/static/js/threat-model.js?v=2"></script>
 <script src="/static/js/logs.js"></script>
 <script src="/static/js/skills.js"></script>

--- a/dashboard/js/common.js
+++ b/dashboard/js/common.js
@@ -1,134 +1,8 @@
-  // ── Dashboard auth: per-session bearer token ────────────────────────────────
-  // The MCP server mints a random token when a scan starts and prints the
-  // dashboard URL with it in the fragment (…/#k=<token>). Capture it into
-  // sessionStorage (never sent to the server via the URL), strip it from the
-  // address bar, and attach it as `Authorization: Bearer …` on every same-origin
-  // API call. Closes the unauthenticated-control-plane / CSRF / DNS-rebind class:
-  // a cross-origin or rebound page can neither read the token (origin-scoped
-  // storage) nor set the Authorization header without a CORS preflight that has
-  // no allow. (A same-origin XSS still holds the token — that is handled by
-  // output escaping/sanitization, not here.)
-  (function initDashboardAuth() {
-    const KEY = 'smith_dash_token';
-    function token() {
-      try { return sessionStorage.getItem(KEY) || ''; } catch (_) { return ''; }
-    }
-    try {
-      const m = (location.hash || '').match(/[#&]k=([^&]+)/);
-      if (m) {
-        sessionStorage.setItem(KEY, decodeURIComponent(m[1]));
-        history.replaceState(null, '', location.pathname + location.search);
-      }
-    } catch (_) { /* storage unavailable — wrapper simply no-ops */ }
-
-    const _origFetch = window.fetch.bind(window);
-    window.fetch = function (input, init) {
-      let sameOrigin = true;
-      try {
-        const raw = (typeof input === 'string') ? input : (input && input.url) || '';
-        sameOrigin = new URL(raw, location.href).origin === location.origin;
-      } catch (_) { sameOrigin = true; }
-      const t = token();
-      if (sameOrigin && t) {
-        init = init ? Object.assign({}, init) : {};
-        const h = new Headers(init.headers || (typeof input !== 'string' && input && input.headers) || {});
-        if (!h.has('Authorization')) h.set('Authorization', 'Bearer ' + t);
-        init.headers = h;
-      }
-      return _origFetch(input, init);
-    };
-
-    // No token yet (bare URL / bookmark)? Ask once — the CLI prints the key with
-    // the dashboard URL. Blank just leaves calls unauthenticated, which is fine
-    // before a scan has started (nothing sensitive is served).
-    try {
-      if (!token()) {
-        const pasted = window.prompt(
-          'Dashboard key required.\nPaste the key printed with the dashboard URL ' +
-          '(leave blank if no scan has started yet):'
-        );
-        if (pasted) sessionStorage.setItem(KEY, pasted.trim());
-      }
-    } catch (_) { /* non-interactive context */ }
-  })();
-
-  // ── HTML sanitizer for untrusted markdown (threat-model tab) ────────────────
-  // marked@9 passes raw HTML through, and scan-derived markdown embeds
-  // attacker-influenced recon strings. Render marked's output through this
-  // allow-list DOM sanitizer before innerHTML so injected tags / event handlers
-  // / scripts / javascript: URLs cannot execute. Keeps <pre><code class=…> so the
-  // mermaid post-processing still finds language-mermaid blocks.
-  const _SANITIZE_ALLOWED_TAGS = new Set([
-    'A','P','DIV','SPAN','BR','HR','PRE','CODE','BLOCKQUOTE','KBD','SMALL',
-    'H1','H2','H3','H4','H5','H6','UL','OL','LI','STRONG','EM','B','I','U',
-    'DEL','INS','SUP','SUB','TABLE','THEAD','TBODY','TFOOT','TR','TH','TD','DL','DT','DD','IMG',
-  ]);
-  const _SANITIZE_ALLOWED_ATTRS = new Set([
-    'href','src','alt','title','class','colspan','rowspan','align','start',
-  ]);
-  const _SANITIZE_DROP_TAGS = new Set([
-    'SCRIPT','STYLE','IFRAME','OBJECT','EMBED','FORM','LINK','META','BASE','SVG','MATH','TEMPLATE',
-  ]);
-  function sanitizeHtml(html) {
-    const doc = new DOMParser().parseFromString(String(html), 'text/html');
-    const walk = (root) => {
-      [...root.children].forEach((el) => {
-        const tag = el.tagName;
-        if (!_SANITIZE_ALLOWED_TAGS.has(tag)) {
-          if (_SANITIZE_DROP_TAGS.has(tag)) { el.remove(); return; }
-          const span = doc.createElement('span');   // unwrap unknown tags to text
-          span.textContent = el.textContent;
-          el.replaceWith(span);
-          return;
-        }
-        [...el.attributes].forEach((a) => {
-          const name = a.name.toLowerCase();
-          if (!_SANITIZE_ALLOWED_ATTRS.has(name)) { el.removeAttribute(a.name); return; }
-          if (name === 'href' || name === 'src') {
-            const v = (a.value || '').replace(/[\u0000-\u0020]+/g, '').toLowerCase();
-            if (v.startsWith('javascript:') || v.startsWith('vbscript:') ||
-                (v.startsWith('data:') && !v.startsWith('data:image/'))) {
-              el.removeAttribute(a.name);
-            }
-          }
-        });
-        walk(el);
-      });
-    };
-    walk(doc.body);
-    return doc.body.innerHTML;
-  }
-
-  mermaid.initialize({
-    startOnLoad: false,
-    theme: 'base',
-    themeVariables: {
-      // Background
-      background: '#0d1117',
-      primaryColor: '#1f2937',
-      primaryTextColor: '#e5e7eb',
-      primaryBorderColor: '#374151',
-      // Secondary (decisions, conditions)
-      secondaryColor: '#1e3a5f',
-      secondaryTextColor: '#e5e7eb',
-      secondaryBorderColor: '#2563eb',
-      // Tertiary
-      tertiaryColor: '#2d1f3d',
-      tertiaryTextColor: '#e5e7eb',
-      tertiaryBorderColor: '#7c3aed',
-      // Lines and text
-      lineColor: '#6b7280',
-      textColor: '#e5e7eb',
-      // Notes
-      noteBkgColor: '#1e293b',
-      noteTextColor: '#cbd5e1',
-      noteBorderColor: '#334155',
-      // Fonts — consistent size
-      fontSize: '14px',
-      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-    },
-    flowchart: { curve: 'linear', htmlLabels: false },
-  });
+  // ── Shared core moved to shared.js ──────────────────────────────────────────
+  // The per-session auth shim, esc(), sanitizeHtml()/allow-lists, and
+  // mermaid.initialize() now live in shared.js (loaded first on this page and on
+  // the finding detail page). Do NOT redefine them here — the sanitizer's
+  // top-level consts would collide across the two <script> scopes.
 
   const POLL_MS   = 5000;
   const SEV_ORDER = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
@@ -142,7 +16,7 @@
   let lastOk     = null;
   let _steeringData = null;
   let _sessionData  = null;
-  let _activeTab = 'overview';
+  let _activeTab = 'findings';
   let _logLines  = [];
 
   // ── Notification system ───────────────────────────────────────────────────
@@ -199,23 +73,18 @@
 
   // ── Tab switching ─────────────────────────────────────────────────────────
   // Order MUST match the .tab-btn DOM order in index.html's sidebar (switchTab maps by index).
-  const TAB_NAMES = ['overview', 'findings', 'topology', 'components', 'coverage', 'skills', 'activity', 'world-model', 'threat-model', 'metrics', 'setup-gates', 'logs'];
+  const TAB_NAMES = ['findings', 'topology', 'components', 'coverage', 'skills', 'activity', 'world-model', 'threat-model', 'metrics', 'setup-gates', 'logs'];
 
   function switchTab(name) {
     _activeTab = name;
     document.querySelectorAll('.tab-btn').forEach((b, i) => {
       b.classList.toggle('active', TAB_NAMES[i] === name);
     });
-    // The command center (Instruct Smith + Complete/Force-stop) lives on Overview
-    // only — on the detail tabs it just clutters. HIR alerts stay visible everywhere.
-    const cmd = document.getElementById('cmd-center');
-    if (cmd) cmd.style.display = (name === 'overview') ? '' : 'none';
     document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
     document.getElementById(`tab-${name}`).classList.add('active');
     if (name === 'topology')      renderTopology(allData.diagrams || []);
     if (name === 'components')    renderComponentMap(allData.findings || []);
     if (name === 'coverage')      pollCoverage();
-    if (name === 'world-model')   pollWorldModel();
     if (name === 'skills')        pollSkills();
     if (name === 'activity') {
       // Immediately paint whatever data we already have so the tab is not
@@ -228,6 +97,7 @@
       renderAdjudicationLog();
       pollQA();
     }
+    if (name === 'world-model')   pollWorldModel();
     if (name === 'metrics')       pollMetrics();
     if (name === 'threat-model')  pollThreatModel();
     if (name === 'setup-gates')   pollSetupGates();

--- a/dashboard/js/finding.js
+++ b/dashboard/js/finding.js
@@ -1,0 +1,273 @@
+// ============================================================================
+//  finding.js — renders the standalone finding "dossier" page (/finding/<id>).
+//  Depends on shared.js for the auth shim + esc() + mermaid setup.
+//  Wrapped in an IIFE; copy buttons use event delegation (no globals needed).
+// ============================================================================
+(function () {
+  const POLL_MS = 5000;
+  const shell    = document.querySelector('.dossier-shell');
+  const fid      = shell ? shell.getAttribute('data-finding-id') : '';
+  const root     = document.getElementById('dossier-root');
+  const statusEl = document.getElementById('dossier-status');
+
+  const SEV_RANK  = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  const VS_LABELS = {
+    confirmed_dynamic:       '✓ CONFIRMED',
+    new_dynamic_finding:     '+ NEW DISCOVERY',
+    code_confirmed:          '◉ CODE CONFIRMED',
+    not_accessible_external: '⊘ INTERNAL ONLY',
+    not_confirmed:           '? NOT CONFIRMED',
+    unverified:              '· UNVERIFIED',
+  };
+
+  let _lastKey = '';
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+  function fmtTime(ts) {
+    if (!ts) return '';
+    const d = new Date(ts);
+    return isNaN(d) ? String(ts) : d.toLocaleString();
+  }
+  function section(title, bodyHtml, extraClass) {
+    if (!bodyHtml) return '';
+    return `<section class="dossier-section ${extraClass || ''}">
+      <h2 class="dossier-section-title">${esc(title)}</h2>
+      ${bodyHtml}
+    </section>`;
+  }
+  function railRow(label, valueHtml) {
+    if (!valueHtml && valueHtml !== 0) return '';
+    return `<div class="drail-label">${esc(label)}</div><div class="drail-value">${valueHtml}</div>`;
+  }
+  function copyBtn(text, label) {
+    // data-copy is base64 so arbitrary payloads survive the attribute intact.
+    const enc = btoa(unescape(encodeURIComponent(text)));
+    return `<button class="dossier-copy" data-copy="${enc}">${esc(label || 'Copy')}</button>`;
+  }
+
+  // ── data-flow trace → vertical stepped timeline ──────────────────────────────
+  function traceHtml(trace) {
+    if (!Array.isArray(trace) || !trace.length) return '';
+    const kindLabel = { entrypoint: 'ENTRY', propagation: 'FLOW', sink: 'SINK' };
+    const steps = trace.map((s, i) => {
+      const kind = (s.kind || '').toLowerCase();
+      const loc  = s.file ? `${esc(s.file)}${s.line ? ':' + esc(s.line) : ''}` : '';
+      return `<li class="trace-step trace-${esc(kind)}">
+        <span class="trace-node"></span>
+        <div class="trace-body">
+          <div class="trace-head">
+            <span class="trace-kind">${esc(kindLabel[kind] || kind || 'STEP')}</span>
+            ${loc ? `<span class="trace-loc">${loc}</span>` : ''}
+            ${s.scope ? `<span class="trace-scope">${esc(s.scope)}</span>` : ''}
+          </div>
+          ${s.description ? `<div class="trace-desc">${esc(s.description)}</div>` : ''}
+        </div>
+      </li>`;
+    }).join('');
+    return `<ol class="trace-timeline">${steps}</ol>`;
+  }
+
+  // ── adjudication (senior review) ─────────────────────────────────────────────
+  function adjudicationHtml(adj) {
+    if (!adj || !adj.rationale) return '';
+    const repro = adj.reproducible === true || adj.reproducible === 'true';
+    const reproHtml = repro
+      ? '<span class="adj-ok">✓ Reproducible</span>'
+      : '<span class="adj-no">✗ Not reproducible</span>';
+    const orig = (adj.original_severity || '').toLowerCase();
+    const rev  = (adj.revised_severity  || '').toLowerCase();
+    let sevHtml;
+    if (orig && rev && orig !== rev) {
+      const up = (SEV_RANK[rev] ?? 9) < (SEV_RANK[orig] ?? 9);
+      sevHtml = `<span class="fadj-sev-old">${esc(orig)}</span>` +
+                `<span class="fadj-sev-arrow">→</span>` +
+                `<span class="${up ? 'fadj-sev-new-up' : 'fadj-sev-new-down'}">${esc(rev)}</span>`;
+    } else {
+      sevHtml = `<span class="fadj-sev-same">${esc(orig || rev || '—')} (unchanged)</span>`;
+    }
+    return `<div class="finding-adjudication">
+      <div class="finding-adjudication-header">⚖ Senior review</div>
+      <div class="finding-adjudication-grid">
+        <span class="fadj-label">Reproducible</span><span class="fadj-value">${reproHtml}</span>
+        <span class="fadj-label">Severity</span><span class="fadj-value">${sevHtml}</span>
+        ${adj.artifact_id ? `<span class="fadj-label">Artifact</span><span class="fadj-value"><code>${esc(adj.artifact_id)}</code></span>` : ''}
+        <span class="fadj-label">Rationale</span><span class="fadj-value">${esc(adj.rationale)}</span>
+      </div>
+    </div>`;
+  }
+
+  // ── remediation ──────────────────────────────────────────────────────────────
+  function remediationHtml(r) {
+    if (!r) return '';
+    const effortClass = r.effort === 'low' ? 'effort-low' : r.effort === 'high' ? 'effort-high' : 'effort-medium';
+    const breaking = r.breaking_change ? '<span class="rem-breaking">⚠ Breaking change</span>' : '';
+    const file = r.file ? `<div class="rem-file">${esc(r.file)}${r.line ? ':' + esc(r.line) : ''}${r.language ? ' (' + esc(r.language) + ')' : ''}</div>` : '';
+    const diff = r.diff ? `<div class="rem-block"><strong>Diff</strong><pre class="evidence">${esc(r.diff)}</pre></div>` : '';
+    const ba = (r.before && r.after)
+      ? `<div class="rem-block"><strong>Before</strong><pre class="evidence rem-before">${esc(r.before)}</pre></div>
+         <div class="rem-block"><strong>After</strong><pre class="evidence rem-after">${esc(r.after)}</pre></div>`
+      : '';
+    const verify = r.verification ? `<div class="rem-block"><strong>Verification</strong><div class="rem-verify">${esc(r.verification)}</div></div>` : '';
+    const refs = Array.isArray(r.references) && r.references.length
+      ? `<div class="rem-block"><strong>References</strong><ul class="rem-refs">${r.references.map(u => `<li><a href="${esc(u)}" target="_blank" rel="noopener">${esc(u)}</a></li>`).join('')}</ul></div>`
+      : '';
+    return `<div class="remediation-detail">
+      <div><strong>${esc(r.summary || 'Remediation')}</strong></div>
+      <div class="rem-meta"><span class="effort-badge ${effortClass}">${esc(r.effort || 'unknown')} effort</span>${breaking}</div>
+      ${file}${diff}${ba}${verify}${refs}
+    </div>`;
+  }
+
+  // ── escalation leads (may be a string or a list of {lead,status,result}) ─────
+  function escalationHtml(leads) {
+    if (!leads) return '';
+    if (typeof leads === 'string') return `<div class="dossier-text">${esc(leads)}</div>`;
+    if (!Array.isArray(leads) || !leads.length) return '';
+    return `<ul class="esc-leads">${leads.map(l => {
+      if (typeof l === 'string') return `<li>${esc(l)}</li>`;
+      const st = l.status ? `<span class="esc-status esc-${esc(l.status)}">${esc(l.status)}</span>` : '';
+      return `<li>${st}${esc(l.lead || '')}${l.result ? ` — ${esc(l.result)}` : ''}</li>`;
+    }).join('')}</ul>`;
+  }
+
+  function chainsHtml(chains) {
+    if (!Array.isArray(chains) || !chains.length) return '';
+    return chains.map(c => `
+      <div class="dossier-chain">
+        <div class="dossier-chain-head">
+          <span class="dossier-chain-name">${esc(c.name || 'Exploit chain')}</span>
+          ${c.combined_severity ? `<span class="badge badge-${esc(c.combined_severity)}">${esc(c.combined_severity)}</span>` : ''}
+        </div>
+        ${c.terminal_impact ? `<div class="dossier-text">${esc(c.terminal_impact)}</div>` : ''}
+        <div class="tm-mermaid-wrap">${c.svg || `<pre class="mermaid">${esc(c.mermaid || '')}</pre>`}</div>
+      </div>`).join('');
+  }
+
+  // ── main render ──────────────────────────────────────────────────────────────
+  function render(data) {
+    const f = data.finding || {};
+    const sev = (f.severity || 'info').toLowerCase();
+    const vs  = f.verification_status || 'unverified';
+
+    document.title = `${f.title ? f.title.slice(0, 60) : 'Finding'} · Pentest Dashboard`;
+    if (statusEl) {
+      statusEl.innerHTML = `<span class="dot"></span>Live · refreshes every 5 s`
+        + (data.archived ? ' · <strong style="color:#faad14">archived</strong>' : '');
+    }
+
+    const badges = [
+      `<span class="badge badge-${esc(sev)}">${esc(sev)}</span>`,
+      `<span class="vbadge vbadge-${esc(vs)}">${esc(VS_LABELS[vs] || vs)}</span>`,
+      f.adjudication?.rationale ? '<span class="triaged-badge">⚖ Triaged</span>' : '',
+      f.status === 'false_positive' ? '<span class="badge" style="background:rgba(107,104,144,.2);color:var(--text-dim)">false positive</span>' : '',
+    ].join('');
+
+    const metaLine = [
+      f.target ? `<span class="target">${esc(f.target)}</span>` : '',
+      f.tool_used ? `<span class="tool">${esc(f.tool_used)}</span>` : '',
+      f.cve ? `<span class="cve">CVE: ${esc(f.cve)}</span>` : '',
+      f.timestamp ? `<span class="finding-ts-meta">first seen ${esc(fmtTime(f.timestamp))}</span>` : '',
+    ].filter(Boolean).join('');
+
+    // ── main (narrative) column ──
+    const impact = f.business_impact
+      ? `<div class="finding-impact">
+           <span class="finding-impact-icon">⚠</span>
+           <span class="finding-impact-label">Business impact&nbsp;&nbsp;</span>
+           <span class="finding-impact-text">${esc(f.business_impact)}</span>
+         </div>`
+      : '';
+    const desc = f.description ? `<div class="dossier-text">${esc(f.description)}</div>` : '';
+    const evidence = f.evidence
+      ? `<div class="dossier-copy-row">${copyBtn(f.evidence, '⧉ Copy evidence')}</div><pre class="evidence dossier-evidence">${esc(f.evidence)}</pre>`
+      : '';
+    const repro = f.reproduction?.command
+      ? `<div class="dossier-copy-row">${copyBtn(f.reproduction.command, '▶ Copy command')}</div><pre class="evidence dossier-evidence">${esc(f.reproduction.command)}</pre>`
+      : '';
+    const poc = Array.isArray(f.poc_files) && f.poc_files.length
+      ? `<ul class="poc-list">${f.poc_files.map(p => `<li><code>${esc(typeof p === 'string' ? p : (p.path || JSON.stringify(p)))}</code></li>`).join('')}</ul>`
+      : '';
+
+    const mainCol = `<div class="dossier-main">
+      ${impact}
+      ${section('Description', desc)}
+      ${section('Data flow', traceHtml(f.trace))}
+      ${section('Evidence', evidence)}
+      ${section('Reproduction', repro)}
+      ${section('Remediation', remediationHtml(f.remediation))}
+      ${section('Escalation leads', escalationHtml(f.escalation_leads))}
+      ${section('Exploit chain', chainsHtml(data.chains))}
+    </div>`;
+
+    // ── metadata rail ──
+    const railRows = [
+      railRow('Severity', `<span class="drail-sev drail-sev-${esc(sev)}">${esc(sev)}</span>`),
+      railRow('Verification', `<span class="vbadge vbadge-${esc(vs)}">${esc(VS_LABELS[vs] || vs)}</span>`),
+      railRow('Target', f.target ? `<span class="mono-wrap">${esc(f.target)}</span>` : ''),
+      railRow('Tool', f.tool_used ? esc(f.tool_used) : ''),
+      railRow('CVE', f.cve ? esc(f.cve) : ''),
+      railRow('Status', f.status ? esc(f.status) : ''),
+      railRow('First seen', f.timestamp ? esc(fmtTime(f.timestamp)) : ''),
+      railRow('Finding ID', `<span class="mono-wrap">${esc(f.id || '')}</span> ${copyBtn(f.id || '', 'copy')}`),
+    ].join('');
+
+    const railCol = `<aside class="dossier-rail">
+      <div class="dossier-rail-card">
+        <div class="drail-grid">${railRows}</div>
+      </div>
+      ${adjudicationHtml(f.adjudication)}
+      ${poc ? `<div class="dossier-rail-card"><div class="drail-heading">PoC files</div>${poc}</div>` : ''}
+    </aside>`;
+
+    root.innerHTML = `
+      <div class="dossier-masthead dossier-sev-${esc(sev)}">
+        <div class="dossier-badges">${badges}</div>
+        <h1 class="dossier-title">${esc(f.title || 'Untitled finding')}</h1>
+        <div class="dossier-meta">${metaLine}</div>
+      </div>
+      <div class="dossier-grid">
+        ${mainCol}
+        ${railCol}
+      </div>`;
+  }
+
+  function renderMissing() {
+    if (statusEl) statusEl.innerHTML = '<span class="dot" style="background:#f85149;box-shadow:0 0 6px #f85149"></span>Not found';
+    root.innerHTML = `<div class="empty-placeholder">This finding was not found — it may have been cleared or archived.
+      <div style="margin-top:1rem"><a class="detail-link" href="/">&#8592; Back to all findings</a></div></div>`;
+    document.title = 'Finding not found · Pentest Dashboard';
+  }
+
+  async function poll() {
+    if (!fid) { renderMissing(); return; }
+    try {
+      const r = await fetch('/api/findings/' + encodeURIComponent(fid) + '?_=' + Date.now());
+      if (r.status === 404) { renderMissing(); return; }
+      if (!r.ok) throw new Error('bad');
+      const data = await r.json();
+      const key = JSON.stringify(data);
+      if (key === _lastKey) return;      // nothing changed — skip re-render
+      _lastKey = key;
+      render(data);
+    } catch (e) {
+      if (statusEl && !root.innerHTML) statusEl.textContent = 'Waiting for the dashboard API…';
+    }
+  }
+
+  // Copy-button delegation.
+  document.addEventListener('click', (ev) => {
+    const btn = ev.target.closest('.dossier-copy');
+    if (!btn) return;
+    let text = '';
+    try { text = decodeURIComponent(escape(atob(btn.getAttribute('data-copy') || ''))); } catch (_) {}
+    navigator.clipboard.writeText(text).then(() => {
+      const orig = btn.textContent;
+      btn.classList.add('copied');
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.classList.remove('copied'); btn.textContent = orig; }, 1600);
+    }).catch(() => {});
+  });
+
+  poll();
+  setInterval(poll, POLL_MS);
+})();

--- a/dashboard/js/findings.js
+++ b/dashboard/js/findings.js
@@ -50,6 +50,23 @@
   function renderStats(findings) {
     const c = { all: findings.length, critical:0, high:0, medium:0, low:0, info:0 };
     findings.forEach(f => { if (c[f.severity] !== undefined) c[f.severity]++; });
+
+    // Overview: a slim severity-distribution bar — the risk profile at a glance.
+    const ov = document.getElementById('findings-overview');
+    if (ov) {
+      const total = c.all || 0;
+      const segs = ['critical','high','medium','low','info']
+        .filter(s => c[s] > 0)
+        .map(s => `<span class="sevbar-seg sevbar-${s}" style="flex:${c[s]}" title="${s}: ${c[s]}"></span>`)
+        .join('');
+      ov.innerHTML = total
+        ? `<div class="fx-overview">
+             <div class="fx-ov-count"><span class="fx-ov-num">${total}</span> finding${total===1?'':'s'}</div>
+             <div class="sevbar">${segs}</div>
+           </div>`
+        : '';
+    }
+
     document.getElementById('stats').innerHTML =
       ['all','critical','high','medium','low','info'].map(s =>
         `<span class="stat stat-${s}${filter===s?' active':''}" onclick="setFilter('${s}')">
@@ -69,38 +86,65 @@
       ).join('');
   }
 
+  const SEV_GROUPS = ['critical', 'high', 'medium', 'low', 'info'];
+
   function renderFindingsTable(findings) {
-    // Detail view takes over the pane when a finding is open (progressive disclosure).
-    if (_openFindingId) {
-      const wrapEl = document.getElementById('findings-wrap');
-      const f = (findings || []).find(x => x.id === _openFindingId);
-      if (f && wrapEl) { wrapEl.innerHTML = renderFindingDetail(f); return; }
-      _openFindingId = null;  // finding vanished (cleared) → fall back to the grid
-    }
     let filtered = filter === 'all' ? findings : findings.filter(f => f.severity === filter);
     if (vfilter !== 'all') filtered = filtered.filter(f => f.verification_status === vfilter);
+
     const wrap = document.getElementById('findings-wrap');
     if (!filtered.length) {
       wrap.innerHTML = '<div class="empty-placeholder">No findings' +
-        (filter !== 'all' || vfilter !== 'all' ? ` matching current filters` : ' yet — run a scan.') + '</div>';
+        (filter !== 'all' || vfilter !== 'all' ? ' matching current filters' : ' yet — run a scan.') + '</div>';
       return;
     }
-    // Group into severity SECTIONS (critical → info); within a section, order by
-    // verification (unverified first — needs attention) then newest first. Each
-    // section is a responsive grid of uniform, scannable cards.
-    const SEVS = ['critical', 'high', 'medium', 'low', 'info'];
-    const bySev = {};
-    filtered.forEach(f => { (bySev[f.severity] = bySev[f.severity] || []).push(f); });
-    wrap.innerHTML = SEVS.filter(s => bySev[s] && bySev[s].length).map(s => {
-      const cards = bySev[s].sort((a, b) =>
-        ((VS_ORDER[a.verification_status] ?? 9) - (VS_ORDER[b.verification_status] ?? 9))
-        || (new Date(b.timestamp) - new Date(a.timestamp))
-      ).map(f => cardHTML(f)).join('');
-      return `<div class="finding-section">
-        <div class="finding-section-head sev-${s}"><span class="fs-dot"></span>${s.toUpperCase()}<span class="fs-count">${bySev[s].length}</span></div>
-        <div class="finding-cards">${cards}</div>
-      </div>`;
+
+    // Group by severity, most severe first; within a group order by verification
+    // confidence, then newest. Reads like a triage board.
+    const groups = {};
+    filtered.forEach(f => { (groups[f.severity] = groups[f.severity] || []).push(f); });
+    const html = SEV_GROUPS.filter(s => groups[s] && groups[s].length).map(s => {
+      const items = groups[s].sort((a, b) => {
+        const vd = (VS_ORDER[a.verification_status]??9) - (VS_ORDER[b.verification_status]??9);
+        return vd !== 0 ? vd : new Date(b.timestamp) - new Date(a.timestamp);
+      });
+      return `<section class="fx-section">
+        <div class="fx-section-head fx-head-${s}">
+          <span class="fx-head-dot"></span>
+          <span class="fx-head-name">${s}</span>
+          <span class="fx-head-count">${items.length}</span>
+        </div>
+        <div class="fx-grid">${items.map(tileHTML).join('')}</div>
+      </section>`;
     }).join('');
+    wrap.innerHTML = html;
+  }
+
+  // Compact finding tile — the whole tile is a same-tab link to the dossier.
+  function tileHTML(f) {
+    const isNew = freshIds.has(f.id);
+    const vs    = f.verification_status || 'unverified';
+    const ts    = new Date(f.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const newBadge = isNew ? '<span class="new-badge">NEW</span>' : '';
+    const fpBadge  = f.status === 'false_positive'
+      ? '<span class="badge" style="background:rgba(107,104,144,.2);color:var(--text-dim)">FP</span>' : '';
+    const line = f.business_impact || f.description || '';
+    const foot = [
+      f.target    ? `<span class="meta-chip chip-target">${esc(f.target)}</span>` : '',
+      f.tool_used ? `<span class="meta-chip chip-tool">${esc(f.tool_used)}</span>` : '',
+      f.cve       ? `<span class="meta-chip chip-cve">${esc(f.cve)}</span>` : '',
+      f.adjudication?.rationale ? '<span class="fx-triaged" title="Senior-reviewed">⚖</span>' : '',
+    ].filter(Boolean).join('');
+    return `<a class="fx-tile sev-${f.severity}" href="/finding/${encodeURIComponent(f.id)}">
+      <div class="fx-tile-top">
+        <span class="badge badge-${f.severity}"><span class="sev-dot"></span>${f.severity}</span>${fpBadge}
+        <span class="fx-grow"></span>
+        <span class="vbadge vbadge-${vs}" title="Verification: ${vs.replace(/_/g,' ')}">${VS_LABELS[vs] || vs}</span>
+      </div>
+      <div class="fx-tile-title">${esc(f.title)}${newBadge}</div>
+      ${line ? `<div class="fx-tile-line">${esc(line)}</div>` : ''}
+      <div class="fx-tile-foot">${foot}<span class="fx-grow"></span><span class="fx-time">${ts}</span></div>
+    </a>`;
   }
 
   const SEV_RANK = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
@@ -134,101 +178,18 @@
       </div>`;
   }
 
-  // ── Full finding detail view (progressive disclosure: card → click → detail) ──
-  let _openFindingId = null;
-
-  function openFinding(id) {
-    _openFindingId = id;
-    renderFindingsTable(allData.findings || []);
-    window.scrollTo(0, 0);
-  }
-  function closeFinding() {
-    _openFindingId = null;
-    renderFindingsTable(allData.findings || []);
-  }
-  function copyEvidence(btn, findingId) {
-    const f = (allData.findings || []).find(x => x.id === findingId);
-    if (!f?.evidence) return;
-    navigator.clipboard.writeText(f.evidence).then(() => {
-      const t = btn.textContent; btn.textContent = 'Copied!';
-      setTimeout(() => { btn.textContent = t; }, 1500);
-    });
+  // Open a finding's detail page in the SAME tab. Bound to the whole card;
+  // bail out when the click landed on an interactive child (button / link) so
+  // those keep their own behaviour and we don't navigate twice.
+  function openFinding(ev, id) {
+    if (ev && ev.target && ev.target.closest('button, a')) return;
+    window.location.assign('/finding/' + encodeURIComponent(id));
   }
 
-  function _rail(label, val) {
-    return `<div class="fd-rail-k">${esc(label)}</div><div class="fd-rail-v">${val}</div>`;
-  }
-
-  function renderFindingDetail(f) {
-    const vs = f.verification_status || 'unverified';
-    const ts = f.timestamp ? new Date(f.timestamp).toLocaleString() : '—';
-    const triaged = f.adjudication?.rationale ? `<span class="triaged-badge">⚖ Triaged</span>` : '';
-    const sevVal  = `<span class="badge badge-${esc(f.severity)}">${esc(f.severity)}</span>`;
-    const idCopy  = `<span class="fd-id">${esc(f.id)}</span>` +
-                    `<button class="fd-copy" onclick="copyFindingId(this,'${esc(f.id)}')">copy</button>`;
-    const evidence = f.evidence ? `
-      <div class="fd-sec-head">Evidence <button class="fd-copy" onclick="copyEvidence(this,'${esc(f.id)}')">Copy evidence</button></div>
-      <pre class="evidence">${esc(f.evidence)}</pre>` : '';
-    const repro = f.reproduction?.command ? `
-      <div class="fd-sec-head">Reproduction <button class="fd-copy" onclick="copyReplay(this,'${esc(f.id)}')">▸ Copy command</button></div>
-      <pre class="evidence">${esc(f.reproduction.command)}</pre>
-      ${f.reproduction.expected ? `<div class="fd-expected">expected: ${esc(f.reproduction.expected)}</div>` : ''}` : '';
-    const seniorReview = f.adjudication?.rationale ? _adjudicationBlock(f.adjudication) : '';
-    const pocs = (f.poc_files && f.poc_files.length)
-      ? `<div class="fd-rail-box"><div class="fd-rail-title">PoC files</div>${
-          f.poc_files.map(p => `<div class="fd-poc">${esc(p)}</div>`).join('')}</div>` : '';
-    const remediation = f.remediation ? `<div class="fd-block">${buildFixDetail(f).replace('display:none', 'display:block')}</div>` : '';
-    const impact = f.business_impact ? `
-      <div class="finding-impact"><span class="finding-impact-icon">&#9888;</span>
-      <span class="finding-impact-label">Business impact&nbsp;&nbsp;</span>
-      <span class="finding-impact-text">${esc(f.business_impact)}</span></div>` : '';
-
-    return `<div class="fd-view">
-      <button class="fd-back" onclick="closeFinding()">← All findings</button>
-      <div class="fd-hero sev-${esc(f.severity)}">
-        <div class="fd-hero-badges">${sevVal}<span class="vbadge vbadge-${vs}">${VS_LABELS[vs] || vs}</span>${triaged}</div>
-        <h2 class="fd-title">${esc(f.title)}</h2>
-        <div class="fd-hero-meta"><span class="target">${esc(f.target)}</span>
-          ${f.tool_used ? `<span class="tool">${esc(f.tool_used)}</span>` : ''}
-          <span class="finding-ts-meta">first seen ${ts}</span></div>
-      </div>
-      <div class="fd-body">
-        <div class="fd-main">
-          ${f.description ? `<div class="fd-sec-head">Description</div><div class="finding-desc">${esc(f.description)}</div>` : ''}
-          ${impact}
-          ${evidence}
-          ${repro}
-          ${remediation}
-        </div>
-        <aside class="fd-rail">
-          <div class="fd-rail-box fd-rail-grid">
-            ${_rail('Severity', sevVal)}
-            ${_rail('Verification', `<span class="vbadge vbadge-${vs}">${VS_LABELS[vs] || vs}</span>`)}
-            ${_rail('Target', esc(f.target))}
-            ${_rail('Tool', esc(f.tool_used || '—'))}
-            ${_rail('Status', esc(f.status || 'confirmed'))}
-            ${_rail('First seen', esc(ts))}
-            ${_rail('Finding ID', idCopy)}
-            ${f.cve ? _rail('CVE', esc(f.cve)) : ''}
-          </div>
-          ${seniorReview}
-          ${pocs}
-        </aside>
-      </div>
-    </div>`;
-  }
-
-  function copyFindingId(btn, id) {
-    navigator.clipboard.writeText(id).then(() => {
-      const t = btn.textContent; btn.textContent = 'copied'; setTimeout(() => { btn.textContent = t; }, 1500);
-    });
-  }
-
-  function cardHTML(f) {
+  function cardHTML(f, openIds) {
     const isNew    = freshIds.has(f.id);
     const ts       = new Date(f.timestamp).toLocaleTimeString();
     const newBadge = isNew ? '<span class="new-badge">NEW</span>' : '';
-    const cve      = f.cve ? `<span class="cve">CVE: ${esc(f.cve)}</span>` : '';
     const statusBadge = f.status === 'false_positive'
       ? `<span class="badge" style="background:rgba(107,104,144,.2);color:var(--text-dim);margin-left:.4rem">false positive</span>`
       : '';
@@ -237,20 +198,47 @@
       : '';
     const vs = f.verification_status || 'unverified';
     const vsBadge = `<span class="vbadge vbadge-${vs}" title="Verification status: ${vs.replace(/_/g,' ')}">${VS_LABELS[vs] || vs}</span>`;
-    // Clean, uniform card — a scannable summary. Evidence, reproduction, senior
-    // review and PoC all live in the click-through detail view (openFinding).
-    return `<div class="finding-card sev-${f.severity}" onclick="openFinding('${esc(f.id)}')" title="Open full detail">
-      <div class="finding-card-top">
-        <span class="badge badge-${f.severity}">${f.severity}</span>${statusBadge}${triagedBadge}
-        <span class="finding-vs-right">${vsBadge}</span>
+    const ghBtn = f.gh_issue
+      ? `<button class="copy-gh-btn" data-id="${esc(f.id)}" onclick="copyGhIssue(this,this.dataset.id)" title="Copy GitHub issue">
+           <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+             <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/>
+           </svg>
+           GH Issue
+         </button>`
+      : '';
+    const replayBtn = f.reproduction?.command
+      ? `<button class="replay-btn" data-id="${esc(f.id)}" onclick="copyReplay(this,this.dataset.id)" title="Copy reproduction command">&#9654; Replay</button>`
+      : '';
+    const detailHref = '/finding/' + encodeURIComponent(f.id);
+    const metaChips = [
+      f.target    ? `<span class="meta-chip chip-target">${esc(f.target)}</span>` : '',
+      f.tool_used ? `<span class="meta-chip chip-tool">${esc(f.tool_used)}</span>` : '',
+      f.cve       ? `<span class="meta-chip chip-cve">${esc(f.cve)}</span>` : '',
+    ].filter(Boolean).join('');
+    // One body line, scannable: lead with the "so what" (business impact) when we
+    // have it, else the technical description. Both live in full on the dossier.
+    const body = f.business_impact
+      ? `<div class="fc-body fc-body-impact"><span class="fc-impact-tag">&#9888; Impact</span>${esc(f.business_impact)}</div>`
+      : (f.description ? `<div class="fc-body">${esc(f.description)}</div>` : '');
+    return `<div class="finding-card sev-${f.severity}" onclick="openFinding(event,'${esc(f.id)}')" title="Open finding detail">
+      <div class="fc-top">
+        <div class="fc-top-left">
+          <span class="badge badge-${f.severity}"><span class="sev-dot"></span>${f.severity}</span>${statusBadge}
+        </div>
+        <div class="fc-top-right">
+          ${triagedBadge}${vsBadge}
+          <span class="finding-ts-meta">${ts}</span>
+          <span class="finding-open-cue" aria-hidden="true">&#8594;</span>
+        </div>
       </div>
-      <div class="finding-title">${esc(f.title)}${newBadge}</div>
-      ${f.description ? `<div class="finding-desc">${esc(f.description)}</div>` : ''}
-      <div class="finding-card-foot">
-        <span class="target">${esc(f.target)}</span>
-        ${f.tool_used ? `<span class="tool">${esc(f.tool_used)}</span>` : ''}
-        ${cve}
-        <span class="finding-ts-meta">${ts}</span>
+      <a class="finding-title-link" href="${detailHref}">
+        <h3 class="finding-title">${esc(f.title)}${newBadge}</h3>
+      </a>
+      ${metaChips ? `<div class="finding-meta-row">${metaChips}</div>` : ''}
+      ${body}
+      <div class="finding-footer">
+        ${replayBtn}${ghBtn}
+        <a class="detail-link" href="${detailHref}">View detail &#8594;</a>
       </div>
     </div>`;
   }

--- a/dashboard/js/shared.js
+++ b/dashboard/js/shared.js
@@ -1,0 +1,142 @@
+  // ============================================================================
+  //  shared.js — security-critical core shared by the dashboard shell (index.html)
+  //  and the standalone finding detail page (finding.html).
+  //
+  //  Loaded FIRST on both pages, before common.js / findings.js / finding.js.
+  //  These definitions used to live in common.js; they were lifted here so the
+  //  detail page (opened in a new browser tab) authenticates with the SAME token
+  //  logic instead of a drifting copy. Keep this the only place they are defined.
+  // ============================================================================
+
+  // ── Dashboard auth: per-session bearer token ────────────────────────────────
+  // The MCP server mints a random token when a scan starts and prints the
+  // dashboard URL with it in the fragment (…/#k=<token>). Capture it into
+  // sessionStorage (never sent to the server via the URL), strip it from the
+  // address bar, and attach it as `Authorization: Bearer …` on every same-origin
+  // API call. A finding detail page opened from a same-origin link inherits a
+  // copy of this sessionStorage, so it authenticates without its own #k= fragment.
+  (function initDashboardAuth() {
+    const KEY = 'smith_dash_token';
+    function token() {
+      try { return sessionStorage.getItem(KEY) || ''; } catch (_) { return ''; }
+    }
+    try {
+      const m = (location.hash || '').match(/[#&]k=([^&]+)/);
+      if (m) {
+        sessionStorage.setItem(KEY, decodeURIComponent(m[1]));
+        history.replaceState(null, '', location.pathname + location.search);
+      }
+    } catch (_) { /* storage unavailable — wrapper simply no-ops */ }
+
+    const _origFetch = window.fetch.bind(window);
+    window.fetch = function (input, init) {
+      let sameOrigin = true;
+      try {
+        const raw = (typeof input === 'string') ? input : (input && input.url) || '';
+        sameOrigin = new URL(raw, location.href).origin === location.origin;
+      } catch (_) { sameOrigin = true; }
+      const t = token();
+      if (sameOrigin && t) {
+        init = init ? Object.assign({}, init) : {};
+        const h = new Headers(init.headers || (typeof input !== 'string' && input && input.headers) || {});
+        if (!h.has('Authorization')) h.set('Authorization', 'Bearer ' + t);
+        init.headers = h;
+      }
+      return _origFetch(input, init);
+    };
+
+    // No token yet (bare URL / bookmark)? Ask once — the CLI prints the key with
+    // the dashboard URL. Blank just leaves calls unauthenticated, which is fine
+    // before a scan has started (nothing sensitive is served).
+    try {
+      if (!token()) {
+        const pasted = window.prompt(
+          'Dashboard key required.\nPaste the key printed with the dashboard URL ' +
+          '(leave blank if no scan has started yet):'
+        );
+        if (pasted) sessionStorage.setItem(KEY, pasted.trim());
+      }
+    } catch (_) { /* non-interactive context */ }
+  })();
+
+  // ── HTML escape ─────────────────────────────────────────────────────────────
+  // The single output-escaping primitive. All scan-derived strings pass through
+  // this before hitting innerHTML.
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  // ── HTML sanitizer for untrusted markdown (threat-model tab, remediation) ────
+  // marked@9 passes raw HTML through, and scan-derived markdown embeds
+  // attacker-influenced recon strings. Render marked's output through this
+  // allow-list DOM sanitizer before innerHTML so injected tags / event handlers
+  // / scripts / javascript: URLs cannot execute. Keeps <pre><code class=…> so the
+  // mermaid post-processing still finds language-mermaid blocks.
+  const _SANITIZE_ALLOWED_TAGS = new Set([
+    'A','P','DIV','SPAN','BR','HR','PRE','CODE','BLOCKQUOTE','KBD','SMALL',
+    'H1','H2','H3','H4','H5','H6','UL','OL','LI','STRONG','EM','B','I','U',
+    'DEL','INS','SUP','SUB','TABLE','THEAD','TBODY','TFOOT','TR','TH','TD','DL','DT','DD','IMG',
+  ]);
+  const _SANITIZE_ALLOWED_ATTRS = new Set([
+    'href','src','alt','title','class','colspan','rowspan','align','start',
+  ]);
+  const _SANITIZE_DROP_TAGS = new Set([
+    'SCRIPT','STYLE','IFRAME','OBJECT','EMBED','FORM','LINK','META','BASE','SVG','MATH','TEMPLATE',
+  ]);
+  function sanitizeHtml(html) {
+    const doc = new DOMParser().parseFromString(String(html), 'text/html');
+    const walk = (root) => {
+      [...root.children].forEach((el) => {
+        const tag = el.tagName;
+        if (!_SANITIZE_ALLOWED_TAGS.has(tag)) {
+          if (_SANITIZE_DROP_TAGS.has(tag)) { el.remove(); return; }
+          const span = doc.createElement('span');   // unwrap unknown tags to text
+          span.textContent = el.textContent;
+          el.replaceWith(span);
+          return;
+        }
+        [...el.attributes].forEach((a) => {
+          const name = a.name.toLowerCase();
+          if (!_SANITIZE_ALLOWED_ATTRS.has(name)) { el.removeAttribute(a.name); return; }
+          if (name === 'href' || name === 'src') {
+            const v = (a.value || '').replace(/[\u0000-\u0020]+/g, '').toLowerCase();
+            if (v.startsWith('javascript:') || v.startsWith('vbscript:') ||
+                (v.startsWith('data:') && !v.startsWith('data:image/'))) {
+              el.removeAttribute(a.name);
+            }
+          }
+        });
+        walk(el);
+      });
+    };
+    walk(doc.body);
+    return doc.body.innerHTML;
+  }
+
+  // ── Mermaid theme (matches the threat-model / topology dark rendering) ───────
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: 'base',
+    themeVariables: {
+      background: '#0d1117',
+      primaryColor: '#1f2937',
+      primaryTextColor: '#e5e7eb',
+      primaryBorderColor: '#374151',
+      secondaryColor: '#1e3a5f',
+      secondaryTextColor: '#e5e7eb',
+      secondaryBorderColor: '#2563eb',
+      tertiaryColor: '#2d1f3d',
+      tertiaryTextColor: '#e5e7eb',
+      tertiaryBorderColor: '#7c3aed',
+      lineColor: '#6b7280',
+      textColor: '#e5e7eb',
+      noteBkgColor: '#1e293b',
+      noteTextColor: '#cbd5e1',
+      noteBorderColor: '#334155',
+      fontSize: '14px',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    },
+    flowchart: { curve: 'linear', htmlLabels: false },
+  });

--- a/dashboard/tabs/activity.html
+++ b/dashboard/tabs/activity.html
@@ -1,5 +1,6 @@
 <!-- ── Tab: Activity (QA alerts + Steering + Tool log + Conversation) ── -->
 <div id="tab-activity" class="tab-content">
+  <div class="tab-head"><h2>Activity</h2><p>Live feed — stalls, QA checks, steering directives, and tool calls.</p></div>
   <!-- Stuck Events log -->
   <div class="activity-section">
     <div class="activity-section-header">

--- a/dashboard/tabs/components.html
+++ b/dashboard/tabs/components.html
@@ -1,4 +1,5 @@
 <!-- ── Tab: Components ───────────────────────────────────────────────────── -->
 <div id="tab-components" class="tab-content">
+  <div class="tab-head"><h2>Components</h2><p>Findings grouped by the application component they affect.</p></div>
   <div id="components-wrap"></div>
 </div>

--- a/dashboard/tabs/coverage.html
+++ b/dashboard/tabs/coverage.html
@@ -1,9 +1,10 @@
 <!-- ── Tab: Coverage ────────────────────────────────────────────────────── -->
 <div id="tab-coverage" class="tab-content">
-  <p style="font-size:.8rem;color:#8b949e;margin:0 0 .75rem;padding:.5rem .75rem;background:#161b22;border:1px solid #30363d;border-radius:6px">
-    <strong style="color:#f0f6fc">Coverage matrix</strong> tracks web endpoint &amp; parameter injection testing (SQLi, XSS, SSRF, etc.).
-    Post-exploitation skills (<code style="font-size:.75rem">network-assess</code>, <code style="font-size:.75rem">post-exploit</code>, <code style="font-size:.75rem">lateral-movement</code>, etc.)
-    operate at the OS/network layer and are tracked separately in the <strong style="color:#f0f6fc">Skills</strong> tab.
+  <div class="tab-head"><h2>Coverage</h2><p>Endpoint × parameter × injection-type test matrix.</p></div>
+  <p class="tab-note">
+    <strong>Coverage matrix</strong> tracks web endpoint &amp; parameter injection testing (SQLi, XSS, SSRF, etc.).
+    Post-exploitation skills (<code>network-assess</code>, <code>post-exploit</code>, <code>lateral-movement</code>, etc.)
+    operate at the OS/network layer and are tracked separately in the <strong>Skills</strong> tab.
   </p>
   <div id="coverage-summary"></div>
   <div id="coverage-wrap"><div class="empty-placeholder">No coverage data yet — run a scan with web-exploit.</div></div>

--- a/dashboard/tabs/findings.html
+++ b/dashboard/tabs/findings.html
@@ -1,5 +1,6 @@
 <!-- ── Tab: Findings ─────────────────────────────────────────────────────── -->
-<div id="tab-findings" class="tab-content">
+<div id="tab-findings" class="tab-content active">
+  <div id="findings-overview"></div>
   <div id="stats"></div>
   <div id="vstats"></div>
   <div id="findings-wrap"><div class="empty-placeholder">No findings yet — run a scan.</div></div>

--- a/dashboard/tabs/metrics.html
+++ b/dashboard/tabs/metrics.html
@@ -1,9 +1,6 @@
 <!-- ── Tab: Metrics ──────────────────────────────────────────────────────── -->
 <div id="tab-metrics" class="tab-content">
-  <div style="display:flex;align-items:center;gap:1rem;margin-bottom:0.75rem">
-    <span class="qa-label">Run Efficiency Metrics</span>
-    <span id="metrics-updated" style="font-size:0.72rem;color:var(--text-dim)"></span>
-  </div>
+  <div class="tab-head"><h2>Run Efficiency Metrics</h2><p>Per-run cost, coverage, and finding efficiency. <span id="metrics-updated" style="color:var(--text-dim)"></span></p></div>
   <div id="metrics-wrap">
     <div class="empty-placeholder">No completed scans yet — metrics appear after session(action='complete').</div>
   </div>

--- a/dashboard/tabs/skills.html
+++ b/dashboard/tabs/skills.html
@@ -1,5 +1,6 @@
 <!-- ── Tab: Skills ───────────────────────────────────────────────────────── -->
 <div id="tab-skills" class="tab-content">
+  <div class="tab-head"><h2>Skills</h2><p>Which skills the agent has run during this assessment.</p></div>
   <p class="skills-intro">
     Use this view to trace which skills have been invoked during the current test.
     Each card turns green once the agent has run that skill. If you expected a skill

--- a/dashboard/tabs/topology.html
+++ b/dashboard/tabs/topology.html
@@ -1,5 +1,6 @@
 <!-- ── Tab: Topology ─────────────────────────────────────────────────────── -->
 <div id="tab-topology" class="tab-content">
+  <div class="tab-head"><h2>Topology</h2><p>Architecture and attack-surface diagrams produced during the scan.</p></div>
   <div id="diagrams-wrap">
     <div class="empty-placeholder">No diagrams yet — Claude calls report_diagram during a scan.</div>
   </div>

--- a/dashboard/tabs/world-model.html
+++ b/dashboard/tabs/world-model.html
@@ -1,17 +1,23 @@
 <div id="tab-world-model" class="tab-content">
   <div id="wm-stats" class="wm-stats"></div>
+
+  <!-- Kill-chains are the payoff of the graph — give them the full width. -->
+  <section class="wm-panel wm-chains-panel">
+    <h3 class="wm-h">Proposed kill-chains <span class="wm-sub">graph-derived — prove &amp; file</span></h3>
+    <div id="wm-chains" class="wm-chains"></div>
+  </section>
+
   <div class="wm-grid">
-    <section class="wm-panel">
-      <h3 class="wm-h">Proposed kill-chains <span class="wm-sub">graph-derived — prove &amp; file</span></h3>
-      <div id="wm-chains" class="wm-chains"></div>
-    </section>
     <section class="wm-panel">
       <h3 class="wm-h">Deepen next <span class="wm-sub">highest-value findings</span></h3>
       <div id="wm-findings" class="wm-list"></div>
-      <h3 class="wm-h wm-h-mt">High-value untested <span class="wm-sub">value-ranked endpoints</span></h3>
+    </section>
+    <section class="wm-panel">
+      <h3 class="wm-h">High-value untested <span class="wm-sub">value-ranked endpoints</span></h3>
       <div id="wm-targets" class="wm-list"></div>
     </section>
   </div>
+
   <section class="wm-panel wm-graph-panel">
     <h3 class="wm-h">World model <span class="wm-sub">hosts · endpoints · params · findings · principals</span></h3>
     <div id="wm-graph" class="wm-graph"></div>

--- a/docs/dashboard-redesign-plan.md
+++ b/docs/dashboard-redesign-plan.md
@@ -1,0 +1,346 @@
+# Dashboard Redesign Plan
+
+A visual + structural redesign of the pentest dashboard that **keeps every colour
+and the logo exactly as they are**, moves navigation to a **left sidebar**, makes
+the whole thing easier to read, and adds a **click-through finding detail page that
+opens in a new browser tab**.
+
+---
+
+## 1. Goals & hard constraints
+
+**What you asked for**
+1. Redesign the dashboard — better visual hierarchy, more readable, "visually pretty".
+2. Keep all the colours and the logo.
+3. Click a finding → open a richer detail view **in a new tab**.
+4. Move the navigation menu to the **left side**.
+
+**Fixed — do not touch**
+- The palette. Every `:root` token stays: `--bg #13112e`, `--bg-card #1a1840`,
+  `--bg-raised #2d2b55`, `--green #5bf29b`, `--purple #7b78ff`, and the severity
+  colours (`#ff4d4f / #fa8c16 / #faad14 / green / purple`). No new hues.
+- The logo (`/logo.png` → `FullLogo_Transparent.png`) and favicons.
+- Every data contract and behaviour: 5 s polling, the Command Center (steer/complete/
+  force-stop/triage), the HIR intervention panel, all 10 tabs, auth token flow, CSP.
+
+**Interpretation of "new tab"** — a real **browser tab** serving a standalone
+`/finding/<id>` page (not an 11th in-dashboard tab). This is the stronger UX: the URL
+is deep-linkable and shareable, right-click / middle-click / ⌘-click work natively, and
+the operator can keep the live scan open in one tab while reading a finding in another.
+If you actually meant an in-app panel, the same detail markup drops into a tab instead —
+say so and I'll pivot; everything else in this plan is unaffected.
+
+---
+
+## 2. Where things stand today (so scope is honest)
+
+- **Frontend** lives in `dashboard/`: one `index.html` shell that Jinja `{% include %}`s
+  10 tab partials from `dashboard/tabs/*.html`, styled by a single **985-line**
+  `dashboard/css/dashboard.css`, driven by per-tab JS in `dashboard/js/*.js`
+  (`common.js` is the shared core: auth shim, `esc()`, sanitizer, `switchTab`, polling).
+- **Served** by FastAPI in `core/api_server/`: `dashboard_routes.py` renders `/` via
+  Jinja2; `/static` is mounted at `dashboard/`; findings come from `GET /api/findings`
+  (returns *all* findings + diagrams + chains, mermaid pre-rendered server-side).
+- **Findings today** render as stacked cards in `findings.js::cardHTML()` with a
+  severity left-border, badges, inline description, and expandable evidence + Replay/Fix/
+  GH-issue buttons. There is **no per-finding route and no detail view** — every field is
+  crammed into the card or hidden in a `<details>`.
+- **Navigation today** is a horizontal `<nav class="tab-nav">` of 10 `.tab-btn`s below
+  the Command Center; `switchTab(name)` toggles `.tab-content.active` and kicks the
+  relevant poller.
+- **Auth** (important for the new tab): a scan mints a bearer token delivered in the URL
+  fragment `#k=…`; `common.js` stores it in `sessionStorage[smith_dash_token]` and a
+  patched `window.fetch` attaches `Authorization: Bearer …` to same-origin `/api/*` calls.
+  `sessionStorage` **is copied into a new tab opened from a same-origin link**, so a
+  detail page opened via `target="_blank"` authenticates automatically — *provided it
+  loads the same auth shim*.
+
+The design system is almost entirely CSS + a few JS render functions. That makes this a
+**low-risk, CSS-led redesign plus additive backend routes** — no change to how scans run.
+
+---
+
+## 3. Design language (refinement, not reinvention)
+
+The brief pins the palette and logo, so craft goes into **typography rhythm, spacing,
+hierarchy, and one signature element** — not new colours.
+
+### 3.1 Keep the fonts, fix the scale
+The existing trio is already characterful and stays: **Chakra Petch** (display/labels),
+**Outfit** (body), **IBM Plex Mono** (data/evidence/metrics). Today everything is tiny and
+flat (`h1` is 1.05 rem; most text 0.7–0.8 rem), which reads as cramped. Introduce a real
+type scale as CSS variables:
+
+| Role | Font | Size / weight | Use |
+|---|---|---|---|
+| Page title | Chakra Petch | 1.5 rem / 600 | header brand line |
+| Section head | Chakra Petch | 1.0 rem / 600, +0.03em | tab titles, detail-page section labels |
+| Card / finding title | Outfit | 0.95 rem / 600 | finding titles |
+| Body | Outfit | 0.875 rem / 400 (**up from ~0.8**) | descriptions, impact |
+| Label / eyebrow | IBM Plex Mono | 0.7 rem / 600 uppercase, +0.08em | field labels, meta |
+| Data / evidence | IBM Plex Mono | 0.8 rem | `<pre>`, metrics, IDs |
+
+### 3.2 Spacing on a 4 px grid
+Add `--sp-1:4px … --sp-6:24px` and use them consistently. The current mix of
+`0.3/0.4/0.55/0.75rem` ad-hoc gaps is what makes it feel noisy. One rhythm = calmer page.
+
+### 3.3 Promote severity to shared tokens
+Lift the severity colours (currently duplicated across `.stat-*`, `.badge-*`, `.sev-*`)
+into `:root` so the list **and** the new detail page share one source of truth:
+
+```css
+:root{
+  --sev-critical:#ff4d4f; --sev-high:#fa8c16; --sev-medium:#faad14;
+  --sev-low:var(--green); --sev-info:var(--purple);
+}
+```
+
+Severity becomes the primary organizing signal everywhere: a coloured **spine** (left
+border), a filled badge, and a matching subtle glow — consistent between card and dossier.
+
+### 3.4 Motion — restrained
+Keep the existing live-`dot` pulse and HIR pulse. Add only: a hover *lift* on finding
+cards (translateY-1px + border brighten), and a one-shot fade/slide-in for the detail
+page masthead. Everything wrapped in `@media (prefers-reduced-motion: reduce)`.
+
+**Signature element:** the per-finding **"dossier"** detail page (§6) — the one place we
+spend boldness. The main dashboard stays quiet and disciplined around it.
+
+---
+
+## 4. New shell: left sidebar navigation
+
+Replace the top `tab-nav` with a fixed **left rail**; the rest of the app moves into a
+main column to its right.
+
+```
+┌──────────────┬─────────────────────────────────────────────────────────┐
+│  [ LOGO ]     │  status: ● Live · target · scan/smith state   (sticky)  │
+│  Pentest      │─────────────────────────────────────────────────────────│
+│  Dashboard    │  ┌─── Command Center (steer / complete / triage) ────┐  │
+│              │  │  target · phase · cov ▓▓▓░ · cost      Instruct… │  │
+│ ▸ Findings  12│  └───────────────────────────────────────────────────┘  │
+│   Topology    │  ┌─── HIR panel (only when scan paused) ─────────────┐  │
+│   Components  │  └───────────────────────────────────────────────────┘  │
+│   Coverage 73%│                                                          │
+│   Skills      │   ── active tab content (Findings by default) ──        │
+│   Activity    │   [ ALL 12 ][ CRIT 2 ][ HIGH 4 ]…   verify: …           │
+│   Threat Model│   ┌───────────────────────────────────────────────┐    │
+│   Metrics     │   │ finding card → opens detail in new tab ↗       │    │
+│   Setup Gates⚠│   └───────────────────────────────────────────────┘    │
+│   Logs        │                                                          │
+│               │                                                          │
+│  Cleanup ·    │                                                          │
+│  Clear All    │                                                          │
+└──────────────┴─────────────────────────────────────────────────────────┘
+```
+
+- **Rail** (~208 px): logo + brand at top, then the 10 nav items as a vertical list.
+  Each item = icon glyph + label, with the active item marked by a green left-accent bar +
+  raised background (`--bg-raised`). Nav items carry **live count/alert badges** driven by
+  existing polled data: Findings count, Coverage %, and the `⚠` Setup-Gates alert that
+  today hides in the Command Center. `Cleanup Tunnels` / `Clear All` move to the rail foot.
+- **Main column**: a **sticky** slim status strip (the current `#status` line), then the
+  Command Center, then the HIR panel (when active), then the active tab content.
+- **Behaviour preserved**: `switchTab()` keeps its signature and pollers; only the button
+  markup/container moves. `.tab-content.active` show/hide logic is unchanged.
+- **Responsive**: < 1100 px the rail collapses to a 56 px **icon-only** rail (labels on
+  hover-tooltip); < 720 px it becomes a top hamburger drawer. Content column is fluid.
+- **A11y**: rail is a `<nav aria-label="Sections">` with `aria-current="page"` on the
+  active item; full keyboard focus rings.
+
+---
+
+## 5. Findings list redesign (the default view)
+
+Keep the filter bars (`#stats` severity + `#vstats` verification) — just restyle them as
+quiet pill toggles. Rework the card into a **scannable summary row** and push the heavy
+detail (full evidence, remediation diff, adjudication, trace, chain) to the new detail page.
+
+```
+┌─ sev spine ─────────────────────────────────────────────────────── ↗ ─┐
+│ [CRITICAL]  ✓ CONFIRMED                                    14:32 · NEW │
+│ SQL injection in /api/users?id                                         │
+│ https://target/api/users   ·   sqlmap   ·   CVE-2024-1234             │
+│ ⚠ Attacker can dump the full user table…            (2-line clamp)     │
+│ [▶ Replay] [🔧 Fix] [⧉ GH Issue]                        Open detail ↗ │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+- **Whole card is a click target** to `/finding/<id>` (`window.open(_,'_blank')`), and the
+  **title is a real `<a target="_blank" rel="noopener">`** so native middle/⌘-click and
+  right-click "open in new tab" work. A small `↗` affordance top-right signals it.
+- Quick-action buttons (Replay/Fix/GH) stay on the card but call
+  `event.stopPropagation()` so they don't trigger navigation; the inline evidence
+  `<details>` is **removed from the card** (it lives on the detail page now) — this is what
+  makes the list finally scannable.
+- Description clamped to 2 lines; badges (severity, verification, triaged, false-positive)
+  restyled to one consistent height/rhythm.
+- `NEW` badge + fresh-id highlight behaviour preserved.
+
+---
+
+## 6. Signature: the Finding "Dossier" detail page  *(new browser tab)*
+
+A standalone page that reads like a case file, reusing the exact same theme/tokens.
+
+### 6.1 What it shows (maps every finding field the store can hold)
+`id, timestamp, title, severity, target, tool_used, cve, description, evidence,
+business_impact, verification_status, status, adjudication{reproducible, original/
+revised_severity, rationale, artifact_id}, remediation{summary, effort, breaking_change,
+diff, before, after, file/line/language, verification, references}, reproduction{command},
+trace[{kind, file, line, scope, description}], escalation_leads[], poc_files[],
+evidence_artifact_id`, plus any exploit **chain** that references this finding.
+
+### 6.2 Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ [LOGO]                                                  ← back to list │
+├─ sev spine ────────────────────────────────────────────────────────── │
+│ [CRITICAL]  ✓ CONFIRMED   ⚖ Triaged                                   │
+│ SQL injection in /api/users?id                                         │
+│ target · tool · CVE · first seen 14:32                                 │
+├───────────────────────────────────┬────────────────────────────────── │
+│  NARRATIVE (main, ~2fr)           │  METADATA RAIL (~1fr)             │
+│                                    │  Severity   CRITICAL              │
+│  ⚠ Business impact                 │  Verify     ✓ confirmed_dynamic   │
+│  Description (readable prose)      │  Target     …                     │
+│                                    │  Tool       sqlmap                │
+│  ── Data flow (trace) ──           │  CVE        CVE-2024-1234         │
+│  ① entrypoint  file:line   ┐       │  Finding ID …  (copy)             │
+│  │ propagation file:line   │ stepped│  First seen · Last update        │
+│  ▼ sink        file:line   ┘ timeline│                                  │
+│                                    │  ⚖ Senior review                  │
+│  ── Evidence ──                    │   reproducible ✓ · sev orig→rev   │
+│  <pre> … copy button …             │   rationale …                     │
+│                                    │                                   │
+│  ── Reproduction ──  [▶ copy cmd]  │  ▶ Reproduction command           │
+│  ── Remediation ──  effort · diff  │  ⧉ GitHub issue  [copy]           │
+│     before/after · verify · refs   │  PoC files: poc/…                 │
+│                                    │                                   │
+│  ── Exploit chain (if any) ──      │                                   │
+│     server-rendered mermaid kill-  │                                   │
+│     chain (MITRE-labelled)         │                                   │
+└───────────────────────────────────┴────────────────────────────────── │
+```
+
+- **Masthead**: severity spine + big title (Chakra Petch), verification/triaged badges,
+  compact meta line. One-shot fade/slide-in on load.
+- **Trace → vertical stepped timeline**: entrypoint → propagation(s) → sink, each step a
+  node with `file:line` in mono and a description. This is the white-box story made legible
+  — a real differentiator over the current buried text.
+- **Remediation**: reuse the existing `buildFixDetail` content (summary, effort badge,
+  breaking-change flag, diff, before/after, verification, references) but as a first-class
+  section, not a toggle.
+- **Chain**: if a `chains[]` entry lists this finding in its steps, render its
+  pre-rendered mermaid SVG (server already renders these in `/api/findings`).
+- **Live**: polls `GET /api/findings/<id>` every 5 s (same cadence), so adjudication /
+  remediation added mid-scan appear without a manual refresh. Falls back to a clean
+  "finding not found / archived" state on 404.
+- Same CSP, fonts, mermaid/marked includes, and **the same auth shim** as `index.html`.
+
+---
+
+## 7. Backend changes (small, additive)
+
+1. **Page route** — `core/api_server/routes/dashboard_routes.py`:
+   ```python
+   @router.get("/finding/{finding_id}")
+   async def finding_detail(request: Request, finding_id: str):
+       return _api.templates.TemplateResponse(
+           request, "finding.html", {"finding_id": finding_id})
+   ```
+   Ordering is safe (`/api/*` and `/static` don't collide). `finding_id` is echoed into a
+   `data-finding-id` attribute (Jinja auto-escaped) so the JS knows what to fetch.
+
+2. **JSON route** — `core/api_server/routes/findings_routes.py`:
+   ```python
+   @router.get("/api/findings/{finding_id}")
+   async def api_finding(finding_id: str) -> JSONResponse:
+       # look up one finding from _FINDINGS_FILE; 404 if missing;
+       # attach any chains[] whose steps reference it; pre-render chain mermaid
+       # via _render_mermaid_svgs (same as api_findings does today).
+   ```
+   Small payload instead of shipping the whole collection to the detail tab.
+
+3. **New template** — `dashboard/tabs/` isn't right (those are includes); add a top-level
+   `dashboard/finding.html` served as its own page. It reuses the same `<head>` block
+   (CSP, favicons, fonts, mermaid, marked, `dashboard.css`).
+
+4. **Share the security-critical core** — extract the **auth shim + `esc()` + sanitizer +
+   mermaid/marked setup** out of `common.js` into a new `dashboard/js/shared.js`. Both
+   `index.html` and `finding.html` load `shared.js` first. This avoids duplicating the
+   bearer-token wrapper (a copy that drifts would be a security bug) and is what lets the
+   new tab authenticate. `common.js` keeps everything dashboard-specific.
+
+No change to `scan_tools`, session lifecycle, MCP tools, or the findings store schema.
+
+---
+
+## 8. Implementation phases (ordered, each independently shippable)
+
+**Phase 0 — Design tokens (CSS only, zero behaviour change)**
+Add the type scale, `--sp-*` spacing, and `--sev-*` tokens to `:root`; refactor existing
+rules to consume them. Ship and eyeball — nothing else changes yet.
+
+**Phase 1 — Left sidebar shell**
+Move `.tab-nav` markup into a left `<nav>` rail; restructure `body` into rail + main grid;
+make status strip sticky; add live count/alert badges (reuse polled data). `switchTab`
+untouched. Add responsive collapse. This is the biggest visual change and is self-contained.
+
+**Phase 2 — Findings list restyle + click-through**
+Rework `cardHTML()`: summary row, clamped description, title as `target="_blank"` anchor,
+whole-card click, `stopPropagation` on action buttons, remove inline evidence `<details>`.
+Cards now link to `/finding/<id>` (page doesn't exist yet → 404 until Phase 3, so land 2+3
+together or feature-flag the link).
+
+**Phase 3 — Finding detail page** *(the headline feature)*
+Extract `shared.js`; add `finding.html` + `finding.js` + a `.dossier-*` CSS block; add the
+two backend routes. Wire trace timeline, remediation, adjudication, chain, live polling.
+
+**Phase 4 — Chrome polish**
+Restyle Command Center, HIR panel, filter pills, empty states, badges to the new scale/
+spacing. Pure CSS. Verify HIR still pulses and all pollers paint.
+
+**Verify each phase**: start the dashboard (`session(action='dashboard')` / `serve.py`),
+run against an existing `findings.json`, click through, confirm the new tab authenticates
+(token copied from opener), and that all 10 tabs + Command Center + HIR still work.
+
+---
+
+## 9. Files touched
+
+| File | Change |
+|---|---|
+| `dashboard/css/dashboard.css` | tokens, type scale, sidebar, restyled cards, `.dossier-*` block |
+| `dashboard/index.html` | sidebar rail markup, sticky status, load `shared.js` |
+| `dashboard/js/common.js` | move auth/esc/sanitizer into `shared.js`; keep dashboard logic |
+| `dashboard/js/shared.js` | **new** — auth shim, `esc`, sanitizer, mermaid/marked setup |
+| `dashboard/js/findings.js` | summary-row card, click-through, drop inline evidence |
+| `dashboard/finding.html` | **new** — standalone dossier page (reuses `<head>`) |
+| `dashboard/js/finding.js` | **new** — fetch `/api/findings/<id>`, render dossier, poll |
+| `core/api_server/routes/dashboard_routes.py` | **new route** `GET /finding/{id}` |
+| `core/api_server/routes/findings_routes.py` | **new route** `GET /api/findings/{id}` |
+| `docs/dashboard-api.md` | document the two new routes |
+
+Nav badges may read existing `/api/coverage`, `/api/session`, `/api/findings` — no new
+data plumbing required.
+
+## 10. Risks, non-goals, open decision
+
+**Risks & mitigations**
+- *Auth in the new tab* — relies on `sessionStorage` copy-on-new-tab; guaranteed only when
+  opened from a same-origin link (our case). Cold-loading `/finding/<id>` from a bookmark
+  falls back to the existing key-prompt. Covered by loading `shared.js`.
+- *CSP* — the detail page must carry the identical `<meta>` CSP; the mermaid CDN + inline
+  handlers are already allow-listed. No new external origins introduced.
+- *Sidebar regressions* — `switchTab` and `.tab-content.active` semantics are preserved;
+  only the button container moves, keeping blast radius small.
+
+**Non-goals** — no palette/logo change; no new scan features; no findings-schema change;
+no touching MCP tools or session lifecycle; not auto-invoking `/report` or `/gh-export`.
+
+**Open decision** — "new tab" is designed as a **new browser tab** (`/finding/<id>`). If
+you meant an in-app tab instead, the same dossier markup slots into the tab system; tell me
+and I'll adjust Phase 3 only.

--- a/tests/test_finding_detail_routes.py
+++ b/tests/test_finding_detail_routes.py
@@ -1,0 +1,127 @@
+"""
+Tests for the finding "dossier" routes added by the dashboard redesign:
+  - GET /finding/{id}          → standalone detail page (HTML)
+  - GET /api/findings/{id}     → one finding + related exploit chains (JSON)
+
+Uses FastAPI's TestClient — no real HTTP server needed.
+"""
+import json
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from core.api_server import app
+
+client = TestClient(app)
+
+
+# ── GET /finding/{id} — standalone dossier page ───────────────────────────────
+
+def test_finding_detail_page_renders_html():
+    resp = client.get("/finding/abc-123")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_finding_detail_page_embeds_the_id():
+    # Jinja autoescapes finding_id into data-finding-id so finding.js can read it.
+    resp = client.get("/finding/d508b493-39d7-4606-9702-9ff9bcc3d5c6")
+    assert resp.status_code == 200
+    assert "d508b493-39d7-4606-9702-9ff9bcc3d5c6" in resp.text
+
+
+# ── GET /api/findings/{id} — single finding + related chains ──────────────────
+
+def _write_findings(tmp_path, monkeypatch, data):
+    import core.api_server as srv
+    f = tmp_path / "findings.json"
+    f.write_text(json.dumps(data))
+    monkeypatch.setattr(srv, "_FINDINGS_FILE", f)
+    return f
+
+
+def test_api_finding_returns_finding_when_present(tmp_path, monkeypatch):
+    _write_findings(tmp_path, monkeypatch, {
+        "meta": {"target": "example.com"},
+        "findings": [{"id": "f1", "title": "SQLi", "severity": "high"}],
+        "chains": [],
+    })
+    resp = client.get("/api/findings/f1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["finding"]["id"] == "f1"
+    assert body["finding"]["title"] == "SQLi"
+    assert body["archived"] is False
+    assert body["chains"] == []
+    assert body["meta"]["target"] == "example.com"
+
+
+def test_api_finding_404_when_unknown(tmp_path, monkeypatch):
+    _write_findings(tmp_path, monkeypatch, {"findings": [{"id": "f1"}], "chains": []})
+    resp = client.get("/api/findings/does-not-exist")
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "not found"
+
+
+def test_api_finding_falls_back_to_archived(tmp_path, monkeypatch):
+    _write_findings(tmp_path, monkeypatch, {
+        "findings": [{"id": "live"}],
+        "archived": [{"id": "gone", "title": "Deleted finding"}],
+        "chains": [],
+    })
+    resp = client.get("/api/findings/gone")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["finding"]["title"] == "Deleted finding"
+    assert body["archived"] is True
+
+
+def test_api_finding_attaches_related_chain_and_renders_svg(tmp_path, monkeypatch):
+    _write_findings(tmp_path, monkeypatch, {
+        "findings": [{"id": "f1", "title": "Prompt injection"}],
+        "chains": [{
+            "name": "PI to PII exfil",
+            "combined_severity": "critical",
+            "mermaid": "graph TD\n  A-->B",
+            "steps": [{"from_finding_id": "f1", "to_finding_id": "f2"}],
+        }],
+    })
+    with patch("core.api_server._render_mermaid_svgs", return_value={"0": "<svg>chain</svg>"}):
+        resp = client.get("/api/findings/f1")
+    assert resp.status_code == 200
+    chains = resp.json()["chains"]
+    assert len(chains) == 1
+    assert chains[0]["svg"] == "<svg>chain</svg>"
+
+
+def test_api_finding_skips_unrelated_chain(tmp_path, monkeypatch):
+    _write_findings(tmp_path, monkeypatch, {
+        "findings": [{"id": "f1"}],
+        "chains": [{
+            "name": "unrelated",
+            "mermaid": "graph TD\n  X-->Y",
+            "steps": [{"from_finding_id": "other", "to_finding_id": "another"}],
+        }],
+    })
+    with patch("core.api_server._render_mermaid_svgs") as mock_render:
+        resp = client.get("/api/findings/f1")
+    assert resp.status_code == 200
+    assert resp.json()["chains"] == []
+    mock_render.assert_not_called()
+
+
+def test_api_finding_keeps_prerendered_chain_svg(tmp_path, monkeypatch):
+    _write_findings(tmp_path, monkeypatch, {
+        "findings": [{"id": "f1"}],
+        "chains": [{
+            "name": "cached",
+            "mermaid": "graph TD\n  A-->B",
+            "svg": "<svg>cached</svg>",
+            "steps": [{"to_finding_id": "f1"}],
+        }],
+    })
+    with patch("core.api_server._render_mermaid_svgs") as mock_render:
+        resp = client.get("/api/findings/f1")
+    assert resp.status_code == 200
+    assert resp.json()["chains"][0]["svg"] == "<svg>cached</svg>"
+    mock_render.assert_not_called()


### PR DESCRIPTION
Reshape the dashboard onto one calm, flat design system (keeping the NullPointer purple/green palette and logo):

- Left sidebar navigation with consistent SVG icons and section groups, replacing the horizontal tab bar; sticky status strip.
- Findings home reworked into a severity triage board: distribution bar + severity-grouped tile grid; whole-tile same-tab link to the finding detail.
- New standalone finding "dossier" page (GET /finding/{id} + GET /api/findings/{id}): masthead, data-flow trace timeline, evidence, remediation, adjudication, exploit-chain diagram, metadata rail.
- Extract the security-critical auth shim + esc + sanitizer + mermaid setup into shared.js so the dossier page reuses the same bearer-token logic.
- World Model tab restyled to the system (kept the /api/graph feature).
- Per-tab redesign for Topology, Components, Coverage (sticky matrix + readable stat pills), Skills, Activity, Threat Model, Metrics, Setup Gates, and Logs, each with a consistent title/subtitle header.

No scan logic, routes' behavior, or data flow changed beyond the two additive read routes above.