### PR TITLE
fix: scan-loop stalls, model-profile merge, RCE→shell escalation, dashboard UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ report_generator.py
 *.swo
 *~
 steering_queue.json
+wishlist_queue.json
 recovery_latest.json
 pentest_metrics.jsonl
 

--- a/core/api_server/__init__.py
+++ b/core/api_server/__init__.py
@@ -108,7 +108,18 @@ async def _require_dashboard_token(request: Request, call_next):
             supplied = hdr[7:].strip() if hdr[:7].lower() == "bearer " else ""
             if not dashboard_auth.verify(supplied):
                 return JSONResponse({"error": "unauthorized"}, status_code=401)
-    return await call_next(request)
+    resp = await call_next(request)
+    # Force the browser to REVALIDATE dashboard assets on every load instead of
+    # serving a heuristically-cached stale copy. Without this, the un-versioned
+    # scripts (common.js / main.js / shared.js / …) and the header-less index.html
+    # get pinned in the browser cache, so a JS fix on disk never reaches the user
+    # (the recurring "findings blank for 5s / stale dashboard" bug). StaticFiles
+    # already emits ETag + Last-Modified, so "no-cache" means: store it, but
+    # revalidate first — a cheap 304 when unchanged, a fresh 200 the moment the file
+    # changes. Kills the whole stale-asset class without per-file ?v= bookkeeping.
+    if path == "/" or path.startswith("/static/") or path.endswith((".html", ".js", ".css")):
+        resp.headers["Cache-Control"] = "no-cache"
+    return resp
 
 
 # Dashboard UI: a Jinja2-rendered index.html that {% include %}s one HTML

--- a/core/api_server/routes/scan_state_routes.py
+++ b/core/api_server/routes/scan_state_routes.py
@@ -116,6 +116,26 @@ async def api_intervention_respond(request: Request) -> JSONResponse:
         scan_session.load_from_disk(force=True)
         scan_session.resolve_intervention(choice, message)
         human_instruction = f"Human resolved HIR — choice='{choice}'" + (f": {message}" if message else "")
+
+        # Consume the operator's TERMINAL choices. resolve_intervention only RECORDS
+        # the choice and returns the scan to 'running' — so without this, ACCEPT_PARTIAL
+        # / ABORT just bounce the agent back into the same blockers and re-fire the HIR
+        # (the write-only-resolution loop). Terminal choices must actually end the scan.
+        choice_u = choice.upper().replace(" ", "_")
+        if choice_u in ("ACCEPT_PARTIAL", "FORCE_COMPLETE", "COMPLETE", "ABORT"):
+            aborted = choice_u == "ABORT"
+            scan_session.complete(
+                notes=(message or (
+                    "operator ABORT — scan stopped with current findings"
+                    if aborted else
+                    "operator ACCEPT_PARTIAL — completed with documented coverage gaps")),
+                stop_reason=("operator_abort" if aborted else "operator_accept_partial"),
+                quality_gate="failed",  # honest: distinguishes a force-complete from a clean one
+            )
+            return JSONResponse({"ok": True, "completed": True, "instruction": human_instruction})
+
+        # Non-terminal choices (CONTINUE / GUIDE / EXTEND / REDUCE_SCOPE / SKIP_CELLS):
+        # resume and let the agent act on the operator's instruction on its next call.
         steering_queue.add_directive(
             code=RESUME_REQUIRED,
             message=(

--- a/core/api_server/smith/__init__.py
+++ b/core/api_server/smith/__init__.py
@@ -26,6 +26,10 @@ from __future__ import annotations
 # object the submodules mutate via ``_smith.<name>``.
 _watchdog_last_progress: tuple | None = None
 _watchdog_no_progress_count = 0
+# Last respawn-failure reason (the child's own exit line, e.g. an out-of-usage /
+# credit / auth message) so the no-progress HIR can report the REAL cause instead
+# of the generic "agent keeps exiting without testing". Cleared on a live respawn.
+_last_spawn_failure: str = ""
 # Restart throttle for the MCP SSE self-heal — reset by tests on this facade.
 _mcp_sse_last_restart_ts: float = 0.0
 

--- a/core/api_server/smith/progress.py
+++ b/core/api_server/smith/progress.py
@@ -51,25 +51,64 @@ def _watchdog_should_escalate_no_progress() -> bool:
     return _smith._watchdog_no_progress_count >= _WATCHDOG_MAX_NO_PROGRESS
 
 
+def _classify_spawn_failure(reason: str) -> tuple[str, str] | None:
+    """If ``reason`` (a failed respawn's own exit line) indicates a billing / usage /
+    auth block rather than a stuck agent, return (kind, operator-facing remedy)."""
+    r = (reason or "").lower()
+    if any(p in r for p in ("out of extra usage", "usage limit", "usage_limit",
+                            "rate limit", "rate_limit", "429", "quota")):
+        return ("usage", "Your Claude subscription hit its usage limit. Wait for the "
+                "reset shown in the message, then resume (CONTINUE). The interactive "
+                "session shares the same pool, so it may be limited until then too.")
+    if any(p in r for p in ("credit balance", "billing", "insufficient", "payment")):
+        return ("credit", "The API account is out of credit. Top it up, OR use your "
+                "subscription instead (unset ANTHROPIC_API_KEY for the server / leave "
+                "SMITH_SPAWN_USE_API_KEY unset), then resume.")
+    if any(p in r for p in ("unauthorized", "not logged in", "please run /login",
+                            "authentication", "invalid api key", "no api key")):
+        return ("auth", "The agent client isn't authenticated. Log it in (or fix the "
+                "API key), then resume.")
+    return None
+
+
 def _escalate_no_progress_hir() -> None:
     """Pause the scan for a human instead of respawning into the same dead end."""
     n = _smith._watchdog_no_progress_count
+    reason = (getattr(_smith, "_last_spawn_failure", "") or "").strip()
+    blocked = _classify_spawn_failure(reason)
+    if blocked:
+        # A respawn couldn't LAUNCH (billing/usage/auth) — NOT a coverage/logic dead
+        # end. Report the real cause + the actual remedy so the operator doesn't chase
+        # a phantom "agent keeps exiting without testing".
+        _kind, remedy = blocked
+        situation = (
+            f"The scan is paused because the agent client could not launch: "
+            f"“{reason[:200]}”. This is NOT a testing dead-end — {remedy}"
+        )
+        tried = [f"{n} respawns failed to launch — {reason[:120]}"]
+        options = [
+            "RESUME: once the limit resets / credit is added / auth is fixed, resume the scan",
+            "ACCEPT_PARTIAL: finish now with the current findings + documented gaps",
+            "EXTEND: provide working credentials/credit or switch auth, then resume",
+            "ABORT: stop the scan",
+        ]
+    else:
+        situation = (
+            f"The scan respawned {n}× with no new findings, no newly-closed cells, and no MCP "
+            "activity — the agent loop keeps exiting without testing. Pausing instead of "
+            "respawning into the same dead end."
+        )
+        tried = [f"{n} consecutive respawns with zero progress"]
+        options = [
+            "COMPLETE: accept the current findings + documented coverage gaps and finish",
+            "GUIDE: give specific next steps (endpoints/findings to focus on) and resume",
+            "EXTEND: raise limits / provide credentials, then resume",
+            "ABORT: stop the scan",
+        ]
     try:
         from core import session as scan_session
         scan_session.trigger_intervention(
-            code="HIR_NO_PROGRESS",
-            situation=(
-                f"The scan respawned {n}× with no new findings, no newly-closed cells, and no MCP "
-                "activity — the agent loop keeps exiting without testing. Pausing instead of "
-                "respawning into the same dead end."
-            ),
-            tried=[f"{n} consecutive respawns with zero progress"],
-            options=[
-                "COMPLETE: accept the current findings + documented coverage gaps and finish",
-                "GUIDE: give specific next steps (endpoints/findings to focus on) and resume",
-                "EXTEND: raise limits / provide credentials, then resume",
-                "ABORT: stop the scan",
-            ],
+            code="HIR_NO_PROGRESS", situation=situation, tried=tried, options=options,
         )
     except Exception:
         _log.exception("no-progress HIR escalation failed")

--- a/core/api_server/smith/spawn.py
+++ b/core/api_server/smith/spawn.py
@@ -16,6 +16,11 @@ import core.api_server.smith as _smith
 
 from ._common import _log, _SPAWN_SOURCE_TAGS
 
+# A healthy `claude -p` / `opencode run` agent runs for minutes. A child that
+# exits within this window died on startup (bad/empty auth, missing binary,
+# "Credit balance is too low") and must NOT be booked as a successful respawn.
+_SPAWN_LIVENESS_SECONDS = 8
+
 
 def _spawn_source_tag(source: str) -> str:
     """Map a _spawn_smith() source argument to its audit-log tag."""
@@ -153,11 +158,54 @@ def _build_spawn_args(binary: str, client: str, resume_sid: str | None, prompt: 
     return [binary, "run", "--dangerously-skip-permissions", prompt]
 
 
-def _build_spawn_kwargs(log_fh) -> dict:
+def _spawn_child_env(client: str) -> dict:
+    """Environment for the respawned client — matching the AUTH CONTEXT the operator's
+    interactive run used.
+
+    The dashboard/MCP-server process loads the repo ``.env`` (mcp_server._app._load_dotenv),
+    which commonly sets ``ANTHROPIC_API_KEY`` for server-side LLM features (QA agent,
+    adjudication). But a detached ``claude -p`` that inherits that key bills against the
+    API pay-as-you-go account instead of the operator's Claude subscription — and when
+    that API account is empty the child dies instantly with "Credit balance is too low"
+    (the exact HIR_NO_PROGRESS dead end seen in the wild). The operator's interactive TUI
+    ran on their subscription precisely because their shell had no such key. So for a
+    ``claude`` respawn we drop the API-key vars, letting the headless child fall back to
+    the same logged-in subscription. Opt back into API-key billing with
+    ``SMITH_SPAWN_USE_API_KEY=1`` (e.g. a subscription-less CI box).
+    """
+    import os as _os
+    env = _os.environ.copy()
+    _use_api_key = _os.environ.get("SMITH_SPAWN_USE_API_KEY", "").lower() in ("1", "true", "yes")
+    if client == "claude" and not _use_api_key:
+        env.pop("ANTHROPIC_API_KEY", None)
+        env.pop("ANTHROPIC_AUTH_TOKEN", None)
+    return env
+
+
+def _tail_spawn_log(log_path, max_chars: int = 240) -> str:
+    """Last non-empty line of the spawn log — carries the child's own exit reason
+    (e.g. 'Credit balance is too low') so a startup failure is diagnosable."""
+    try:
+        lines = [ln.strip() for ln in log_path.read_text(errors="replace").splitlines() if ln.strip()]
+        for ln in reversed(lines):
+            if ln.startswith("=== ["):  # skip our own audit banner
+                continue
+            return ln[:max_chars]
+    except Exception:
+        pass
+    return ""
+
+
+def _build_spawn_kwargs(log_fh, client: str) -> dict:
     """Build create_subprocess_exec kwargs, detaching the child so signals to the
     dashboard process don't reach it. POSIX uses os.setsid() via start_new_session;
-    Windows uses the CREATE_NEW_PROCESS_GROUP creationflag — same intent, different API."""
-    spawn_kwargs: dict = {"stdout": log_fh, "stderr": log_fh, "cwd": str(_api._REPO_ROOT)}
+    Windows uses the CREATE_NEW_PROCESS_GROUP creationflag — same intent, different API.
+    ``env`` is set explicitly so the child's billing/auth matches the operator's run
+    (see _spawn_child_env)."""
+    spawn_kwargs: dict = {
+        "stdout": log_fh, "stderr": log_fh, "cwd": str(_api._REPO_ROOT),
+        "env": _spawn_child_env(client),
+    }
     import sys as _sys
     if _sys.platform == "win32":
         # CREATE_NEW_PROCESS_GROUP is only defined on Windows CPython; the literal
@@ -224,9 +272,33 @@ async def _spawn_smith(client: str, source: str = "api") -> tuple[bool, int | st
         args = _build_spawn_args(binary, client, resume_sid, prompt)
 
         log_fh = await loop.run_in_executor(None, lambda: log_path.open("a"))
-        spawn_kwargs = _build_spawn_kwargs(log_fh)
+        spawn_kwargs = _build_spawn_kwargs(log_fh, client)
 
         proc = await asyncio.create_subprocess_exec(*args, **spawn_kwargs)
+
+        # Liveness probe: a healthy agent runs for minutes, so proc.wait() times out
+        # (good). A child that exits within the window died on startup — most often
+        # "Credit balance is too low" (API-key billing on an empty account). Do NOT
+        # book that as a successful respawn: return the child's own last log line so
+        # the watchdog surfaces the REAL cause instead of laundering it into a generic
+        # HIR_NO_PROGRESS coverage dead-end.
+        try:
+            rc = await asyncio.wait_for(proc.wait(), timeout=_SPAWN_LIVENESS_SECONDS)
+        except asyncio.TimeoutError:
+            rc = None  # still alive after the probe → healthy
+        except Exception as _probe_err:
+            # Never fail a real spawn because the liveness probe itself errored
+            # (e.g. a non-awaitable proc stub) — assume alive and proceed.
+            _log.debug("spawn_smith: liveness probe error, assuming alive: %s", _probe_err)
+            rc = None
+        if rc is not None:
+            reason = await loop.run_in_executor(None, lambda: _tail_spawn_log(log_path))
+            _log.warning(
+                "spawn_smith: %s exited rc=%s within %ss of launch — not a live respawn: %s",
+                client, rc, _SPAWN_LIVENESS_SECONDS, reason or "(no output)",
+            )
+            return False, f"{client} exited on launch (rc={rc}): {reason or 'no output'}"
+
         _api._SMITH_PID_FILE.write_text(str(proc.pid))
         _api._SMITH_CLIENT_FILE.write_text(client)
 

--- a/core/api_server/smith/watchdog.py
+++ b/core/api_server/smith/watchdog.py
@@ -76,7 +76,28 @@ async def _watchdog_respawn_flow(now: float) -> None:
     if ok:
         _api._watchdog_last_restart_ts = now
         _api._watchdog_restart_count_window.append(now)
+        _smith._last_spawn_failure = ""   # live respawn — clear any prior failure reason
         _log.info("watchdog: spawned pid=%d", int(result) if isinstance(result, int) else 0)
+    else:
+        # Record the child's own exit reason so the no-progress HIR can report the
+        # REAL cause (out-of-usage / credit / auth) instead of the generic
+        # "agent keeps exiting without testing".
+        _smith._last_spawn_failure = str(result)
+        # The child died on launch (bad/empty auth, "Credit balance is too low",
+        # missing binary). Count it against the min-gap so we don't hot-loop, and
+        # surface the child's REAL exit reason to the operator — otherwise the
+        # no-progress fingerprint would relabel a billing/auth failure as a coverage
+        # dead-end (HIR_NO_PROGRESS) and hide the actual fix.
+        _api._watchdog_last_restart_ts = now
+        _log.warning("watchdog: respawn failed to stay alive — %s", result)
+        _smith._watchdog_notify(
+            "Smith respawn failed to start",
+            f"Watchdog relaunched {client} but it exited immediately: {result}. "
+            "If this says 'Credit balance is too low', the headless respawn is billing an "
+            "API key (from .env) instead of your Claude subscription — unset ANTHROPIC_API_KEY "
+            "for the server, add API credit, or set SMITH_SPAWN_USE_API_KEY=1 intentionally.",
+            "WATCHDOG_RESPAWN_FAILED",
+        )
 
 
 def _kill_stalled_or_hung(hung_pid, stalled_pid) -> None:

--- a/core/coverage/operations.py
+++ b/core/coverage/operations.py
@@ -488,8 +488,22 @@ async def list_cells(
 
 
 async def reset() -> None:
-    """Clear the entire coverage matrix."""
+    """Clear the entire coverage matrix (archiving a non-empty one first)."""
     async with _cov._lock:
+        # Archive-before-wipe: a target-less re-init through this path previously
+        # DESTROYED a live matrix (900+ cells / findings) with no recovery. Copy any
+        # non-empty matrix to logs/ before blanking so the forensic record survives.
+        try:
+            cov_file = _cov.COVERAGE_FILE
+            existing = _cov._load()
+            if cov_file.exists() and (existing.get("matrix") or existing.get("endpoints")):
+                import shutil
+                ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+                arch_dir = cov_file.parent / "logs"
+                arch_dir.mkdir(exist_ok=True)
+                shutil.copy2(cov_file, arch_dir / f"coverage_matrix_{ts}.json")
+        except Exception:
+            pass
         _cov._save({
             "meta": {
                 "created": datetime.now(timezone.utc).isoformat(),

--- a/core/gate_keywords.py
+++ b/core/gate_keywords.py
@@ -18,10 +18,15 @@ RCE_KEYWORDS = (
     "os command", "shell injection", "eval injection",
 )
 
-# Keywords in notes that indicate container/K8s environment — triggers container gate.
+# Keywords indicating a container/K8s execution context — triggers the container-escape
+# gate. Includes plain-DOCKER markers (not just K8s): a confirmed RCE inside any
+# container warrants an escape assessment, and run_2's postgres-container RCE never
+# fired this because it only matched kube/serviceaccount tokens.
 K8S_KEYWORDS = (
     "kubernetes", "kubepods", "/.dockerenv", "dockerenv",
     "sa token", "serviceaccount", "k8s", "containerd", "cri-o",
+    "docker container", "docker.sock", "docker socket", "container escape",
+    "inside a container", "in-container", "container runtime", "/proc/1/",
 )
 
 # Keywords in notes that indicate cloud metadata access — triggers cloud gate.

--- a/core/logger.py
+++ b/core/logger.py
@@ -79,10 +79,14 @@ _log = logging.getLogger("pentest")
 _log.setLevel(logging.DEBUG)
 _log.addHandler(_fh)
 
-# Write session boundary so multiple restarts are easy to distinguish
-_session_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-_log.info("=" * 80)
-_log.info("SESSION_START  %s", _session_ts)
+def log_session_boundary() -> None:
+    """Write a SESSION_START banner to pentest.log so server restarts are easy to tell
+    apart. Called EXPLICITLY by the long-running server entry points — NOT at import —
+    so short-lived imports (the test suite, tooling, in-process probes/subprocesses)
+    don't churn the scan log with phantom session boundaries indistinguishable from a
+    real scan start."""
+    _log.info("=" * 80)
+    _log.info("SESSION_START  %s", datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
 
 
 # ---------------------------------------------------------------------------

--- a/core/model_detect.py
+++ b/core/model_detect.py
@@ -73,7 +73,7 @@ def classify_model(name: str) -> tuple[str | None, str]:
         if b is not None and b >= _MEDIUM_PARAM_THRESHOLD_B:
             return "medium", f"large local model '{name}' (~{b:g}B) -> medium"
         size = f" (~{b:g}B)" if b is not None else ""
-        return "small", f"local model '{name}'{size} -> small (conservative)"
+        return "medium", f"local model '{name}'{size} -> medium ('small' merged into medium)"
     return None, f"unrecognised model '{name}'"
 
 
@@ -107,10 +107,13 @@ def detect_profile(explicit: str | None = None) -> tuple[str, str]:
     # A detected window drives the profile directly, ranking ABOVE the name match.
     win = _detected_context_window()
     if win:
-        if win <= 49_152:      # ≤ ~48k tokens
-            return "small", f"detected context window {win} -> small"
+        # 'small' is merged into 'medium' on the capability axis — a small window
+        # floors at medium (advisory gates + condensed directives), never the broken
+        # small tier. The window ITSELF still scales the context budget (budget.py
+        # _window_scaled_budget), so a genuinely tiny window gets a small budget while
+        # keeping medium's gentle gate behaviour.
         if win <= 131_072:     # ≤ ~128k tokens
-            return "medium", f"detected context window {win} -> medium"
+            return "medium", f"detected context window {win} -> medium (local floor)"
         return "full", f"detected context window {win} -> full"
 
     for var in _MODEL_ENV_VARS:
@@ -121,6 +124,6 @@ def detect_profile(explicit: str | None = None) -> tuple[str, str]:
                 return profile, f"{var}={val}: {reason}"
 
     if os.environ.get("OLLAMA_HOST", "").strip():
-        return "small", "OLLAMA_HOST set (local runtime) -> small (conservative)"
+        return "medium", "OLLAMA_HOST set (local runtime) -> medium (local floor)"
 
     return "full", "no model signal -> full (default)"

--- a/core/qa_agent/__init__.py
+++ b/core/qa_agent/__init__.py
@@ -114,6 +114,7 @@ from .checks_depth import (  # noqa: E402
 from .checks_skills import (  # noqa: E402
     _check_core_skill_chain,
     _check_missing_skill,
+    _check_post_exploit_depth,
     _check_no_spider_after_httpx,
     _maybe_inject_business_logic_directive,
     _maybe_inject_param_fuzz_directive,

--- a/core/qa_agent/checks_skills.py
+++ b/core/qa_agent/checks_skills.py
@@ -179,6 +179,42 @@ def _check_core_skill_chain(entries: list[dict], session_data: dict,
     return alerts
 
 
+def _check_post_exploit_depth(session_data: dict) -> list[dict]:
+    """Once a confirmed RCE / container / internal-reachability gate has opened, nudge
+    the DEEP post-exploitation skills that turn 'command execution proven' into a real
+    shell / container escape / actual pivot — the run_2 gap where RCE never became
+    shell access. Non-blocking (the gates themselves enforce at completion on the full
+    profile); this surfaces it mid-scan so the model chains it WHILE it still holds the
+    access. Fires per gate only when that gate is pending AND actually requires the
+    skill AND the skill has not run."""
+    gates = session_data.get("gates", [])
+    skills_run = {e.get("skill") for e in session_data.get("skill_history", [])}
+    checks = [
+        ("post_exploit_rce", "reverse-shell", "SHELL_ESCALATION",
+         "RCE is confirmed but /reverse-shell has NOT run — command execution is not a "
+         "session. Escalate the exec primitive to an interactive/persistent shell (bash "
+         "/dev/tcp to a listener, SSH key, cron, or a msfvenom payload); if egress is "
+         "blocked, document why and record what a shell would enable."),
+        ("container_k8s", "container-k8s-security", "CONTAINER_ESCAPE",
+         "RCE is inside a container but /container-k8s-security has NOT run — assess "
+         "container escape (Docker socket, privileged caps, host mounts, SA token, "
+         "kernel)."),
+        ("internal_network", "lateral-movement", "LATERAL_MOVEMENT",
+         "Internal hosts are reachable WITH code execution but /lateral-movement has NOT "
+         "run — turn reachability into real movement (land access on the second host); "
+         "do not stop at a topology map."),
+    ]
+    alerts: list[dict] = []
+    for gid, skill, code, msg in checks:
+        g = next((x for x in gates if x.get("id") == gid), None)
+        if (g and g.get("status") == "pending"
+                and skill in g.get("required_skills", [])
+                and skill not in skills_run):
+            alerts.append({"code": f"MISSING_{code}", "urgency": "high", "blocking": False,
+                           "message": msg})
+    return alerts
+
+
 def _check_missing_skill(coverage_data: dict, session_data: dict) -> list[dict]:
     """Flag when a discovered endpoint type requires a skill that has never been invoked."""
     try:

--- a/core/qa_agent/daemon.py
+++ b/core/qa_agent/daemon.py
@@ -48,6 +48,7 @@ from .checks_skills import (
     _check_core_skill_chain,
     _check_missing_skill,
     _check_no_spider_after_httpx,
+    _check_post_exploit_depth,
 )
 
 _log = logging.getLogger(__name__)
@@ -93,6 +94,8 @@ _CHECKS: list[tuple] = [
     (_check_no_spider_after_httpx, ("entries",)),
     (_check_core_skill_chain,      ("entries", "session_data", "coverage_data")),
     (_check_missing_skill,         ("coverage_data", "session_data")),
+    # Deep post-exploitation: RCE→shell, container escape, real lateral movement
+    (_check_post_exploit_depth,    ("session_data",)),
 ]
 
 

--- a/core/session/__init__.py
+++ b/core/session/__init__.py
@@ -183,6 +183,7 @@ from .limits import (  # noqa: E402
     check_limits,
     get_context_pressure,
     remaining,
+    reset_context_meter,
 )
 from .intervention import (  # noqa: E402
     get_intervention,
@@ -194,10 +195,12 @@ from .gates import (  # noqa: E402
     defer_gates,
     open_trigger_gate,
     pending_gates,
+    reconcile_worked_gates,
     restore_gates,
     satisfy_gate,
     set_skill,
     set_step,
+    skill_worked,
     trigger_gate,
 )
 from .assets import (  # noqa: E402

--- a/core/session/gates.py
+++ b/core/session/gates.py
@@ -135,9 +135,65 @@ def set_skill(
             "reason":       reason,
             "chained_from": chained_from or None,
             "timestamp":    datetime.now(timezone.utc).isoformat(),
+            # A skill-chain gate is satisfied only once the skill has actually DONE
+            # WORK (a tool call fired while it was active), not on mere declaration —
+            # set by add_tool_called, checked by skill_worked/reconcile_worked_gates.
+            "worked":       False,
         })
     _sess._flush()
     return _sess._current
+
+
+_SUBSTANTIVE_WORK_MIN_TOOLS = 3
+
+
+def _scan_has_substantive_work() -> bool:
+    """True when THIS session has done real work — measured session-locally (so it is
+    correctly sandboxed and never reads another scan's disk files). The agent typically
+    EXPLOITS FIRST and only declares skills afterward, so 'a tool fired while this skill
+    was active' under-counts real work; a scan that ran several distinct tools and then
+    acknowledged the skill has genuinely done the work. A fresh/empty session (no tool
+    activity) still fails, so a bare declaration on an empty scan is NOT satisfied."""
+    cur = _sess._current or {}
+    ti = cur.get("tool_invocations", 0)
+    inv_count = len(ti) if isinstance(ti, (list, dict)) else (ti or 0)
+    return inv_count >= _SUBSTANTIVE_WORK_MIN_TOOLS or \
+        len(cur.get("tools_called", [])) >= _SUBSTANTIVE_WORK_MIN_TOOLS
+
+
+def skill_worked(skill_name: str) -> bool:
+    """True when ``skill_name`` was DECLARED (set_skill) AND real work was done.
+
+    Real work = a tool fired while the skill was active (the strong signal), OR the
+    scan produced substantive results (findings / addressed cells). The fallback
+    matters because the agent routinely exploits a target before formally declaring
+    the covering skills — requiring 'work while active' alone left the gates
+    permanently unsatisfiable and stalled productive scans. A bare declaration on an
+    EMPTY scan (no findings, no coverage) still does NOT satisfy — the rubber-stamp
+    is rejected."""
+    if _sess._current is None:
+        return False
+    declared = any(e.get("skill") == skill_name
+                   for e in _sess._current.get("skill_history", []))
+    if not declared:
+        return False
+    if any(e.get("skill") == skill_name and e.get("worked")
+           for e in _sess._current.get("skill_history", [])):
+        return True
+    return _scan_has_substantive_work()
+
+
+def reconcile_worked_gates() -> None:
+    """Satisfy each gate whose required skills have all done real work (see
+    skill_worked). Called at completion-evaluation time so a legitimately-worked
+    skill chain closes its gates, while a merely-declared one does not."""
+    _sess._reconcile_if_external_write()
+    if _sess._current is None:
+        return
+    for gate in _sess._current.get("gates", []):
+        for skill in gate.get("required_skills", []):
+            if skill_worked(skill) and skill not in gate.get("satisfied_skills", []):
+                satisfy_gate(gate["id"], skill)
 
 
 def set_step(step: str) -> dict | None:
@@ -150,11 +206,36 @@ def set_step(step: str) -> dict | None:
     return _sess._current
 
 
+def _mark_active_skill_worked() -> bool:
+    """Flag the current active skill's history entry as having done work. Returns True
+    if it changed anything (so the caller knows to flush)."""
+    active = _sess._current.get("skill")
+    if not active:
+        return False
+    for e in reversed(_sess._current.get("skill_history", [])):
+        if e.get("skill") == active:
+            if not e.get("worked"):
+                e["worked"] = True
+                return True
+            return False
+    return False
+
+
 def add_tool_called(tool_name: str) -> None:
-    """Persist a tool name to the tools_called list in session.json."""
+    """Persist a tool name to the tools_called list in session.json.
+
+    Also marks the ACTIVE skill as having done work (worked=True) — a tool call
+    fired while it was current — which is what lets its skill-chain gate be satisfied
+    (skill_worked/reconcile_worked_gates), rather than a bare set_skill declaration."""
     _sess._reconcile_if_external_write()
-    if _sess._current and _sess._current["status"] == "running":
-        tools = _sess._current.setdefault("tools_called", [])
-        if tool_name not in tools:
-            tools.append(tool_name)
-            _sess._flush()
+    if not (_sess._current and _sess._current["status"] == "running"):
+        return
+    tools = _sess._current.setdefault("tools_called", [])
+    changed = False
+    if tool_name not in tools:
+        tools.append(tool_name)
+        changed = True
+    if _mark_active_skill_worked():
+        changed = True
+    if changed:
+        _sess._flush()

--- a/core/session/limits.py
+++ b/core/session/limits.py
@@ -84,6 +84,23 @@ def charge_context(chars: int) -> None:
         _sess._flush()
 
 
+def reset_context_meter() -> None:
+    """Re-seed the context meter to the fixed resident overhead — call at the
+    compaction/recovery boundary.
+
+    ``context_chars_sent`` is otherwise monotonic (seeded once at start, only ever
+    incremented by charge_context), so on a long scan it climbs past the model's
+    real window and get_context_pressure() pegs at 1.0 (Tier-3) and STAYS there —
+    the agent is told it's out of context for the rest of the run and stops, even
+    though the client actually compacts its window periodically. The client's
+    session(action='recovery') call IS that compaction boundary: afterwards the
+    resident context is back to the fixed overhead, so the meter must drop to match
+    and re-accumulate from there. Best-effort; never raises into the recovery path."""
+    if _sess._current is not None:
+        _sess._current["context_chars_sent"] = _fixed_context_overhead_chars()
+        _sess._flush()
+
+
 def charge_skill_context(skill_name: str) -> None:
     """SM-1: add a loaded skill's byte size to the context meter. A skill can be
     30-44 KB — on a small window that's most of the budget, and the meter must

--- a/dashboard/finding.html
+++ b/dashboard/finding.html
@@ -16,7 +16,8 @@
 
 <div class="dossier-shell" data-finding-id="{{ finding_id }}">
   <header class="dossier-topbar">
-    <a class="dossier-back" href="/">&#8592; All findings</a>
+    <a class="dossier-back" href="/"
+       onclick="if (window.history.length > 1) { window.history.back(); return false; }">&#8592; All findings</a>
     <div class="dossier-brand">
       <img class="dossier-logo" src="/logo.png" alt="NullPointer Studio" onerror="this.style.display='none'">
       <span>Pentest <span class="h1-accent">Dashboard</span></span>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -176,7 +176,7 @@
 
 <script src="/static/js/shared.js"></script>
 <script src="/static/js/common.js"></script>
-<script src="/static/js/findings.js?v=3"></script>
+<script src="/static/js/findings.js?v=5"></script>
 <script src="/static/js/topology.js?v=2"></script>
 <script src="/static/js/components.js"></script>
 <script src="/static/js/coverage.js"></script>

--- a/dashboard/js/finding.js
+++ b/dashboard/js/finding.js
@@ -234,7 +234,8 @@
   function renderMissing() {
     if (statusEl) statusEl.innerHTML = '<span class="dot" style="background:#f85149;box-shadow:0 0 6px #f85149"></span>Not found';
     root.innerHTML = `<div class="empty-placeholder">This finding was not found — it may have been cleared or archived.
-      <div style="margin-top:1rem"><a class="detail-link" href="/">&#8592; Back to all findings</a></div></div>`;
+      <div style="margin-top:1rem"><a class="detail-link" href="/"
+        onclick="if (window.history.length > 1) { window.history.back(); return false; }">&#8592; Back to all findings</a></div></div>`;
     document.title = 'Finding not found · Pentest Dashboard';
   }
 

--- a/dashboard/js/findings.js
+++ b/dashboard/js/findings.js
@@ -1,4 +1,16 @@
+  const _FINDINGS_CACHE_KEY = 'smith_findings_cache';
+
   async function pollFindings() {
+    // On (re)load — e.g. returning from a /finding/<id> detail page — paint the
+    // last findings from sessionStorage IMMEDIATELY so the list isn't blank for a
+    // whole poll cycle (~5s) while the fetch below is in flight. The live fetch
+    // refreshes it (and the NEW badges) a moment later.
+    if (!(allData.findings || []).length) {
+      try {
+        const cached = sessionStorage.getItem(_FINDINGS_CACHE_KEY);
+        if (cached) { allData = JSON.parse(cached); renderFindings(); }
+      } catch { /* ignore malformed/absent cache */ }
+    }
     try {
       const r = await fetch(`/api/findings?_=${Date.now()}`);
       if (!r.ok) throw new Error('not found');
@@ -10,12 +22,17 @@
       });
       allData = data;
       lastOk  = new Date();
+      try { sessionStorage.setItem(_FINDINGS_CACHE_KEY, JSON.stringify(data)); } catch { /* quota */ }
       renderFindings();
     } catch {
       document.getElementById('status').innerHTML =
         '<span class="dot" style="background:#f85149"></span>Waiting for data…';
     }
   }
+
+  // Returning via the browser's back/forward cache doesn't re-run init, so the
+  // next interval poll can be up to 5s away — refresh findings right on restore.
+  window.addEventListener('pageshow', (e) => { if (e.persisted) pollFindings(); });
 
   function renderFindings() {
     const findings = allData.findings || [];
@@ -343,6 +360,7 @@
         freshIds = new Set();
         filter   = 'all';
         _logLines = [];
+        try { sessionStorage.removeItem(_FINDINGS_CACHE_KEY); } catch { /* ignore */ }
 
         // ── Status bar ───────────────────────────────────────────────────
         document.getElementById('status').innerHTML =

--- a/dashboard/js/findings.js
+++ b/dashboard/js/findings.js
@@ -34,13 +34,23 @@
   // next interval poll can be up to 5s away — refresh findings right on restore.
   window.addEventListener('pageshow', (e) => { if (e.persisted) pollFindings(); });
 
-  function renderFindings() {
-    const findings = allData.findings || [];
-    const target   = allData.meta?.target || '';
+  // The "last updated Ns ago" freshness line. Lives in the shared #status header
+  // (above every tab panel), so it must tick on ALL tabs — not just findings.
+  // Skipped while an HIR is active so it doesn't overwrite the "Scan paused" banner.
+  function updateFreshness() {
+    if (_hirActive) return;
+    const el = document.getElementById('status');
+    if (!el) return;
+    const target = allData.meta?.target || '';
     const ago = lastOk ? Math.round((Date.now() - lastOk) / 1000) + 's ago' : '';
-    document.getElementById('status').innerHTML =
+    el.innerHTML =
       `<span class="dot"></span>Live · refreshes every 5 s · last updated ${ago}` +
       (target ? ` · <strong style="color:#c9d1d9">${target}</strong>` : '');
+  }
+
+  function renderFindings() {
+    const findings = allData.findings || [];
+    updateFreshness();
     renderStats(findings);
     renderFindingsTable(findings);
     if (_activeTab === 'topology')   renderTopology(allData.diagrams || []);

--- a/dashboard/js/main.js
+++ b/dashboard/js/main.js
@@ -110,7 +110,9 @@
   setInterval(pollThreatModel,   POLL_MS);
   setInterval(pollQA,            POLL_MS);
   setInterval(pollMetrics,       POLL_MS * 6);
-  setInterval(() => { if (!scanDone && lastOk && _activeTab === 'findings') renderFindings(); }, 1000);
+  // #status is a shared header shown on every tab, so the "last updated Ns ago"
+  // counter must keep ticking regardless of which menu item is open.
+  setInterval(() => { if (!scanDone && lastOk) updateFreshness(); }, 1000);
   setInterval(() => { if (!scanDone && _activeTab === 'logs') pollLogs(); }, 3000);
   setInterval(() => { if (_activeTab === 'overview') pollOverview(); }, POLL_MS);
   setInterval(() => { if (_activeTab === 'world-model') pollWorldModel(); }, POLL_MS);

--- a/mcp_server/__main__.py
+++ b/mcp_server/__main__.py
@@ -136,6 +136,10 @@ _phase("LOADING .env  →  mcp_server._app._load_dotenv")
 try:
     from mcp_server._app import _load_dotenv
     _load_dotenv()
+    # Mark a real server-start boundary in pentest.log (no longer emitted at import
+    # time, so tests/tooling/in-process probes don't churn phantom SESSION_STARTs).
+    from core import logger as _logger
+    _logger.log_session_boundary()
     _phase(".env loaded OK")
 except BaseException:
     _phase("FAILED during _load_dotenv")

--- a/mcp_server/report_tools/coverage.py
+++ b/mcp_server/report_tools/coverage.py
@@ -252,6 +252,38 @@ async def _sweep_oob_ssrf(target, matrix, eps, ep_filter, max_cells, candidates)
     return note + "."
 
 
+def _sweep_auth_headers() -> dict:
+    """Auth material to RETRY a probe with when it hits 401/403 — the freshest captured
+    JWT (``Authorization: Bearer``) and/or session cookies from known_assets. Empty when
+    the scan holds no auth (an unauthenticated run stays unauthenticated)."""
+    headers: dict = {}
+    try:
+        from core import session as scan_session
+        ka = (scan_session.get() or {}).get("known_assets") or {}
+        toks = ka.get("auth_tokens") or []
+        if toks and isinstance(toks[-1], dict) and toks[-1].get("value"):
+            headers["Authorization"] = f"Bearer {toks[-1]['value']}"
+        pairs = [f"{c['name']}={c.get('value', '')}"
+                 for c in (ka.get("session_cookies") or [])
+                 if isinstance(c, dict) and c.get("name")]
+        if pairs:
+            headers["Cookie"] = "; ".join(pairs)
+    except Exception:
+        pass
+    return headers
+
+
+def _sqlmap_auth_blocked(body: str) -> bool:
+    """True when sqlmap's own output shows it never got past auth (HTTP 401/403), so a
+    'not injectable' verdict is a false negative — the payload never reached the DB
+    layer. Specific to sqlmap's HTTP-error reporting to avoid false 'inconclusive'."""
+    b = (body or "").lower()
+    return any(s in b for s in (
+        "error code (401)", "error code (403)",
+        "401 (unauthorized)", "403 (forbidden)",
+    ))
+
+
 async def _run_sweep_probe(c, ep, target):
     """Build + run the probe for one cell, store the artifact, evaluate it.
     Returns (artifact_id, verdict_dict) — or None when the probe couldn't run
@@ -269,13 +301,43 @@ async def _run_sweep_probe(c, ep, target):
         return None
     try:
         if probe["kind"] == "http":
-            resp = await http_probe(probe["url"], probe["method"])
+            base = probe.get("headers") or {}
+            resp = await http_probe(probe["url"], probe["method"], headers=base or None)
+            # Self-heal auth: a 401/403 means auth blocked the payload before it reached
+            # the code path under test — so RETRY once with the session's captured auth
+            # (Bearer token and/or session cookies from known_assets), testing the cell
+            # UNDER auth instead of recording a permanent auth-block. The sweep adds auth
+            # itself when it sees the gate, rather than leaving hundreds of cells stuck.
+            if resp.get("status") in (401, 403):
+                auth = _sweep_auth_headers()
+                if auth:
+                    healed = await http_probe(probe["url"], probe["method"], headers={**base, **auth})
+                    if healed.get("status") not in (401, 403):
+                        resp = healed
             status, body = resp.get("status", 0), resp.get("body", "")
             content = _json.dumps(resp)[:20_000]
         else:  # kali — sqlmap runs its own oracle
             from tools import kali_runner
-            body = await kali_runner.exec_command(probe["cmd"])
+            import shlex as _shlex
+            cmd = probe["cmd"]
+            # Thread session auth into sqlmap so it tests UNDER auth. Otherwise it hits
+            # 401/403, reports "not injectable", and the sweep records a FALSE
+            # tested_clean — the kali branch sets status=0, which bypasses the 401/403
+            # rejection guard that protects the http branch. Mirrors the http self-heal.
+            auth = _sweep_auth_headers()
+            if auth.get("Authorization"):
+                cmd += f" --header={_shlex.quote('Authorization: ' + auth['Authorization'])}"
+            if auth.get("Cookie"):
+                cmd += f" --cookie={_shlex.quote(auth['Cookie'])}"
+            # Bound the sub-probe: one sqlmap cell must not burn the default 600s and
+            # stall the whole sweep (the model then hand-calls sweep in a loop).
+            body = await kali_runner.exec_command(cmd, timeout=90)
             status, content = 0, body[:20_000]
+            # Never let an auth-blocked sqlmap run masquerade as tested_clean: if the
+            # output shows it never got past auth, it's inconclusive, not clean.
+            if _sqlmap_auth_blocked(body):
+                log.note(f"sweep: sqlmap on cell {c['id']} appears auth-blocked — inconclusive, not clean")
+                return None
     except Exception as exc:  # fail-soft — one dead probe never aborts the sweep
         log.note(f"sweep probe error on cell {c['id']}: {exc}")
         return None

--- a/mcp_server/report_tools/gates.py
+++ b/mcp_server/report_tools/gates.py
@@ -32,16 +32,38 @@ def _maybe_trigger_cve_gate(text: str, cve: str, speculative: bool, severity: st
     return "analyze_cve"
 
 
-def _maybe_trigger_rce_gate(text: str, title: str, severity: str, speculative: bool) -> str | None:
-    """RCE-class finding → post-exploit is mandatory — but ONLY when code execution
-    is actually confirmed. A speculative mention ("appears to support SSTI", ${7*7}
-    merely reflected) is not RCE, so it must not impose the gate."""
-    if (severity in ("critical", "high")
+def _maybe_trigger_rce_gate(text: str, title: str, severity: str, speculative: bool) -> list[str]:
+    """RCE-class finding → obligate the FULL post-exploitation escalation, ONLY when
+    code execution is actually confirmed (a speculative "appears to support SSTI" /
+    reflected ${7*7} is not RCE and imposes nothing).
+
+    Command execution is NOT the finish line — run_2 proved COPY-TO/FROM-PROGRAM code
+    exec (output via an error oracle) and stopped there, never getting an interactive
+    shell, never escaping the container. So a confirmed RCE now requires:
+      • post-exploit   — enumerate + escalate over the exec primitive
+      • reverse-shell  — turn one-shot command exec into a real interactive/persistent
+                         session (the missing "shell access")
+      • container-k8s-security — WHEN the RCE is inside a container (Docker/K8s markers),
+                         assess container escape.
+    These obligate the ATTEMPT (satisfied by the skill running + documenting the
+    outcome — an egress-blocked target that can't yield a shell still satisfies by
+    recording why), so they never become an unsatisfiable wall."""
+    if not (severity in ("critical", "high")
             and any(kw in text for kw in _RCE_KEYWORDS)
             and not speculative):
-        scan_session.trigger_gate("post_exploit_rce", f"RCE confirmed: {title}", ["post-exploit"])
-        return "post_exploit_rce"
-    return None
+        return []
+    triggered: list[str] = []
+    scan_session.trigger_gate(
+        "post_exploit_rce", f"RCE confirmed: {title}", ["post-exploit", "reverse-shell"])
+    triggered.append("post_exploit_rce")
+    # Detect container context from the RCE finding ITSELF (uid=999 in-container,
+    # "Docker Container" title, /.dockerenv) — not only from a later note, which is
+    # why run_2's DB-container RCE never opened the escape gate.
+    if any(kw in text for kw in _K8S_KEYWORDS):
+        scan_session.trigger_gate(
+            "container_k8s", f"RCE inside a container: {title}", ["container-k8s-security"])
+        triggered.append("container_k8s")
+    return triggered
 
 
 def _maybe_trigger_auth_gate(text: str, title: str, severity: str) -> str | None:
@@ -72,12 +94,15 @@ def _auto_trigger_finding_gates(title: str, severity: str, description: str, cve
         return []
 
     speculative = any(m in text for m in _SPECULATION_MARKERS)
-    candidates = (
-        _maybe_trigger_cve_gate(text, cve, speculative, severity),
-        _maybe_trigger_rce_gate(text, title, severity, speculative),
-        _maybe_trigger_auth_gate(text, title, severity),
-    )
-    return [g for g in candidates if g]
+    triggered: list[str] = []
+    cve_gate = _maybe_trigger_cve_gate(text, cve, speculative, severity)
+    if cve_gate:
+        triggered.append(cve_gate)
+    triggered.extend(_maybe_trigger_rce_gate(text, title, severity, speculative))  # returns a list
+    auth_gate = _maybe_trigger_auth_gate(text, title, severity)
+    if auth_gate:
+        triggered.append(auth_gate)
+    return triggered
 
 
 def _auto_trigger_note_gates(message: str) -> list[str]:
@@ -109,10 +134,17 @@ def _auto_trigger_note_gates(message: str) -> list[str]:
         triggered.append("cloud_pivot")
 
     if any(kw in text for kw in _INTERNAL_NET_KEYWORDS):
+        # network-assess maps the topology; but once we ALSO have code execution,
+        # internal reachability must be turned into actual MOVEMENT, not just a
+        # topology diagram — obligate lateral-movement too. (run_2 proved the app
+        # container was 'reachable' but never moved into it.) Both are attempt-gates:
+        # satisfied by the skill running, so a genuinely un-pivotable target still
+        # closes them by documenting why.
+        net_skills = ["network-assess"] + (["lateral-movement"] if rce_gate_exists else [])
         scan_session.trigger_gate(
             "internal_network",
-            "Internal network reachable",
-            ["network-assess"],
+            "Internal network reachable" + (" — with code execution" if rce_gate_exists else ""),
+            net_skills,
         )
         triggered.append("internal_network")
 

--- a/mcp_server/scan_engine/artifacts.py
+++ b/mcp_server/scan_engine/artifacts.py
@@ -42,6 +42,24 @@ def artifact_exists(artifact_id: str) -> bool:
     return (_ARTIFACTS_DIR / f"{artifact_id.strip()}.txt").exists()
 
 
+# Bounds for a SINGLE artifact retrieval, so one pull can't dominate/overflow the
+# model window (a max_chars=1_000_000 'full' pull previously returned ~1MB inline).
+_ARTIFACT_ABS_CEILING = 120_000   # never return more than ~30K tokens in one call
+_ARTIFACT_ABS_FLOOR = 20_000      # always allow at least this much
+
+
+def _artifact_ceiling() -> int:
+    """Upper clamp for one retrieval — ~30% of the model's context budget, bounded by
+    sane absolutes. Scales with the profile/window so a small-window model gets a
+    smaller cap; falls back safely when the profile can't be resolved."""
+    try:
+        from mcp_server.scan_engine.budget import get_profile
+        budget = int(get_profile().get("context_budget_chars") or 400_000)
+    except Exception:
+        budget = 400_000
+    return max(_ARTIFACT_ABS_FLOOR, min(int(budget * 0.30), _ARTIFACT_ABS_CEILING))
+
+
 def retrieve_artifact(
     artifact_id: str,
     mode: str = "summary",
@@ -66,10 +84,19 @@ def retrieve_artifact(
     raw = path.read_text(encoding="utf-8")
     total = len(raw)
 
+    # Clamp the caller-supplied max_chars to the safe, profile-scaled ceiling.
+    try:
+        requested = max(1, int(max_chars))
+    except (TypeError, ValueError):
+        requested = 4000
+    ceiling = _artifact_ceiling()
+    eff_max = min(requested, ceiling)
+    clamped = eff_max < requested
+
     if mode in ("summary", "head"):
-        content = raw[:max_chars]
+        content = raw[:eff_max]
     elif mode == "tail":
-        content = raw[-max_chars:] if total > max_chars else raw
+        content = raw[-eff_max:] if total > eff_max else raw
     elif mode == "grep":
         if not pattern:
             return json.dumps({"error": "grep mode requires a pattern"})
@@ -79,9 +106,21 @@ def retrieve_artifact(
         except re.error as e:
             return json.dumps({"error": f"Invalid regex: {e}"})
         matches = [line for line in raw.splitlines() if regex.search(line)]
-        content = "\n".join(matches)[:max_chars]
+        content = "\n".join(matches)[:eff_max]
     elif mode == "full":
-        content = raw[:max_chars]
+        if total > eff_max:
+            # Keep the START and END (where scan results usually sit) and tell the
+            # model exactly how to fetch the rest — bounded, never a silent loss.
+            head = (eff_max * 2) // 3
+            tail = eff_max - head
+            content = (
+                raw[:head]
+                + f"\n\n… [{total - eff_max} of {total} chars omitted — narrow with "
+                  "mode='grep' pattern='<term>', or mode='tail'/'head' for the ends] …\n\n"
+                + raw[-tail:]
+            )
+        else:
+            content = raw[:eff_max]
     else:
         return json.dumps({"error": f"Unknown mode: {mode}. Use: summary, head, tail, grep, full"})
 
@@ -91,6 +130,8 @@ def retrieve_artifact(
         "chars_returned": len(content),
         "total_chars": total,
         "truncated": len(content) < total,
+        "clamped": clamped,          # max_chars was capped to the safe ceiling
+        "ceiling": ceiling,
         "content": content,
     })
 

--- a/mcp_server/scan_engine/budget.py
+++ b/mcp_server/scan_engine/budget.py
@@ -52,14 +52,18 @@ MODEL_PROFILES: dict[str, dict] = {
     },
     "medium": {
         "enforce_budget": True,
-        # SM-5: with the server-side sweep (report coverage type='sweep') a medium
-        # model can now honestly close injection cells without hand-running every
-        # probe, so coverage is a hard completion gate again. `small` stays
-        # advisory until the sweep is proven on a real 27B run (a hard gate on the
-        # smallest window risks the "spun on a 700-cell matrix and stalled" failure).
-        "enforce_coverage": True,
+        # LOCAL / weak-model tier (small is merged into this on the capability axis —
+        # model_detect no longer returns 'small'; it floors at 'medium'). Coverage is
+        # ADVISORY, not a hard gate: a local model is weaker at honestly closing a
+        # 700-900 cell matrix, so a hard floor drives game-then-stall (false
+        # tested_clean, then HIR_NO_PROGRESS) — the exact regression seen twice. The
+        # floor % stays visible in status/recovery as guidance; the closure-INTEGRITY
+        # guards (artifact-backed, auth-block, suspect-N/A) stay ON for every profile.
+        # enforce_coverage=True is ALSO what makes the skill-chain gates hard-block
+        # (completion_gates), so False here keeps those advisory for local too.
+        "enforce_coverage": False,
         "budget_multiplier": 1.0,    # base budgets as-is
-        "context_budget_chars": 160_000,  # ~40K tokens
+        "context_budget_chars": 160_000,  # ~40K tokens (overridden by SMITH_CONTEXT_WINDOW when known)
         "recovery_cells_shown": 10,
         "execute_next_in_summary": True,
         "condensed_directives": True,
@@ -80,13 +84,39 @@ MODEL_PROFILES: dict[str, dict] = {
 }
 
 
+def _window_scaled_budget() -> int | None:
+    """``context_budget_chars`` scaled from the model's REAL context window
+    (SMITH_CONTEXT_WINDOW, in tokens), or None when the window is unknown.
+
+    The per-profile default is a static number (full = 400K chars ≈ 100K tokens),
+    so a 200K- or 1M-token Claude/Qwen is throttled to a fraction of its real window
+    and the context-pressure meter fires far too early. When the true window is known
+    (the opencode installer exports it; an operator can export it for cloud Claude
+    too), derive the budget from it: ~3.5 chars/token, 75% headroom so pressure warns
+    before the client's own compaction fires."""
+    try:
+        from core.model_detect import _detected_context_window
+        win = _detected_context_window()
+        if win and win > 0:
+            return int(win * 3.5 * 0.75)
+    except Exception:
+        pass
+    return None
+
+
 def get_profile(profile_name: str | None = None) -> dict:
-    """Get model profile. Reads from session if not specified."""
+    """Get model profile. Reads from session if not specified. When the model's real
+    context window is known, context_budget_chars is scaled from it (see
+    _window_scaled_budget) instead of the profile's static default."""
     if profile_name is None:
         from core import session as scan_session
         current = scan_session.get()
         profile_name = (current or {}).get("model_profile", "full")
-    return MODEL_PROFILES.get(profile_name, MODEL_PROFILES["full"])
+    base = MODEL_PROFILES.get(profile_name, MODEL_PROFILES["full"])
+    scaled = _window_scaled_budget()
+    if scaled is not None:
+        return {**base, "context_budget_chars": scaled}
+    return base
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_server/scan_engine/envelope/assets.py
+++ b/mcp_server/scan_engine/envelope/assets.py
@@ -58,17 +58,25 @@ _JWT_RE = __import__("re").compile(r"eyJ[A-Za-z0-9_-]{4,}\.eyJ[A-Za-z0-9_-]{4,}\
 _AUTH_PATH_HINTS = ("login", "signin", "auth", "token", "session")
 
 
-def _update_jwt_tokens(scan_session: Any, req_headers: dict, body_prev: str, url: str) -> None:
-    """Scan response body + auth-y request headers for JWT strings and persist any found."""
+def _update_jwt_tokens(scan_session: Any, req_headers: dict, body_prev: str, url: str,
+                       body_jwts: list | None = None) -> None:
+    """Scan response body + auth-y request headers for JWT strings and persist any found.
+
+    ``body_jwts`` (pre-extracted from the FULL response body by the summarizer) is
+    preferred over the truncated body_prev so a token deeper than 500 chars is still
+    captured — otherwise the sweep's auth self-heal has no token to replay."""
     from datetime import datetime, timezone
     haystack = body_prev
     for k, v in req_headers.items():
         if isinstance(v, str) and "auth" in k.lower():
             haystack += " " + v
+    found = list(body_jwts or []) + _JWT_RE.findall(haystack)
+    seen: set = set()
+    uniq = [m for m in found if not (m in seen or seen.add(m))]
     tokens = [
         {"type": "jwt", "value": m,
          "obtained_at": datetime.now(timezone.utc).isoformat(), "source_url": url}
-        for m in _JWT_RE.findall(haystack)
+        for m in uniq
     ]
     if tokens:
         scan_session.update_known_assets("auth_tokens", tokens)
@@ -86,6 +94,16 @@ def _update_credentials(
         req_data = json.loads(req_body) if req_body.lstrip().startswith("{") else None
     except Exception:
         req_data = None
+    if not isinstance(req_data, dict):
+        # Form-urlencoded login (username=x&password=y) — the classic HTML-form case
+        # the JSON-only path was silently dropping, so form-auth apps captured no creds.
+        if "=" in req_body:
+            from urllib.parse import parse_qs
+            try:
+                req_data = {k: v[0] for k, v in
+                            parse_qs(req_body, keep_blank_values=True).items() if v}
+            except Exception:
+                req_data = None
     if not isinstance(req_data, dict):
         return
     uname = req_data.get("username") or req_data.get("user") or req_data.get("email")
@@ -154,7 +172,8 @@ def _persist_http_auth_assets(scan_session: Any, evidence: dict, ctx: dict) -> N
     req_body    = ctx.get("body", "") or ""
     req_headers = ctx.get("headers") or {}
 
-    _update_jwt_tokens(scan_session, req_headers, body_prev, url)
+    _update_jwt_tokens(scan_session, req_headers, body_prev, url,
+                       body_jwts=evidence.get("jwt_hits"))
     _update_credentials(scan_session, url, method, status, req_body)
     _update_session_cookies(scan_session, evidence, url)
     _update_rate_limits(scan_session, evidence, url)

--- a/mcp_server/scan_engine/summarizers/http.py
+++ b/mcp_server/scan_engine/summarizers/http.py
@@ -168,6 +168,12 @@ def _summarize_http_request(raw: str, ctx: dict) -> SummaryResult:
         "status": status,
         "content_type": headers.get("Content-Type", ""),
         "body_preview": body[:500],
+        # Capture JWTs from the FULL body, not just the 500-char preview — a real
+        # login response often carries the token deeper than 500 chars, and the auth
+        # asset capture (envelope/assets.py) would otherwise miss it, starving the
+        # sweep's auth self-heal of a token to replay.
+        "jwt_hits": __import__("re").findall(
+            r"eyJ[A-Za-z0-9_-]{4,}\.eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]+", body)[:5],
         # CH-2: surface Set-Cookie so the envelope can capture a session cookie
         # into known_assets for reuse (the majority of classic web apps are
         # cookie-session, not JWT).

--- a/mcp_server/session_tools/__init__.py
+++ b/mcp_server/session_tools/__init__.py
@@ -25,9 +25,15 @@ from mcp.server.fastmcp import Context
 
 _background_tasks: set[asyncio.Task] = set()  # keeps fire-and-forget tasks alive
 
-# Track completion attempts — after _MAX_COMPLETE_ATTEMPTS the scan escalates to HIR
+# Track completion attempts — after _MAX_COMPLETE_ATTEMPTS the scan escalates to the
+# HIR_FORCE_COMPLETE human-override valve. Kept low (4) so a genuinely-stuck scan
+# reaches a human quickly with the accept-gaps / skip-cells options, instead of the
+# agent silently giving up long before the valve (the observed failure: a findings-rich
+# run stopped at complete_attempts=2 and never escalated). The progress-aware refund
+# below means legitimate one-blocker-at-a-time fixing does NOT accumulate attempts, so
+# a low ceiling only bites truly non-progressing retries.
 _complete_attempts = 0
-_MAX_COMPLETE_ATTEMPTS = 8
+_MAX_COMPLETE_ATTEMPTS = 4
 
 # Blocker count from the previous complete() attempt. Under condensed (small/
 # medium) profiles, blockers are surfaced ONE AT A TIME, so a model legitimately

--- a/mcp_server/session_tools/complete.py
+++ b/mcp_server/session_tools/complete.py
@@ -63,11 +63,59 @@ async def _autoclose_crosscutting_best_effort() -> None:
         log.note("auto_crosscutting (pre-complete) failed — non-fatal")
 
 
+def _thorough_keep_working_response(current: dict) -> str:
+    """Directive returned to the AGENT when it calls complete() in thorough mode —
+    thorough is OPERATOR-TERMINATED, so the agent never ends the scan; it keeps
+    working until the operator clicks Complete Scan. Points at concrete next work."""
+    lines = [
+        "THOROUGH MODE — the scan does NOT auto-complete; only the OPERATOR ends it "
+        "(the dashboard 'Complete Scan' button). Do NOT call session(action='complete') "
+        "again — there are no cost/time/call limits; keep testing until the operator stops you:",
+    ]
+    try:
+        from core.coverage import get_matrix
+        pending = sum(1 for c in get_matrix().get("matrix", []) if c.get("status") == "pending")
+        if pending:
+            lines.append(
+                f"  • {pending} coverage cells still pending — burn them down: "
+                "report(action='coverage', data={type:'sweep', max_cells:60}) repeatedly, then "
+                "report(action='coverage', data={type:'auto_crosscutting'}), then next_batch/bulk_tested.")
+    except Exception:
+        pass
+    gates = [g for g in (current.get("gates") or []) if g.get("status") == "pending"]
+    missing = sorted({s for g in gates
+                      for s in (set(g.get("required_skills", [])) - set(g.get("satisfied_skills", [])))})
+    if missing:
+        lines.append(f"  • Skills not yet run: {', '.join(missing)} — chain each applicable one.")
+    lines.append("  • Adjudicate each high/critical finding, then go DEEPER — chain confirmed findings "
+                 "to maximum impact and re-test at escalating aggression.")
+    lines.append("Keep going. The operator will complete the scan when satisfied.")
+    return "\n".join(lines)
+
+
 def _do_complete():
+    current0 = _st.scan_session.get() or {}
+    # THOROUGH = OPERATOR-TERMINATED. In thorough depth the AGENT can never end the
+    # scan — it keeps working until the operator clicks Complete Scan (POST /api/complete
+    # → scan_session.complete() directly, unaffected by this gate). We short-circuit
+    # BEFORE counting an attempt, so this never trips HIR_FORCE_COMPLETE either.
+    if str(current0.get("depth", "")).lower() == "thorough":
+        return _thorough_keep_working_response(current0)
     _st._complete_attempts += 1
 
     data = findings_store._load()
     current = _persist_completion_counters()
+
+    # Skill-chain gates must be EVALUATED honestly at completion:
+    #  - restore_gates() un-defers gates the per-response throttle parked, so a
+    #    deferred gate can no longer leak past the terminal check (they were both
+    #    non-blocking AND invisible to recovery).
+    #  - reconcile_worked_gates() satisfies each gate whose required skills actually
+    #    DID work — a merely-declared skill (set_skill without running the workflow)
+    #    does not clear its gate. Together: thorough mode genuinely requires the
+    #    applicable skills to run before it can complete.
+    _st.scan_session.restore_gates()
+    _st.scan_session.reconcile_worked_gates()
 
     effective = _st._effective_tools()
     blockers = _st._collect_completion_blockers(data, effective)

--- a/mcp_server/session_tools/completion_gates.py
+++ b/mcp_server/session_tools/completion_gates.py
@@ -81,7 +81,14 @@ def _collect_completion_blockers(data: dict, effective: set) -> list[str]:
     """Run all completion gate checks and return the list of blocker strings."""
     blockers: list[str] = []
 
-    blockers.extend(_st._gate_blockers())
+    # Skill-chain gates HARD-BLOCK completion only on the enforcing (full / capable
+    # cloud) profile. On local/weak profiles (medium+small, enforce_coverage=False)
+    # they are ADVISORY — still surfaced in recovery/status, but not a completion wall
+    # — because a weak model that already exploited the domains shouldn't be wedged for
+    # not formally running each skill workflow (the game-then-stall failure).
+    from mcp_server.scan_engine.budget import get_profile
+    if get_profile().get("enforce_coverage", True):
+        blockers.extend(_st._gate_blockers())
     blockers.extend(_st._qa_blockers())
     blockers.extend(_st._escalation_lead_blockers(data))
 

--- a/mcp_server/session_tools/coverage_gates.py
+++ b/mcp_server/session_tools/coverage_gates.py
@@ -12,6 +12,38 @@ from .integrity_gates import _integrity_blockers
 # being reused to "close" 36 different injection cells).
 _COVERAGE_FLOOR_PCT = 40
 
+# Cross-cutting cell types that are fanned out for EVERY endpoint (taxonomy.py)
+# but have NO automated closer anywhere — not the injection sweep (sweep.py) nor
+# the cross-cutting auto-closer (autoclose.py handles only cors/csrf/
+# security_headers/cache). Each can only be closed by a bespoke authenticated
+# request, so on a 55-endpoint app they alone add 5×55=275 pure-manual cells and
+# dominate the matrix. Counting them in the FLOOR denominator makes 40% demand
+# hundreds of hand-tests the pipeline can't assist with, so the floor becomes
+# practically unreachable and the model rationally abandons it. Exclude them from
+# the floor's denominator (they still exist in the matrix and stay visible as
+# advisory gaps + are honestly closable by hand) so the floor measures the work
+# the automated closers (sweep + auto_crosscutting) CAN actually drive to done.
+_NO_AUTOCLOSER_TYPES = {"rate_limit", "method_tampering", "jwt", "race", "bfla"}
+
+
+def _floor_view(cov: dict, total: int, addressed: int) -> tuple[int, int, float]:
+    """Recompute (total, addressed, pct) for the coverage FLOOR over only the cells
+    the pipeline can help close — i.e. excluding _NO_AUTOCLOSER_TYPES. Falls back to
+    the raw numbers when the matrix list isn't materialised (stub/partial matrices),
+    so it never inflates coverage on a matrix it can't see."""
+    matrix = cov.get("matrix", [])
+    _addressed_states = ("tested_clean", "vulnerable", "not_applicable")
+    excl_total = sum(1 for c in matrix if c.get("injection_type") in _NO_AUTOCLOSER_TYPES)
+    excl_addr = sum(
+        1 for c in matrix
+        if c.get("injection_type") in _NO_AUTOCLOSER_TYPES
+        and c.get("status") in _addressed_states
+    )
+    c_total = max(0, total - excl_total)
+    c_addr = max(0, addressed - excl_addr)
+    c_pct = (c_addr / c_total * 100) if c_total else 100.0
+    return c_total, c_addr, c_pct
+
 
 def _low_coverage_blocker(cov: dict, total: int, addressed: int, pct: float) -> str | None:
     """Block completion while the coverage matrix is substantially unworked.
@@ -31,16 +63,24 @@ def _low_coverage_blocker(cov: dict, total: int, addressed: int, pct: float) -> 
     stuck-completion HIR (_MAX_COMPLETE_ATTEMPTS) is the safety valve when the model
     genuinely can't reach the floor, so this can't hard-stall.
     """
-    if pct >= _COVERAGE_FLOOR_PCT:
+    # Judge the floor over the cells the automated closers can actually drive to
+    # done — not the auto-fanned manual-only cross-cutting cells that inflate the
+    # denominator into an unreachable wall.
+    f_total, f_addr, f_pct = _floor_view(cov, total, addressed)
+    if f_pct >= _COVERAGE_FLOOR_PCT:
         return None
     pending = sum(1 for c in cov.get("matrix", []) if c.get("status", "pending") == "pending")
     return (
-        f"SCAN NOT COMPLETE — the coverage matrix is the deliverable and it is only {pct:.0f}% worked "
-        f"({addressed}/{total} cells; {pending} still untested). Working the matrix IS the remaining "
-        f"job, not optional bookkeeping — you do NOT finish by finding some bugs while most cells are "
-        f"untested. Get the next cells + their exact requests with report(action='coverage', "
-        f"data={{type:'next_batch'}}), test them with REAL probes (sqlmap / nuclei / targeted "
-        f"payloads — never canned filler), then close each with its artifact via "
+        f"SCAN NOT COMPLETE — the coverage matrix is the deliverable and it is only {f_pct:.0f}% worked "
+        f"({f_addr}/{f_total} closeable cells; {pending} still untested). Working the matrix IS the "
+        f"remaining job, not optional bookkeeping — you do NOT finish by finding some bugs while most "
+        f"cells are untested. Close cells FAST with the mechanized closers, not one-by-one: "
+        f"(1) report(action='coverage', data={{type:'sweep', max_cells:60}}) repeatedly — it probes + "
+        f"auto-closes pending injection cells (sqli/xss/ssti/cmdi/traversal) and hands you oracle-"
+        f"positive candidates to confirm+file; (2) report(action='coverage', data={{type:'auto_"
+        f"crosscutting'}}) to bulk-close app-wide CORS / security-header / CSRF / cache cells in one "
+        f"call. For what remains, report(action='coverage', data={{type:'next_batch'}}) → test with "
+        f"REAL probes (sqlmap / nuclei / targeted payloads — never canned filler) → close via "
         f"report(action='coverage', data={{type:'bulk_tested', updates:[...]}}). Mark a cell "
         f"not_applicable ONLY when the injection type is genuinely irrelevant to that param (with a "
         f"specific reason) — do NOT bulk-N/A to clear the count. Keep working the matrix; if you are "

--- a/mcp_server/session_tools/integrity_gates.py
+++ b/mcp_server/session_tools/integrity_gates.py
@@ -77,9 +77,18 @@ def _na_untooled_blocker(cells: list[dict], bypass_types: dict) -> str | None:
 
 
 def _injection_breadth_blocker(cells: list[dict], coverage_enforced: bool) -> str | None:
-    """Return a blocker if text params have sqli cells but no xss/ssti/ssrf/cmdi cells."""
+    """Return a blocker if text params have sqli cells but no xss/ssti/ssrf/cmdi cells.
+
+    'path' is deliberately EXCLUDED: the taxonomy never generates an ssrf cell for a
+    path param (core/taxonomy.py — path/integer=[sqli,idor,traversal],
+    path/string=[sqli,xss,ssti,traversal,cmdi,idor]), so demanding the full breadth
+    set for a sqli-bearing path param is structurally unsatisfiable — every complete()
+    then re-hits this wall and burns the attempt/context budget (verified deadlock on
+    'account_number'). Path params get their own idor/traversal coverage; the
+    xss/ssti/ssrf/cmdi breadth push is for query/body params, which the taxonomy
+    fans out fully."""
     _BREADTH_REQUIRED = {"xss", "ssti", "ssrf", "cmdi"}
-    _TEXT_PARAM_TYPES = {"query", "body_form", "body_json", "path", "header", "cookie"}
+    _TEXT_PARAM_TYPES = {"query", "body_form", "body_json", "header", "cookie"}
     from collections import defaultdict
     by_param: dict[tuple, set] = defaultdict(set)
     for c in cells:

--- a/mcp_server/session_tools/recovery.py
+++ b/mcp_server/session_tools/recovery.py
@@ -160,6 +160,17 @@ def _do_recovery():
             ),
         }, indent=2)
 
+    # A running-session recovery IS the compaction boundary — the client just
+    # compacted its window and is re-orienting. Re-seed the context meter to the
+    # fixed resident overhead so pressure reflects the CURRENT window, not the
+    # lifetime-cumulative total (which would peg at Tier-3 forever and make the
+    # agent believe it is permanently out of context).
+    scan_session.reset_context_meter()
+    # Un-defer skill-chain gates so the recovery brief SURFACES the full remaining
+    # skill chain — the per-response throttle otherwise hides deferred gates here,
+    # so a re-oriented agent never learns which skills it still must run.
+    scan_session.restore_gates()
+
     # Coverage matrix: in_progress and pending cells
     from core.coverage import get_matrix
     cov = get_matrix()
@@ -177,7 +188,16 @@ def _do_recovery():
         if c["status"] == "in_progress"
     ]
 
-    pending_count = sum(1 for c in cov.get("matrix", []) if c["status"] == "pending")
+    # Count only CLOSEABLE pending cells for the exit-ramp — the no-autocloser
+    # cross-cutting types (rate_limit/method_tampering/jwt/race/bfla) are excluded
+    # from the coverage floor too, so telling the agent to "drain ALL pending" over
+    # cells nothing can close contradicts the gate and sends it chasing uncloseable
+    # work. Aligns recovery with coverage_gates._floor_view.
+    from mcp_server.session_tools.coverage_gates import _NO_AUTOCLOSER_TYPES
+    pending_count = sum(
+        1 for c in cov.get("matrix", [])
+        if c["status"] == "pending" and c.get("injection_type") not in _NO_AUTOCLOSER_TYPES
+    )
 
     # Findings with pending escalation leads
     data = findings_store._load()

--- a/mcp_server/session_tools/recovery_build.py
+++ b/mcp_server/session_tools/recovery_build.py
@@ -170,14 +170,22 @@ def _concrete_next_call(target: str, tools_run: set, in_progress: list, pending_
         return f"scan(tool='nuclei', target='{target}')"
     if pending_count > 0:
         # Concrete next action so a respawned/recovered model doesn't flounder
-        # (it kept looking for in_progress work, found none, and idled). Give a
-        # specific high-value probe AND the finish-up path — never a vague nudge.
+        # (it kept looking for in_progress work, found none, and idled). Drive the
+        # MECHANIZED closers in a loop — NOT a "finish if exploitation is done" exit
+        # ramp, which is exactly what let a findings-rich run stop at ~20% coverage.
+        # Finishing comes only AFTER the pending queue is drained (or a human approves
+        # the gaps via the stuck-completion HIR).
         return (
-            f"{pending_count} cells still pending. Do ONE of these now — do NOT idle: "
-            f"(A) test a high-value endpoint: {_next_pending_probe(target)}; or "
-            "(B) if exploitation is done, FINISH — adjudicate each high/critical finding "
-            "(report(action='update_finding', data={id, adjudication:{reproducible, rationale, "
-            "artifact_id}})), then session(action='complete')."
+            f"{pending_count} cells still pending — do NOT idle and do NOT stop to summarise. "
+            f"Burn them down in a loop, cheapest first: "
+            f"(1) report(action='coverage', data={{type:'sweep', max_cells:60}}) — repeat until it "
+            f"returns no more candidates, confirming + filing each oracle-positive cell; "
+            f"(2) report(action='coverage', data={{type:'auto_crosscutting'}}) to bulk-close app-wide "
+            f"CORS / security-header / CSRF / cache cells in one call; "
+            f"(3) for what remains, {_next_pending_probe(target)} then close it via "
+            f"report(action='coverage', data={{type:'bulk_tested', updates:[...]}}). "
+            f"ONLY once pending is drained: adjudicate each high/critical finding "
+            f"(report(action='update_finding', ...)), then session(action='complete')."
         )
     return "session(action='complete', options={\"notes\": \"all testing complete\"})"
 

--- a/mcp_server/session_tools/skills.py
+++ b/mcp_server/session_tools/skills.py
@@ -19,7 +19,14 @@ def _do_artifact(opts):
     mode = opts.get("mode", "summary")
     max_chars = opts.get("max_chars", 4000)
     pattern = opts.get("pattern", "")
-    return retrieve_artifact(artifact_id, mode=mode, max_chars=max_chars, pattern=pattern)
+    result = retrieve_artifact(artifact_id, mode=mode, max_chars=max_chars, pattern=pattern)
+    # Make the context meter honest: artifact retrieval bypasses the wrap() path, so
+    # without this the pressure gauge is blind to (now-bounded) pulls into the window.
+    try:
+        _st.scan_session.charge_context(len(result))
+    except Exception:
+        pass
+    return result
 
 
 
@@ -78,7 +85,11 @@ def _manage_skill_gates(skill_name: str, result: dict) -> list[str]:
     """Satisfy gates requiring skill_name, defer others. Returns list of satisfied gate IDs."""
     satisfied_gates: list[str] = []
     for gate in result.get("gates", []):
-        if gate["status"] == "pending" and skill_name in gate["required_skills"]:
+        # Satisfy only when the skill has actually done work — a bare set_skill
+        # declaration must NOT clear a completion gate (enforce-properly). The
+        # completion path also runs reconcile_worked_gates() as the backstop.
+        if (gate["status"] == "pending" and skill_name in gate["required_skills"]
+                and _st.scan_session.skill_worked(skill_name)):
             _st.scan_session.satisfy_gate(gate["id"], skill_name)
             satisfied_gates.append(gate["id"])
 

--- a/mcp_server/session_tools/start.py
+++ b/mcp_server/session_tools/start.py
@@ -27,6 +27,16 @@ def _start_response(cfg: dict, classification: dict, target: str, scan_mode: str
         else "Pentest (human-in-the-loop for exploitation decisions)"
     )
     first_move = _start_first_move(classification, target)
+    # Freshly minted in _do_start(); the token rides the URL *fragment* so it
+    # never hits an HTTP access log. Surface the whole link here so the operator
+    # can open the dashboard even if the agent runs report(action='dashboard')
+    # silently (the failure the operator hit: dashboard started, token never shown).
+    try:
+        from core import dashboard_auth
+        _tok = dashboard_auth.read_token()
+    except Exception:
+        _tok = None
+    dash_url = f"http://localhost:7777/#k={_tok}" if _tok else "http://localhost:7777/"
     lines = [
         "Scan started.",
         f"  Target: {target} | Depth: {cfg['depth_label']} | Mode: {mode_label} | Limits: {cost_str}/{time_str}/{call_limit_str}",
@@ -36,6 +46,13 @@ def _start_response(cfg: dict, classification: dict, target: str, scan_mode: str
         f"  Model profile: {cfg.get('model_profile', 'full')} "
         f"({cfg.get('model_profile_reason', 'default')}) — scopes context/output budgets. "
         f"Override with options={{model_profile: 'full|medium|small'}} or env SMITH_MODEL_PROFILE.",
+        "",
+        "  ┌─ DASHBOARD ─────────────────────────────────────────────────────────",
+        f"  │  {dash_url}",
+        "  │  Open in a browser to watch this scan live. The #k=… token is the",
+        "  │  dashboard key — it is REQUIRED to load data, and a new scan mints a",
+        "  │  new one. Show this link to the operator before you go silent.",
+        "  └─────────────────────────────────────────────────────────────────────",
         "",
     ]
     if scan_mode == "benchmark":
@@ -62,7 +79,8 @@ def _start_response(cfg: dict, classification: dict, target: str, scan_mode: str
     except Exception:
         pass
     lines += [
-        "EXECUTE NOW (do not ask questions, do not output text):",
+        "EXECUTE NOW (do not ask questions): first give the operator the DASHBOARD",
+        "link shown above, then continue silently from here.",
         "  report(action='dashboard', data={'port': 7777})",
         first_move if not is_resume else "  Continue from recovery state above — follow EXECUTE_NOW field.",
         "",
@@ -143,6 +161,11 @@ def _do_start(opts):
             "Respond via session(action='resume', options={choice: '...', message: '...'}) "
             "before starting a new scan."
         )
+    # Capture persisted completion progress BEFORE the reset so a same-target RESUME
+    # (e.g. after an MCP daemon restart zeroed these process-global counters) keeps its
+    # attempt/pass progress instead of silently starting the thorough passes over.
+    _prev_complete_attempts = existing.get("complete_attempts", 0) or 0
+    _prev_analysis_passes = existing.get("analysis_passes", 0) or 0
     _st._complete_attempts = 0
     _st._analysis_passes = 0
     _st._last_blocker_count = None
@@ -179,7 +202,20 @@ def _do_start(opts):
     # FastAPI middleware requires it as a bearer token on every /api/* call.
     try:
         from core import dashboard_auth
-        dashboard_auth.mint_token()
+        _tok = dashboard_auth.mint_token()
+        # Print the dashboard link (token in the URL *fragment*) to the MCP
+        # server's stderr — the operator's own console / `docker logs`. This is
+        # the one channel that does NOT depend on the agent choosing to relay the
+        # report(action='dashboard') result, which the EXECUTE-NOW block otherwise
+        # tells it to run silently. A fragment never reaches an HTTP access log
+        # (see dashboard_auth docstring); stderr is operator-facing by design.
+        import sys as _sys
+        print(
+            f"\n[agent-smith] Dashboard → http://localhost:7777/#k={_tok}\n"
+            "[agent-smith]   open in a browser; the #k=… token is required to load "
+            "scan data (a new scan mints a new token).\n",
+            file=_sys.stderr, flush=True,
+        )
     except Exception:
         pass
     # Deterministic target classification — an advisory PRIOR, never a gate. It
@@ -191,6 +227,13 @@ def _do_start(opts):
     _cur = scan_session.get()
     if _cur is not None:
         _cur["classifier"] = classification
+        # Same-target resume: restore the completion counters scan_session.start()
+        # just zeroed, so an MCP restart mid-thorough-scan doesn't lose pass progress.
+        if is_resume and (_prev_complete_attempts or _prev_analysis_passes):
+            _st._complete_attempts = _prev_complete_attempts
+            _st._analysis_passes = _prev_analysis_passes
+            _cur["complete_attempts"] = _prev_complete_attempts
+            _cur["analysis_passes"] = _prev_analysis_passes
         scan_session._flush()
     try:
         from core.adjunction.log import clear as _adj_log_clear

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -37,6 +37,16 @@ def test_dashboard_returns_html():
     assert "text/html" in response.headers["content-type"]
 
 
+def test_html_and_static_assets_sent_no_cache():
+    """The dashboard HTML + static JS/CSS must carry Cache-Control: no-cache so the
+    browser revalidates and never serves a stale copy of an un-versioned script
+    (the recurring 'findings blank / stale dashboard' bug)."""
+    assert client.get("/").headers.get("cache-control") == "no-cache"
+    js = client.get("/static/js/common.js")
+    assert js.status_code == 200
+    assert js.headers.get("cache-control") == "no-cache"
+
+
 # ── GET /api/findings ─────────────────────────────────────────────────────────
 
 def test_api_findings_returns_json(tmp_path, monkeypatch):

--- a/tests/test_api_smith_endpoints.py
+++ b/tests/test_api_smith_endpoints.py
@@ -1129,6 +1129,77 @@ class TestSpawnSmith:
         # subprocess should NEVER be called when the binary is missing
         spawn.assert_not_called()
 
+    def test_claude_respawn_strips_api_key_to_use_subscription(self, spawn_env, monkeypatch):
+        """A headless `claude -p` respawn must NOT inherit ANTHROPIC_API_KEY — with it,
+        the child bills the API pay-as-you-go account ('Credit balance is too low' when
+        empty) instead of the operator's Claude subscription (the interactive run's
+        auth). Regression guard for the watchdog credit dead-end."""
+        env = spawn_env
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-be-stripped")
+        monkeypatch.delenv("SMITH_SPAWN_USE_API_KEY", raising=False)
+        captured: dict = {}
+
+        async def _cap(*args, **kw):
+            captured.update(kw)
+            m = MagicMock(); m.pid = 24680
+            return m  # MagicMock.wait() is non-awaitable → probe assumes alive
+
+        with patch.dict("sys.modules", {"core.steering": env["steering_module"]}), \
+             patch("core.session.load_from_disk"), \
+             patch("core.session.get", return_value={}), \
+             patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("asyncio.create_subprocess_exec", side_effect=_cap):
+            ok, _ = asyncio.get_event_loop().run_until_complete(
+                api._spawn_smith("claude", source="test")
+            )
+
+        assert ok is True
+        assert "ANTHROPIC_API_KEY" not in captured["env"]
+        assert "ANTHROPIC_AUTH_TOKEN" not in captured["env"]
+
+    def test_claude_respawn_keeps_api_key_when_opted_in(self, spawn_env, monkeypatch):
+        """SMITH_SPAWN_USE_API_KEY=1 preserves API-key billing for subscription-less boxes."""
+        env = spawn_env
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-keep-me")
+        monkeypatch.setenv("SMITH_SPAWN_USE_API_KEY", "1")
+        captured: dict = {}
+
+        async def _cap(*args, **kw):
+            captured.update(kw)
+            m = MagicMock(); m.pid = 24681
+            return m
+
+        with patch.dict("sys.modules", {"core.steering": env["steering_module"]}), \
+             patch("core.session.load_from_disk"), \
+             patch("core.session.get", return_value={}), \
+             patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("asyncio.create_subprocess_exec", side_effect=_cap):
+            asyncio.get_event_loop().run_until_complete(
+                api._spawn_smith("claude", source="test")
+            )
+
+        assert captured["env"].get("ANTHROPIC_API_KEY") == "sk-keep-me"
+
+    def test_child_dying_on_launch_is_not_booked_as_respawn(self, spawn_env):
+        """A child that exits within the liveness window (credit/auth failure) must
+        return (False, reason) — NOT a phantom successful respawn that the watchdog's
+        no-progress fingerprint would then launder into a generic HIR_NO_PROGRESS."""
+        env = spawn_env
+        dead = MagicMock(); dead.pid = 99999
+        dead.wait = AsyncMock(return_value=1)  # exits immediately, rc=1
+
+        with patch.dict("sys.modules", {"core.steering": env["steering_module"]}), \
+             patch("core.session.load_from_disk"), \
+             patch("core.session.get", return_value={}), \
+             patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=dead)):
+            ok, result = asyncio.get_event_loop().run_until_complete(
+                api._spawn_smith("claude", source="test")
+            )
+
+        assert ok is False
+        assert "exited on launch" in result
+
     def test_posix_uses_start_new_session(self, spawn_env):
         """On macOS/Linux _spawn_smith must pass start_new_session=True to
         detach the child from the dashboard's process group."""
@@ -2194,3 +2265,14 @@ async def test_watchdog_tick_no_respawn_when_running_and_not_exited(tmp_path, mo
     monkeypatch.setattr(api, "_spawn_smith", _fake_spawn)
     await smith._watchdog_tick(10_000.0)
     assert spawned == []   # healthy run left alone
+
+
+# ── HIR no-progress: real spawn-failure reason surfaced (billing/usage/auth) ──
+
+def test_classify_spawn_failure_detects_usage_credit_auth():
+    from core.api_server.smith.progress import _classify_spawn_failure
+    assert _classify_spawn_failure("You're out of extra usage · resets 1:30pm")[0] == "usage"
+    assert _classify_spawn_failure("Credit balance is too low")[0] == "credit"
+    assert _classify_spawn_failure("Please run /login")[0] == "auth"
+    assert _classify_spawn_failure("normal agent exit") is None
+    assert _classify_spawn_failure("") is None

--- a/tests/test_gap_phase1b.py
+++ b/tests/test_gap_phase1b.py
@@ -92,7 +92,8 @@ class TestProfileFromWindow:
         return md.detect_profile()[0]
 
     def test_small_window(self, monkeypatch):
-        assert self._isolate(monkeypatch, 32768) == "small"
+        # small window floors to medium (small merged into medium on the capability axis)
+        assert self._isolate(monkeypatch, 32768) == "medium"
 
     def test_medium_window(self, monkeypatch):
         assert self._isolate(monkeypatch, 131072) == "medium"
@@ -101,13 +102,13 @@ class TestProfileFromWindow:
         assert self._isolate(monkeypatch, 200000) == "full"
 
     def test_window_beats_name_guess(self, monkeypatch):
-        # a small measured window wins over a frontier-sounding model name
+        # a small measured window wins over a frontier-sounding model name → medium floor
         from core import model_detect as md
         for v in ("SMITH_MODEL_PROFILE", "OLLAMA_HOST"):
             monkeypatch.delenv(v, raising=False)
         monkeypatch.setenv("OPENCODE_MODEL", "gpt-4o")   # would classify full by name
         monkeypatch.setenv("SMITH_CONTEXT_WINDOW", "32768")
-        assert md.detect_profile()[0] == "small"
+        assert md.detect_profile()[0] == "medium"
 
     def test_no_window_falls_through(self, monkeypatch):
         assert self._isolate(monkeypatch, None) == "full"

--- a/tests/test_model_detect.py
+++ b/tests/test_model_detect.py
@@ -21,10 +21,10 @@ def clean_env(monkeypatch):
     ("claude-opus-4-8", "full"),
     ("gpt-4o", "full"),
     ("gemini-2.0-flash", "full"),
-    ("qwen2.5:32b", "small"),
-    ("qwen3-27b-instruct", "small"),
-    ("llama3.1:8b", "small"),
-    ("mistral-7b", "small"),
+    ("qwen2.5:32b", "medium"),        # 'small' merged into 'medium' on the capability axis
+    ("qwen3-27b-instruct", "medium"),
+    ("llama3.1:8b", "medium"),
+    ("mistral-7b", "medium"),
     ("llama-3.1-70b", "medium"),
     ("qwen2.5:72b", "medium"),
 ])
@@ -53,18 +53,18 @@ def test_smith_override_env(clean_env, monkeypatch):
 
 def test_opencode_model_classified(clean_env, monkeypatch):
     monkeypatch.setenv("OPENCODE_MODEL", "qwen3-27b")
-    assert md.detect_profile(None)[0] == "small"
+    assert md.detect_profile(None)[0] == "medium"   # local floors to medium
 
 
 def test_client_var_beats_global_openai(clean_env, monkeypatch):
     monkeypatch.setenv("OPENAI_MODEL", "gpt-4o")        # frontier
     monkeypatch.setenv("OLLAMA_MODEL", "qwen2.5:32b")   # local — checked first
-    assert md.detect_profile(None)[0] == "small"
+    assert md.detect_profile(None)[0] == "medium"   # local floors to medium
 
 
 def test_ollama_host_bare_signal(clean_env, monkeypatch):
     monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
-    assert md.detect_profile(None)[0] == "small"
+    assert md.detect_profile(None)[0] == "medium"   # local runtime floors to medium
 
 
 def test_no_signal_defaults_full(clean_env):

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -18,12 +18,31 @@ class _FakeSession:
     def __init__(self, depth="thorough"):
         self.depth = depth
         self.triggered = []
+        self.trigger_calls = []
 
     def trigger_gate(self, gate_id, reason, skills):
         self.triggered.append(gate_id)
+        self.trigger_calls.append((gate_id, list(skills)))
 
     def get(self):
         return {"depth": self.depth}
+
+
+def test_finding_gates_rce_obligates_shell_and_container_escape(monkeypatch):
+    """A confirmed RCE inside a container must obligate the ESCALATION — reverse-shell
+    (get a real session) + container-k8s-security (escape) — not just post-exploit.
+    This closes the run_2 gap where RCE proved command-exec and stopped there."""
+    from mcp_server.report_tools import gates as gmod
+    sess = _FakeSession()
+    monkeypatch.setattr(gmod, "scan_session", sess)
+    out = _auto_trigger_finding_gates(
+        "RCE via PostgreSQL COPY TO PROGRAM (postgres superuser) - Docker Container",
+        "critical", "confirmed command execution uid=999(postgres) inside docker container")
+    assert "post_exploit_rce" in out and "container_k8s" in out
+    calls = dict(sess.trigger_calls)
+    assert "reverse-shell" in calls["post_exploit_rce"]        # obligate a real shell
+    assert "post-exploit" in calls["post_exploit_rce"]
+    assert calls["container_k8s"] == ["container-k8s-security"]
 
 
 def test_finding_gates_skip_benign(monkeypatch):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -512,6 +512,46 @@ def test_pending_gates_empty_without_session():
     assert core.session.pending_gates() == []
 
 
+# ── enforce-properly: skill-chain gates need real WORK, not just declaration ──
+
+def test_skill_worked_false_on_bare_declaration():
+    core.session.start("example.com")
+    core.session.set_skill("api-security")  # declared, no tool work yet
+    assert core.session.skill_worked("api-security") is False
+
+
+def test_skill_worked_true_after_a_tool_call():
+    core.session.start("example.com")
+    core.session.set_skill("api-security")
+    core.session.add_tool_called("http")   # a tool fired while api-security is active
+    assert core.session.skill_worked("api-security") is True
+
+
+def test_reconcile_worked_gates_only_satisfies_worked_skills():
+    core.session.start("example.com")
+    core.session.trigger_gate("api_coverage", "api discovered", ["api-security"])
+    # Declared but not worked → gate stays pending after reconcile.
+    core.session.set_skill("api-security")
+    core.session.reconcile_worked_gates()
+    assert any(g["id"] == "api_coverage" and g["status"] == "pending"
+               for g in core.session.get()["gates"])
+    # Now it does work → reconcile satisfies the gate.
+    core.session.add_tool_called("http")
+    core.session.reconcile_worked_gates()
+    assert all(g["status"] == "satisfied"
+               for g in core.session.get()["gates"] if g["id"] == "api_coverage")
+
+
+# ── context meter resets at the compaction/recovery boundary ──────────────────
+
+def test_reset_context_meter_drops_to_fixed_overhead():
+    core.session.start("example.com")
+    core.session.charge_context(500_000)   # simulate a long run pegging the meter
+    assert core.session.get()["context_chars_sent"] > 400_000
+    core.session.reset_context_meter()
+    assert core.session.get()["context_chars_sent"] == core.session._fixed_context_overhead_chars()
+
+
 def test_gates_persisted_to_file(tmp_path, monkeypatch):
     import json
     monkeypatch.setattr(core.session, "_SESSION_FILE", tmp_path / "session.json")

--- a/tests/test_session_tools_helpers.py
+++ b/tests/test_session_tools_helpers.py
@@ -954,16 +954,19 @@ class TestDoComplete:
             or "complete" in result.lower()
         )
 
-    def test_thorough_depth_no_blockers_adds_iteration_gate(self, tmp_path, monkeypatch):
+    def test_thorough_is_operator_terminated_agent_never_completes(self, tmp_path, monkeypatch):
+        # THOROUGH is OPERATOR-TERMINATED: the agent's complete() never ends the scan —
+        # it is told to keep working until the operator clicks Complete Scan, and it must
+        # NOT count as a complete() attempt (so it can't trip HIR_FORCE_COMPLETE).
         import mcp_server.session_tools as st
-        monkeypatch.setattr(st, "_analysis_passes", 0)
+        monkeypatch.setattr(st, "_complete_attempts", 0)
         self._setup_session(tmp_path, monkeypatch, depth="thorough")
         with patch("mcp_server.session_tools._effective_tools", return_value=set()), \
-             patch("mcp_server.session_tools._collect_completion_blockers", return_value=[]), \
-             patch("mcp_server.session_tools._is_whitebox_scan", return_value=False), \
-             patch("mcp_server.session_tools._deepen_brief", return_value="ITERATION GATE: pass 1"):
+             patch("mcp_server.session_tools._collect_completion_blockers", return_value=[]):
             result = _do_complete()
-        assert "ITERATION GATE" in result or "complete BLOCKED" in result
+        assert "does NOT auto-complete" in result
+        assert "operator" in result.lower() and "keep" in result.lower()
+        assert st._complete_attempts == 0  # not counted as an attempt
 
     def test_multiple_blockers_full_profile_shows_all(self, tmp_path, monkeypatch):
         """Full profile (large context, ``condensed_directives=False``) gets the
@@ -1332,6 +1335,29 @@ def test_low_coverage_blocker_fires_below_floor_even_when_findings_rich():
 def test_low_coverage_blocker_passes_above_floor():
     cov = {"matrix": []}
     assert _low_coverage_blocker(cov, total=100, addressed=50, pct=50.0) is None
+
+
+def test_low_coverage_floor_excludes_no_autocloser_types():
+    # 10 injection cells fully worked + 90 pending rate_limit cells (no automated
+    # closer). Raw pct = 10/100 = 10%, but the floor must judge only the 10
+    # CLOSEABLE cells (100% worked) so it does NOT block on manual-only cruft.
+    matrix = (
+        [{"id": f"i{i}", "status": "tested_clean", "injection_type": "sqli"} for i in range(10)]
+        + [{"id": f"x{i}", "status": "pending", "injection_type": "rate_limit"} for i in range(90)]
+    )
+    assert _low_coverage_blocker({"matrix": matrix}, total=100, addressed=10, pct=10.0) is None
+
+
+def test_low_coverage_floor_still_blocks_when_closeable_cells_unworked():
+    # 50 unworked sqli (closeable) + 50 pending jwt (no closer). Closeable = 0/50 → blocks,
+    # and the message must point at the mechanized closers (sweep + auto_crosscutting).
+    matrix = (
+        [{"id": f"i{i}", "status": "pending", "injection_type": "sqli"} for i in range(50)]
+        + [{"id": f"j{i}", "status": "pending", "injection_type": "jwt"} for i in range(50)]
+    )
+    b = _low_coverage_blocker({"matrix": matrix}, total=100, addressed=0, pct=0.0)
+    assert b is not None and "SCAN NOT COMPLETE" in b
+    assert "sweep" in b and "auto_crosscutting" in b
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -76,6 +76,44 @@ async def test_sweep_leaves_auth_blocked_pending(coverage_file, running_session,
     assert all(s == "pending" for s in statuses)  # never auto-closed clean under auth block
 
 
+@pytest.mark.asyncio
+async def test_sweep_self_heals_401_by_retrying_with_known_auth(coverage_file, monkeypatch):
+    """A probe that hits 401/403 must be RETRIED with the session's captured auth
+    (Bearer token / cookies) so the cell is tested under auth — not recorded as a
+    permanent auth-block (wish-aa4da3d6)."""
+    monkeypatch.setattr(_artifacts, "_ARTIFACTS_DIR", core.coverage._ARTIFACTS_DIR)
+    scan_session._current = {
+        "status": "running", "target": "http://t.test",
+        "known_assets": {"auth_tokens": [{"type": "jwt", "value": "TOK123"}]},
+    }
+    try:
+        await core.coverage.add_endpoint(
+            "/a", "GET", [{"name": "q", "type": "query", "value_hint": ""}])
+        seen = {"authed": False}
+
+        async def fake_probe(url, method="GET", headers=None, body=None, timeout=20):
+            if headers and headers.get("Authorization") == "Bearer TOK123":
+                seen["authed"] = True
+                return {"status": 200, "headers": {}, "body": "nothing interesting here"}
+            return {"status": 401, "headers": {}, "body": "unauthorized"}
+
+        async def fake_kali(cmd, *a, **k):
+            return "all tested parameters do not appear to be injectable"
+
+        monkeypatch.setattr(http_tools, "http_probe", fake_probe)
+        monkeypatch.setattr(kali_runner, "exec_command", fake_kali)
+
+        await rt._do_coverage_sweep({"max_cells": 50}, core.coverage)
+
+        assert seen["authed"] is True  # retried WITH the captured token after the 401
+        statuses = {c["injection_type"]: c["status"]
+                    for c in core.coverage.get_matrix()["matrix"] if c["param"] == "q"}
+        assert statuses.get("xss") == "tested_clean"   # tested under auth, not auth-blocked
+        assert statuses.get("cmdi") == "tested_clean"
+    finally:
+        scan_session._current = None
+
+
 async def _async_ret(v):
     return v
 
@@ -90,10 +128,13 @@ async def test_sweep_no_target():
         scan_session._current = None
 
 
-def test_medium_enforces_coverage():
+def test_local_profiles_coverage_advisory():
+    # small is merged into medium on the capability axis — both advisory for weak local
+    # models; only the full (capable cloud) profile hard-enforces coverage + skill gates.
     from mcp_server.scan_engine import budget
-    assert budget.MODEL_PROFILES["medium"]["enforce_coverage"] is True
-    assert budget.MODEL_PROFILES["small"]["enforce_coverage"] is False  # still advisory
+    assert budget.MODEL_PROFILES["medium"]["enforce_coverage"] is False
+    assert budget.MODEL_PROFILES["small"]["enforce_coverage"] is False
+    assert budget.MODEL_PROFILES["full"]["enforce_coverage"] is True
 
 
 @pytest.mark.asyncio

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -123,14 +123,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     && rm -rf /var/lib/apt/lists/*
 
 # Layer 7: SMB / Windows / AD
-# rpcclient is bundled inside smbclient; ldapdomaindump is pip-only
+# rpcclient is bundled inside smbclient.
 # certipy-ad — ADCS enumeration and exploitation (ESC1-ESC8)
-# bloodhound — BloodHound ingestor for AD attack path mapping
+# bloodhound.py — BloodHound ingestor for AD attack path mapping
+# ldapdomaindump / certipy-ad / bloodhound.py all live in the Kali repos now, so
+# install them from apt rather than pip. The old `pip3 install certipy-ad==5.0.4`
+# tail pulled dnspython~=2.7.0 and pip cannot uninstall the apt-managed dnspython
+# 2.8.0 (no RECORD file) → `uninstall-no-record-file` aborted the ENTIRE image
+# build — even though apt had already installed all three tools on this same line.
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     smbmap smbclient samba-common-bin impacket-scripts \
     enum4linux-ng netexec ldap-utils python3-pip \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --no-cache-dir ldapdomaindump==0.9.4 certipy-ad==5.0.4 bloodhound==1.9.0 --break-system-packages
+    certipy-ad bloodhound.py python3-ldapdomaindump \
+    && rm -rf /var/lib/apt/lists/*
 
 # Layer 8: service enumeration
 # snmpwalk is bundled in the snmp package; snmp-check not available on arm64


### PR DESCRIPTION
## Summary

A batch of fixes hardening the autonomous scan loop, model-profile handling, post-exploitation depth, and the dashboard — plus the day's dashboard UX fixes. **46 source files, +1083/−125.** Paired skill-doc changes are in a linked PR: **0x0pointer/skills#53** (bumped via the submodule pointer here).

> Committed while a live scan is running. Nothing here touches scan runtime state — all runtime files (`session.json`, `findings.json`, `wishlist_queue.json`, `logs/`) are gitignored/excluded, and only source was staged.

## What's in it

### 🔁 Scan-loop stalls — agent stopped after ~30 min (mislabeled `HIR_NO_PROGRESS`)
Root cause was **not** raw logs in context; it was a cumulative-never-reset context meter + unsatisfiable gates + a subscription usage cap surfaced as the wrong HIR.
- `core/session/limits.py`, `mcp_server/session_tools/recovery.py`, `recovery_build.py` — reset the context-pressure meter on recovery/restart so it stops false-tripping.
- `core/session/gates.py`, `core/session/__init__.py`, `mcp_server/session_tools/complete.py` — a `worked` flag + `reconcile_worked_gates` + session-local `_scan_has_substantive_work`, so a gate obligates the **attempt** (skill ran + documented) and can never become permanently unsatisfiable. *(This was the regression you caught: the earlier work-while-active signal never fired because the agent exploits-first, then rapid-fires `set_skill`.)*

### 🎚️ Model-profile merge — `small` was structurally broken
- `mcp_server/scan_engine/budget.py`, `core/model_detect.py`, `mcp_server/session_tools/completion_gates.py` — fold `small` → `medium` on the capability axis; make medium's coverage **advisory (not enforced)** for local models; window-scaled budget; `_gate_blockers` behind `enforce_coverage`.

### ⏱️ `depth=thorough` = operator-terminated (never auto-stop)
- `mcp_server/session_tools/complete.py`, `start.py`, `scan_engine/budget.py` — no budget/time/call limits under thorough; completion short-circuits to "keep working" until the operator clicks **Complete Scan**.

### 🐚 RCE → shell / container-escape / lateral-movement escalation
The run_2 gap: a scan proved command execution but never turned it into shell access.
- `mcp_server/report_tools/gates.py` — a confirmed RCE now obligates **reverse-shell**, plus **container-k8s-security** when it's inside a container.
- `core/gate_keywords.py` — broadened container-detection keywords (`docker.sock`, `container escape`, `/proc/1/`, …).
- `core/qa_agent/checks_skills.py` + `daemon.py` + `__init__.py` — `_check_post_exploit_depth` nudges `MISSING_SHELL_ESCALATION` / `MISSING_CONTAINER_ESCAPE` / `MISSING_LATERAL_MOVEMENT` **mid-scan**, while the agent still holds the access.
- Paired skill docs (forward chains + blind-RCE playbook + OOB rendezvous): **0x0pointer/skills#53**.

### 💳 Spawn auth — subscription vs API credit (respawns hit "Credit balance is too low")
- `core/api_server/smith/spawn.py`, `watchdog.py`, `progress.py`, `__init__.py` — strip the inherited `ANTHROPIC_API_KEY` for the `claude` CLI so watchdog respawns use the **subscription**, not API credit; liveness probe + spawn-log tail; surface the **real** spawn-failure reason instead of a generic `HIR_NO_PROGRESS`.

### 🧮 Coverage-matrix robustness
- `mcp_server/report_tools/coverage.py` — auth-aware `sweep` + sqlmap (auth headers, 401/403 self-heal, 90s timeout).
- `mcp_server/session_tools/coverage_gates.py`, `integrity_gates.py` — dropped `path` from the breadth text-param types.
- `core/coverage/operations.py` — **archive the matrix before any wipe** (this saved your 891-cell matrix when a session clear fired).

### 🧠 Artifact context-budget clamp (DGX Spark / small-window safety)
- `mcp_server/scan_engine/artifacts.py` — `_artifact_ceiling` + head/tail truncation so `session(action='artifact', mode='full')` can't overflow a small context window.
- `mcp_server/session_tools/skills.py` — charge context on artifact retrieval.

### 🔑 Auth/creds extraction
- `mcp_server/scan_engine/summarizers/http.py`, `envelope/assets.py` — capture full-body JWTs and form-urlencoded credentials into `known_assets`.

### 🖥️ Dashboard
- `core/api_server/__init__.py` — `Cache-Control: no-cache` so stale JS can't linger.
- `core/api_server/routes/scan_state_routes.py` — HIR resolution consumes `ACCEPT_PARTIAL` / `ABORT`.
- `dashboard/finding.html`, `js/finding.js` — "back to all findings" uses `history.back()` (back-forward-cache restore) so the overview can't blank on return.
- `dashboard/js/findings.js`, `main.js` — the "last updated Ns ago" freshness counter now ticks on **every** tab (extracted `updateFreshness()`; skips during HIR so it won't stomp the "Scan paused" banner). `index.html` bumps `findings.js?v=5`.
- `mcp_server/session_tools/start.py` — surface the dashboard **access token** to the operator on scan start.

### 🧰 Misc
- `tools/kali/Dockerfile` — drop the pip `dnspython` conflict (`Cannot uninstall … no RECORD`), install via apt.
- `core/logger.py` + `mcp_server/__main__.py` — off-import session-boundary logging.
- `.gitignore` — add `wishlist_queue.json` (runtime state, like `steering_queue.json` and its siblings).

## Testing
Python test suite was **green at 1647 passed** as of the last full run covering all Python changes here; only frontend (`dashboard/js`, `finding.html`, `index.html`) and skill docs have changed since. Edited dashboard JS was `node --check`-clean. The suite was **not** re-run in this commit to avoid any interference with the live scan's runtime state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
