### PR TITLE
feat(kali): modular domain-gated image + installer module prompts

### DIFF
--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -258,6 +258,14 @@ function Confirm-Yes {
     return ($ans -eq '' -or $ans -match '^[Yy]')
 }
 
+function Confirm-Default {
+    param([string]$Prompt, [bool]$Default = $true)
+    $hint = if ($Default) { '[Y/n]' } else { '[y/N]' }
+    $ans = Read-Host "$Prompt $hint"
+    if ($ans -eq '') { return $Default }
+    return ($ans -match '^[Yy]')
+}
+
 # Lightweight scanner images — pulled, not built
 $ScannerImages = @(
     'instrumentisto/nmap'
@@ -284,9 +292,31 @@ if (Confirm-Yes '  Pull lightweight scanner images? (~2 min)') {
 
 Write-Host ''
 $KaliCtx = Join-Path $RepoDir 'tools\kali\'
-if (Confirm-Yes '  Build Kali image? (~10 min — required for most skills)') {
+if (Confirm-Yes '  Build Kali image? (required for most skills)') {
+    Write-Host ''
+    Write-Host '  Choose Kali tool modules (core is always included). Build-time'
+    Write-Host '  estimates are approximate and depend on your network speed:'
+    Write-Host ''
+    Write-Host '    core   (always)  MCP server, recon: nmap/nuclei/httpx/subfinder    ~6 min'
+    Write-Host '    web              web/API exploit, fuzzing, injection, JWT, SSL      ~8 min'
+    Write-Host '    infra            internal net, AD, credentials, service enum, pivot ~5 min'
+    Write-Host '    mobile           Android/iOS reversing + Frida dynamic analysis     ~4 min'
+    Write-Host '    cloud            AWS/Azure/GCP CLIs, Prowler, ScoutSuite, trivy      ~7 min'
+    Write-Host '    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest)   ~12 min'
+    Write-Host ''
+    $kaliArgs = @()
+    foreach ($m in @(
+        @{ Name = 'web';    Arg = 'INSTALL_WEB';    Def = $true  },
+        @{ Name = 'infra';  Arg = 'INSTALL_INFRA';  Def = $true  },
+        @{ Name = 'mobile'; Arg = 'INSTALL_MOBILE'; Def = $false },
+        @{ Name = 'cloud';  Arg = 'INSTALL_CLOUD';  Def = $false },
+        @{ Name = 'ai';     Arg = 'INSTALL_AI';     Def = $false }
+    )) {
+        $val = if (Confirm-Default ("    Include {0} module?" -f $m.Name) $m.Def) { '1' } else { '0' }
+        $kaliArgs += '--build-arg'; $kaliArgs += ('{0}={1}' -f $m.Arg, $val)
+    }
     Write-Host '  Building pentest-agent/kali-mcp (this may take a while)...'
-    docker build -t pentest-agent/kali-mcp $KaliCtx
+    docker build @kaliArgs -t pentest-agent/kali-mcp $KaliCtx
     if ($LASTEXITCODE -eq 0) {
         Write-Ok 'Kali image built: pentest-agent/kali-mcp'
     } else {

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -381,12 +381,43 @@ fi
 
 echo ""
 
-# Kali image (build)
-printf "  Build Kali image? (~10 min — required for most skills) [Y/n]: "
+# Kali image (build) — modular: choose which tool domains to bake in.
+# core is always installed; each other domain is a --build-arg toggle.
+printf "  Build Kali image? (required for most skills) [Y/n]: "
 read -r _kali_answer || true
 if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
+    echo ""
+    echo "  Choose Kali tool modules (core is always included). Build-time estimates"
+    echo "  are approximate and depend on your network speed:"
+    echo ""
+    echo "    core   (always)  MCP server, recon: nmap/nuclei/httpx/subfinder, wordlists  ~6 min"
+    echo "    web              web/API exploit, fuzzing, injection, JWT/OAuth, SSL, crawl  ~8 min"
+    echo "    infra            internal net, AD, credentials, service enum, pivoting       ~5 min"
+    echo "    mobile           Android/iOS reversing + Frida/objection dynamic analysis    ~4 min"
+    echo "    cloud            AWS/Azure/GCP CLIs, Prowler, ScoutSuite, trivy, kube-bench   ~7 min"
+    echo "    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest: torch)      ~12 min"
+    echo ""
+    _kali_build_args=()
+    _ask_kali_module() {  # $1=name  $2=build-arg  $3=default(Y|N)
+        local _def="$3" _ans _hint
+        [ "$_def" = "Y" ] && _hint="Y/n" || _hint="y/N"
+        printf "    Include %-7s module? [%s]: " "$1" "$_hint"
+        read -r _ans || true
+        _ans="${_ans:-$_def}"
+        if [[ "$_ans" =~ ^[Yy]$ ]]; then
+            _kali_build_args+=(--build-arg "$2=1")
+        else
+            _kali_build_args+=(--build-arg "$2=0")
+        fi
+    }
+    _ask_kali_module web    INSTALL_WEB    Y
+    _ask_kali_module infra  INSTALL_INFRA  Y
+    _ask_kali_module mobile INSTALL_MOBILE N
+    _ask_kali_module cloud  INSTALL_CLOUD  N
+    _ask_kali_module ai     INSTALL_AI     N
+    echo ""
     echo "  Building pentest-agent/kali-mcp (this may take a while)..."
-    if docker build -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then
+    if docker build "${_kali_build_args[@]}" -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then
         ok "Kali image built: pentest-agent/kali-mcp"
     else
         warn "Kali build failed — run manually: docker build -t pentest-agent/kali-mcp $REPO_DIR/tools/kali/"

--- a/installers/install_codex.ps1
+++ b/installers/install_codex.ps1
@@ -95,6 +95,14 @@ function Confirm-Yes {
     return ($ans -eq '' -or $ans -match '^[Yy]')
 }
 
+function Confirm-Default {
+    param([string]$Prompt, [bool]$Default = $true)
+    $hint = if ($Default) { '[Y/n]' } else { '[y/N]' }
+    $ans = Read-Host "$Prompt $hint"
+    if ($ans -eq '') { return $Default }
+    return ($ans -match '^[Yy]')
+}
+
 $ScannerImages = @(
     'instrumentisto/nmap'
     'projectdiscovery/naabu'
@@ -120,9 +128,31 @@ if (Confirm-Yes '  Pull lightweight scanner images? (~2 min)') {
 
 Write-Host ''
 $KaliCtx = Join-Path $RepoDir 'tools\kali\'
-if (Confirm-Yes '  Build Kali image? (~10 min - required for most skills)') {
+if (Confirm-Yes '  Build Kali image? (required for most skills)') {
+    Write-Host ''
+    Write-Host '  Choose Kali tool modules (core is always included). Build-time'
+    Write-Host '  estimates are approximate and depend on your network speed:'
+    Write-Host ''
+    Write-Host '    core   (always)  MCP server, recon: nmap/nuclei/httpx/subfinder    ~6 min'
+    Write-Host '    web              web/API exploit, fuzzing, injection, JWT, SSL      ~8 min'
+    Write-Host '    infra            internal net, AD, credentials, service enum, pivot ~5 min'
+    Write-Host '    mobile           Android/iOS reversing + Frida dynamic analysis     ~4 min'
+    Write-Host '    cloud            AWS/Azure/GCP CLIs, Prowler, ScoutSuite, trivy      ~7 min'
+    Write-Host '    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest)   ~12 min'
+    Write-Host ''
+    $kaliArgs = @()
+    foreach ($m in @(
+        @{ Name = 'web';    Arg = 'INSTALL_WEB';    Def = $true  },
+        @{ Name = 'infra';  Arg = 'INSTALL_INFRA';  Def = $true  },
+        @{ Name = 'mobile'; Arg = 'INSTALL_MOBILE'; Def = $false },
+        @{ Name = 'cloud';  Arg = 'INSTALL_CLOUD';  Def = $false },
+        @{ Name = 'ai';     Arg = 'INSTALL_AI';     Def = $false }
+    )) {
+        $val = if (Confirm-Default ("    Include {0} module?" -f $m.Name) $m.Def) { '1' } else { '0' }
+        $kaliArgs += '--build-arg'; $kaliArgs += ('{0}={1}' -f $m.Arg, $val)
+    }
     Write-Host '  Building pentest-agent/kali-mcp (this may take a while)...'
-    docker build -t pentest-agent/kali-mcp $KaliCtx
+    docker build @kaliArgs -t pentest-agent/kali-mcp $KaliCtx
     if ($LASTEXITCODE -eq 0) {
         Write-Ok 'Kali image built: pentest-agent/kali-mcp'
     } else {

--- a/installers/install_codex.sh
+++ b/installers/install_codex.sh
@@ -306,11 +306,43 @@ fi
 
 echo ""
 
-printf "  Build Kali image? (~10 min - required for most skills) [Y/n]: "
+# Kali image (build) - modular: choose which tool domains to bake in.
+# core is always installed; each other domain is a --build-arg toggle.
+printf "  Build Kali image? (required for most skills) [Y/n]: "
 read -r _kali_answer || true
 if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
+    echo ""
+    echo "  Choose Kali tool modules (core is always included). Build-time estimates"
+    echo "  are approximate and depend on your network speed:"
+    echo ""
+    echo "    core   (always)  MCP server, recon: nmap/nuclei/httpx/subfinder, wordlists  ~6 min"
+    echo "    web              web/API exploit, fuzzing, injection, JWT/OAuth, SSL, crawl  ~8 min"
+    echo "    infra            internal net, AD, credentials, service enum, pivoting       ~5 min"
+    echo "    mobile           Android/iOS reversing + Frida/objection dynamic analysis    ~4 min"
+    echo "    cloud            AWS/Azure/GCP CLIs, Prowler, ScoutSuite, trivy, kube-bench   ~7 min"
+    echo "    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest: torch)      ~12 min"
+    echo ""
+    _kali_build_args=()
+    _ask_kali_module() {  # args: name  build-arg  default(Y|N)
+        local _def="$3" _ans _hint
+        [ "$_def" = "Y" ] && _hint="Y/n" || _hint="y/N"
+        printf "    Include %-7s module? [%s]: " "$1" "$_hint"
+        read -r _ans || true
+        _ans="${_ans:-$_def}"
+        if [[ "$_ans" =~ ^[Yy]$ ]]; then
+            _kali_build_args+=(--build-arg "$2=1")
+        else
+            _kali_build_args+=(--build-arg "$2=0")
+        fi
+    }
+    _ask_kali_module web    INSTALL_WEB    Y
+    _ask_kali_module infra  INSTALL_INFRA  Y
+    _ask_kali_module mobile INSTALL_MOBILE N
+    _ask_kali_module cloud  INSTALL_CLOUD  N
+    _ask_kali_module ai     INSTALL_AI     N
+    echo ""
     echo "  Building pentest-agent/kali-mcp (this may take a while)..."
-    if docker build -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then
+    if docker build "${_kali_build_args[@]}" -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then
         ok "Kali image built: pentest-agent/kali-mcp"
     else
         warn "Kali build failed - run manually: docker build -t pentest-agent/kali-mcp $REPO_DIR/tools/kali/"

--- a/installers/install_opencode.ps1
+++ b/installers/install_opencode.ps1
@@ -217,6 +217,14 @@ function Confirm-Yes {
     return ($ans -eq '' -or $ans -match '^[Yy]')
 }
 
+function Confirm-Default {
+    param([string]$Prompt, [bool]$Default = $true)
+    $hint = if ($Default) { '[Y/n]' } else { '[y/N]' }
+    $ans = Read-Host "$Prompt $hint"
+    if ($ans -eq '') { return $Default }
+    return ($ans -match '^[Yy]')
+}
+
 $ScannerImages = @(
     'instrumentisto/nmap'
     'projectdiscovery/naabu'
@@ -242,9 +250,31 @@ if (Confirm-Yes '  Pull lightweight scanner images? (~2 min)') {
 
 Write-Host ''
 $KaliCtx = Join-Path $RepoDir 'tools\kali\'
-if (Confirm-Yes '  Build Kali image? (~10 min — required for most skills)') {
+if (Confirm-Yes '  Build Kali image? (required for most skills)') {
+    Write-Host ''
+    Write-Host '  Choose Kali tool modules (core is always included). Build-time'
+    Write-Host '  estimates are approximate and depend on your network speed:'
+    Write-Host ''
+    Write-Host '    core   (always)  MCP server, recon: nmap/nuclei/httpx/subfinder    ~6 min'
+    Write-Host '    web              web/API exploit, fuzzing, injection, JWT, SSL      ~8 min'
+    Write-Host '    infra            internal net, AD, credentials, service enum, pivot ~5 min'
+    Write-Host '    mobile           Android/iOS reversing + Frida dynamic analysis     ~4 min'
+    Write-Host '    cloud            AWS/Azure/GCP CLIs, Prowler, ScoutSuite, trivy      ~7 min'
+    Write-Host '    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest)   ~12 min'
+    Write-Host ''
+    $kaliArgs = @()
+    foreach ($m in @(
+        @{ Name = 'web';    Arg = 'INSTALL_WEB';    Def = $true  },
+        @{ Name = 'infra';  Arg = 'INSTALL_INFRA';  Def = $true  },
+        @{ Name = 'mobile'; Arg = 'INSTALL_MOBILE'; Def = $false },
+        @{ Name = 'cloud';  Arg = 'INSTALL_CLOUD';  Def = $false },
+        @{ Name = 'ai';     Arg = 'INSTALL_AI';     Def = $false }
+    )) {
+        $val = if (Confirm-Default ("    Include {0} module?" -f $m.Name) $m.Def) { '1' } else { '0' }
+        $kaliArgs += '--build-arg'; $kaliArgs += ('{0}={1}' -f $m.Arg, $val)
+    }
     Write-Host '  Building pentest-agent/kali-mcp (this may take a while)...'
-    docker build -t pentest-agent/kali-mcp $KaliCtx
+    docker build @kaliArgs -t pentest-agent/kali-mcp $KaliCtx
     if ($LASTEXITCODE -eq 0) {
         Write-Ok 'Kali image built: pentest-agent/kali-mcp'
     } else {

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -581,11 +581,43 @@ fi
 
 echo ""
 
-printf "  Build Kali image? (~10 min — required for most skills) [Y/n]: "
+# Kali image (build) — modular: choose which tool domains to bake in.
+# core is always installed; each other domain is a --build-arg toggle.
+printf "  Build Kali image? (required for most skills) [Y/n]: "
 read -r _kali_answer || true
 if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
+    echo ""
+    echo "  Choose Kali tool modules (core is always included). Build-time estimates"
+    echo "  are approximate and depend on your network speed:"
+    echo ""
+    echo "    core   (always)  MCP server, recon: nmap/nuclei/httpx/subfinder, wordlists  ~6 min"
+    echo "    web              web/API exploit, fuzzing, injection, JWT/OAuth, SSL, crawl  ~8 min"
+    echo "    infra            internal net, AD, credentials, service enum, pivoting       ~5 min"
+    echo "    mobile           Android/iOS reversing + Frida/objection dynamic analysis    ~4 min"
+    echo "    cloud            AWS/Azure/GCP CLIs, Prowler, ScoutSuite, trivy, kube-bench   ~7 min"
+    echo "    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest: torch)      ~12 min"
+    echo ""
+    _kali_build_args=()
+    _ask_kali_module() {  # $1=name  $2=build-arg  $3=default(Y|N)
+        local _def="$3" _ans _hint
+        [ "$_def" = "Y" ] && _hint="Y/n" || _hint="y/N"
+        printf "    Include %-7s module? [%s]: " "$1" "$_hint"
+        read -r _ans || true
+        _ans="${_ans:-$_def}"
+        if [[ "$_ans" =~ ^[Yy]$ ]]; then
+            _kali_build_args+=(--build-arg "$2=1")
+        else
+            _kali_build_args+=(--build-arg "$2=0")
+        fi
+    }
+    _ask_kali_module web    INSTALL_WEB    Y
+    _ask_kali_module infra  INSTALL_INFRA  Y
+    _ask_kali_module mobile INSTALL_MOBILE N
+    _ask_kali_module cloud  INSTALL_CLOUD  N
+    _ask_kali_module ai     INSTALL_AI     N
+    echo ""
     echo "  Building pentest-agent/kali-mcp (this may take a while)..."
-    if docker build -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then
+    if docker build "${_kali_build_args[@]}" -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then
         ok "Kali image built: pentest-agent/kali-mcp"
     else
         warn "Kali build failed — run manually: docker build -t pentest-agent/kali-mcp $REPO_DIR/tools/kali/"

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://kali.download/kali kali-rolling main contrib non-free non-f
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && echo "deb https://kali.download/kali kali-rolling main contrib non-free non-free-firmware" > /etc/apt/sources.list
-    
+
 # SSL bypass for Docker build environments where a proxy CA intercepts HTTPS
 # (e.g. Zscaler, corporate VPN). Only applies at build time — the running
 # container inherits these only if explicitly passed at runtime.
@@ -21,42 +21,150 @@ ENV GOPRIVATE=*
 ENV NODE_TLS_REJECT_UNAUTHORIZED=0
 RUN echo "insecure" > /root/.curlrc
 
-# Core apt tools — split into layers so a single failed package doesn't abort everything
+# OPT-IN TLS-interception CA capture — for building BEHIND a MITM proxy only.
+# OFF by default. A normal build reaches crates.io / PyPI directly and needs
+# none of this; do NOT enable it unless your build network intercepts TLS.
+# Enable for a proxied build with:
+#     docker build --build-arg TRUST_BUILD_PROXY_CA=1 -t pentest-agent/kali-mcp ./tools/kali/
+#
+# Why it exists: the env-var bypasses above cover pip/git/npm/curl, but NOT
+# cargo (used later to compile PyRIT's base2048 Rust dep). cargo has no
+# "insecure" switch and, behind a MITM proxy (e.g. Aikido endpoint proxy,
+# Zscaler), hard-fails with "self-signed certificate in certificate chain".
+# When enabled, we capture the CA the proxy presents for a couple of stable
+# hosts (keeping only the issuer chain, not the per-host leaf) and add it to the
+# trust store so cargo accepts it. This deliberately trusts whatever the local
+# proxy presents, so it is gated behind an explicit opt-in rather than forced on
+# every user of the image.
+ARG TRUST_BUILD_PROXY_CA=0
+RUN if [ "$TRUST_BUILD_PROXY_CA" != "0" ] && [ "$TRUST_BUILD_PROXY_CA" != "false" ]; then \
+        echo "TRUST_BUILD_PROXY_CA set — capturing local proxy CA into the trust store"; \
+        apt-get update && apt-get install -y --no-install-recommends openssl \
+        && rm -rf /var/lib/apt/lists/* \
+        && cd /usr/local/share/ca-certificates \
+        && for host in index.crates.io pypi.org; do \
+             echo | openssl s_client -showcerts -servername "$host" -connect "$host":443 2>/dev/null \
+             | awk -v h="$host" '/-----BEGIN CERTIFICATE-----/{n++} n>1{print > ("mitm-" h "-" n ".crt")}' || true; \
+           done \
+        && update-ca-certificates || true; \
+    else echo "TRUST_BUILD_PROXY_CA not set — skipping proxy CA capture (normal direct build)"; fi
 
-# Layer 1: network scanning
+# ============================================================================
+# DOMAIN SELECTION (composable tool bundles)
+# ----------------------------------------------------------------------------
+# The image is split into domains so users install only what they need. `core`
+# is ALWAYS installed (the MCP server + universal recon/utility toolchain);
+# every other domain is a build-arg toggle (1 = install, anything else = skip).
+# Compose any combination in ONE image, e.g. a web+mobile build:
+#     docker build --build-arg INSTALL_MOBILE=1 -t pentest-agent/kali-mcp ./tools/kali/
+#
+# Defaults: web + infra ON (the classic pentest baseline); mobile/cloud/ai are
+# heavier/specialized and opt-IN. A bare `docker build ./tools/kali/` therefore
+# yields a core+web+infra image. The installer prompts for domains and passes
+# the matching --build-arg flags.
+#
+# Each domain is introduced by exactly one ARG and its layers guard on that ARG
+# alone, so toggling one domain only invalidates that domain's cache (and the
+# layers after it) — not the whole build.
+# ============================================================================
+ARG INSTALL_WEB=1
+ARG INSTALL_INFRA=1
+ARG INSTALL_MOBILE=0
+ARG INSTALL_CLOUD=0
+ARG INSTALL_AI=0
+
+# ============================================================================
+# CORE — always installed. The MCP server, python/pip, universal recon
+# (nmap/naabu/httpx/nuclei/subfinder/dnsx/amass), DNS/OSINT enumeration,
+# network utilities, wordlists, and the OOB callback client.
+# ============================================================================
+
+# Python + pip MUST exist before the first `pip3 install` anywhere below. The
+# base kali-rolling image ships no pip, and several domains invoke pip3 — install
+# it once here in core so every downstream domain can rely on it.
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    nmap masscan hping3 arp-scan nbtscan fping ncat tcpdump tshark \
+    python3 python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 2: DNS / subdomain
+# Core network + shell tooling (nmap/ncat are used by the scan() dispatchers and
+# nearly every skill; openssl backs TLS probing everywhere).
+RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    nmap ncat fping openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+# DNS / subdomain / OSINT recon — the reconnaissance backbone shared by web,
+# infra and osint workflows, so it lives in core.
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     dnsrecon dnsenum fierce dmitry dnstwist dnsmap whois bind9-dnsutils \
+    theharvester nfs-common lbd \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 3: web scanning + exploit-db + php (for running PHP exploits)
-# wpscan — WordPress plugin/theme/core CVE scanner (the authoritative source
-#   for WordPress plugin vulnerabilities — nuclei templates are incomplete)
+# Network utilities + wordlists + document/archive tools (universal helpers).
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    socat proxychains4 curl wget \
+    seclists wordlists \
+    unrar p7zip-full poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# ProjectDiscovery recon suite via apt (katana ships per-domain in web).
+RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    naabu httpx-toolkit subfinder amass dnsx nuclei \
+    && rm -rf /var/lib/apt/lists/*
+
+# interactsh-client — out-of-band callback listener for blind SSRF / RCE / XXE /
+# DNS exfil. OOB confirmation is cross-cutting (web injection AND infra blind
+# RCE), so it lives in core rather than a single domain. Prebuilt binary.
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+    && apt-get update && apt-get install -y --no-install-recommends --fix-missing unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && INTERACTSH_VERSION=1.2.1 \
+    && curl -fsSL "https://github.com/projectdiscovery/interactsh/releases/download/v${INTERACTSH_VERSION}/interactsh-client_${INTERACTSH_VERSION}_linux_${ARCH}.zip" \
+        -o /tmp/interactsh.zip \
+    && unzip /tmp/interactsh.zip interactsh-client -d /usr/local/bin/ \
+    && chmod +x /usr/local/bin/interactsh-client \
+    && rm /tmp/interactsh.zip
+
+# Official Kali MCP server — provides POST /api/command (and per-tool endpoints)
+# on port 5000. This is what the CMD launches; mandatory in every build.
+RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    mcp-kali-server \
+    && rm -rf /var/lib/apt/lists/*
+
+# Decompress rockyou wordlist (needed by hydra, john, and web brute-force).
+RUN gzip -d /usr/share/wordlists/rockyou.txt.gz 2>/dev/null || true
+
+# ============================================================================
+# WEB (INSTALL_WEB) — web/API exploitation: scanners, fuzzers, injection
+# specialists, JWT/OAuth, SSL/TLS, JS-aware crawling, deserialization gadgets.
+# Skills: web-exploit, api-security, param-fuzz, business-logic, ssl-tls-audit,
+# credential-audit.
+# ============================================================================
+
+# Web scanning + exploit-db + php (for running PHP exploits).
+# wpscan — WordPress plugin/theme/core CVE scanner.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     nikto sqlmap whatweb wafw00f wapiti commix xsser davtest skipfish \
     zaproxy exploitdb php-cli wpscan \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 4: web fuzzing / discovery
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+# Web fuzzing / content discovery.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     ffuf gobuster feroxbuster dirb dirsearch wfuzz \
     && rm -rf /var/lib/apt/lists/*
 
-# Layer 4b: Phase-1 injection specialists — raise detector CLEAN-trust for the
-# injection cells from Partial to Automatable (see docs/phase1-detector-trust.md).
-# Installed from PREBUILT release binaries (like katana/interactsh) — NOT built
-# from source — so this layer stays small and never pulls a 240 MB golang
-# toolchain + huge module trees onto the build disk. Split into independent
-# layers so one failure can't poison the others; `|| true` degrades gracefully
-# (the sweep falls back to nuclei -dast / wapiti for any missing tool).
-#
-# dalfox — context-aware XSS scanner (reflected/stored/DOM). Asset names use the
-# raw `uname -m` arch (aarch64 / x86_64). Pinned — bump explicitly.
-RUN ARCH=$(uname -m) \
+# SSL / TLS audit tooling.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    sslscan sslyze testssl.sh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Injection specialists (prebuilt binaries; fail-soft — the sweep falls back to
+# nuclei -dast / wapiti for any missing tool).
+# dalfox — context-aware XSS scanner. Pinned — bump explicitly.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    ARCH=$(uname -m) \
     && DALFOX_VERSION=3.1.2 \
     && curl -fsSL "https://github.com/hahwul/dalfox/releases/download/v${DALFOX_VERSION}/dalfox-v${DALFOX_VERSION}-linux-${ARCH}.tar.gz" -o /tmp/dalfox.tar.gz \
     && tar -xzf /tmp/dalfox.tar.gz -C /tmp/ \
@@ -66,115 +174,63 @@ RUN ARCH=$(uname -m) \
 
 # nosqli — NoSQL injection scanner (Charlie-belmer). Only x86_64 prebuilt exists;
 # on arm64 it's skipped and the sweep falls back to nuclei -dast for nosqli.
-RUN ARCH=$(uname -m) \
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then \
          curl -fsSL "https://github.com/Charlie-belmer/nosqli/releases/download/v0.5.4/nosqli_linux_x64_v0.5.4" -o /usr/local/bin/nosqli \
          && chmod +x /usr/local/bin/nosqli; \
        else echo "nosqli: no ${ARCH} prebuilt — skipped (sweep uses nuclei -dast for nosqli)"; fi || true
 
 # SSTImap — multi-engine SSTI detect+exploit (maintained Python3 fork of tplmap).
-# Create the PATH wrapper right after clone (independent of the requirements
-# install) so `sstimap` is runnable even if a single dep fails — the old `&&`
-# chain under `|| true` left /opt/SSTImap cloned but no wrapper on PATH.
-RUN git clone --depth=1 https://github.com/vladko312/SSTImap /opt/SSTImap || true; \
+# Wrapper is created right after clone (independent of the requirements install)
+# so `sstimap` is runnable even if a single dep fails.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    git clone --depth=1 https://github.com/vladko312/SSTImap /opt/SSTImap || true; \
     if [ -d /opt/SSTImap ]; then \
         printf '#!/bin/sh\nexec python3 /opt/SSTImap/sstimap.py "$@"\n' > /usr/local/bin/sstimap \
         && chmod +x /usr/local/bin/sstimap; \
         pip3 install --no-cache-dir -r /opt/SSTImap/requirements.txt --break-system-packages || true; \
     fi
 
-# arjun (HTTP param discovery) + graphql-cop / graphw00f (GraphQL fingerprint,
-# introspection, batching tests). Installed SEPARATELY — pip resolves a single
-# invocation atomically, so batching them meant one unresolvable dep on arm64
-# silently took down all three (the prior build shipped none of them).
-RUN for pkg in arjun graphql-cop graphw00f; do \
-        pip3 install --no-cache-dir "$pkg" --break-system-packages || echo "WARN: pip install $pkg failed (continuing)"; \
-    done
+# arjun (HTTP param discovery) is on PyPI. graphql-cop and graphw00f (GraphQL
+# fingerprint, introspection, batching tests) are NOT — `pip install` on those
+# names returns "No matching distribution found" on every platform; they are
+# run-from-source tools, so clone them and drop PATH wrappers.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    pip3 install --no-cache-dir arjun --break-system-packages || echo "WARN: pip install arjun failed (continuing)"
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    git clone --depth=1 https://github.com/dolevf/graphql-cop /opt/graphql-cop || true; \
+    if [ -f /opt/graphql-cop/graphql-cop.py ]; then \
+        printf '#!/bin/sh\nexec python3 /opt/graphql-cop/graphql-cop.py "$@"\n' > /usr/local/bin/graphql-cop \
+        && chmod +x /usr/local/bin/graphql-cop; \
+        pip3 install --no-cache-dir -r /opt/graphql-cop/requirements.txt --break-system-packages || true; \
+    else echo "WARN: graphql-cop clone failed (continuing)"; fi
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    git clone --depth=1 https://github.com/dolevf/graphw00f /opt/graphw00f || true; \
+    if [ -f /opt/graphw00f/main.py ]; then \
+        printf '#!/bin/sh\nexec python3 /opt/graphw00f/main.py "$@"\n' > /usr/local/bin/graphw00f \
+        && chmod +x /usr/local/bin/graphw00f; \
+        pip3 install --no-cache-dir -r /opt/graphw00f/requirements.txt --break-system-packages || true; \
+    else echo "WARN: graphw00f clone failed (continuing)"; fi
 
 # jwt_tool — JWT attack toolkit (none alg, alg confusion, kid injection, key brute)
-# KOAuth   — automated OAuth 2.0 security scanner (22 checks)
-# interactsh-client — out-of-band callback listener for blind SSRF / DNS exfil
-RUN (git clone --depth=1 https://github.com/ticarpi/jwt_tool /opt/jwt_tool \
+# KOAuth   — automated OAuth 2.0 security scanner (built from source with golang,
+#            which is installed then purged to keep the layer small).
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    (git clone --depth=1 https://github.com/ticarpi/jwt_tool /opt/jwt_tool \
         && pip3 install --no-cache-dir pycryptodomex termcolor cprint requests --break-system-packages \
         && printf '#!/bin/sh\nexec python3 /opt/jwt_tool/jwt_tool.py "$@"\n' > /usr/local/bin/jwt_tool \
         && chmod +x /usr/local/bin/jwt_tool) || true \
-    && apt-get update && apt-get install -y --no-install-recommends ca-certificates golang-go unzip \
+    && apt-get update && apt-get install -y --no-install-recommends golang-go unzip \
     && rm -rf /var/lib/apt/lists/* \
     && git clone --depth=1 https://github.com/morganc3/KOAuth /opt/KOAuth \
     && cd /opt/KOAuth && go build -o /usr/local/bin/KOAuth . \
-    && apt-get purge -y golang-go && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
-    && INTERACTSH_VERSION=1.2.1 \
-    && curl -fsSL "https://github.com/projectdiscovery/interactsh/releases/download/v${INTERACTSH_VERSION}/interactsh-client_${INTERACTSH_VERSION}_linux_${ARCH}.zip" \
-        -o /tmp/interactsh.zip \
-    && unzip /tmp/interactsh.zip interactsh-client -d /usr/local/bin/ \
-    && chmod +x /usr/local/bin/interactsh-client \
-    && rm /tmp/interactsh.zip
+    && apt-get purge -y golang-go && apt-get autoremove -y
 
-# Layer 5: SSL / TLS
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    sslscan sslyze testssl.sh openssl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Layer 6: credential testing
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    hydra ncrack john cewl crunch medusa \
-    && rm -rf /var/lib/apt/lists/*
-
-# Layer 7: SMB / Windows / AD
-# rpcclient is bundled inside smbclient.
-# certipy-ad — ADCS enumeration and exploitation (ESC1-ESC8)
-# bloodhound.py — BloodHound ingestor for AD attack path mapping
-# ldapdomaindump / certipy-ad / bloodhound.py all live in the Kali repos now, so
-# install them from apt rather than pip. The old `pip3 install certipy-ad==5.0.4`
-# tail pulled dnspython~=2.7.0 and pip cannot uninstall the apt-managed dnspython
-# 2.8.0 (no RECORD file) → `uninstall-no-record-file` aborted the ENTIRE image
-# build — even though apt had already installed all three tools on this same line.
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    smbmap smbclient samba-common-bin impacket-scripts \
-    enum4linux-ng netexec ldap-utils python3-pip \
-    certipy-ad bloodhound.py python3-ldapdomaindump \
-    && rm -rf /var/lib/apt/lists/*
-
-# Layer 8: service enumeration
-# snmpwalk is bundled in the snmp package; snmp-check not available on arm64
-# default-mysql-client — MySQL/MariaDB CLI for database enumeration and credential extraction
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    ssh-audit redis-tools snmp onesixtyone swaks \
-    smtp-user-enum ike-scan finger rpcbind \
-    default-mysql-client \
-    && rm -rf /var/lib/apt/lists/*
-
-# Layer 9: OSINT / recon
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    theharvester nfs-common lbd \
-    && rm -rf /var/lib/apt/lists/*
-
-# Layer 10: network utilities + wordlists + document tools + cross-compilation
-# gcc-mingw-w64 — cross-compile C exploits to Windows EXE/DLL from Kali
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    socat proxychains4 curl wget \
-    seclists wordlists \
-    gcc gcc-mingw-w64 unrar p7zip-full \
-    poppler-utils \
-    && rm -rf /var/lib/apt/lists/*
-
-# Optional: gcc-multilib (amd64 only) + freerdp (xfreerdp for RDP)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends --fix-missing gcc-multilib 2>/dev/null || true \
-    && apt-get install -y --no-install-recommends --fix-missing freerdp2-x11 2>/dev/null \
-    || apt-get install -y --no-install-recommends --fix-missing xfreerdp 2>/dev/null || true \
-    && rm -rf /var/lib/apt/lists/*
-
-# ProjectDiscovery tools via apt (katana not in arm64 repo — installed via pre-built binary)
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    naabu httpx-toolkit subfinder amass dnsx nuclei \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install katana from pre-built GitHub release (supports amd64 + arm64)
-# Pinned to v1.5.0 — update explicitly when needed
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+# katana — JS-aware web crawler (prebuilt release; supports amd64 + arm64).
+# Pinned to v1.5.0 — update explicitly when needed.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
     && KATANA_VERSION=1.5.0 \
     && curl -fsSL "https://github.com/projectdiscovery/katana/releases/download/v${KATANA_VERSION}/katana_${KATANA_VERSION}_linux_${ARCH}.zip" \
         -o /tmp/katana.zip \
@@ -182,113 +238,81 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
     && chmod +x /usr/local/bin/katana \
     && rm /tmp/katana.zip
 
-# Official Kali MCP server — provides POST /api/command (and per-tool endpoints)
-# on port 5000. Replaces our hand-rolled server.py.
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    mcp-kali-server \
-    && rm -rf /var/lib/apt/lists/*
-
-# AI red-teaming: Microsoft PyRIT + thin CLI runner
-# pyrit-runner wraps the PyRIT SDK for scripted multi-turn adversarial attacks.
-# base2048 (PyRIT dep) requires Rust to compile — install, build, then clean up.
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing rustc cargo \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip3 install --no-cache-dir --ignore-installed pyrit==0.11.0 --break-system-packages \
-    && apt-get purge -y rustc cargo \
-    && apt-get autoremove -y \
-    && rm -rf /root/.cargo /root/.rustup
-COPY pyrit_runner.py /usr/local/bin/pyrit-runner
-RUN chmod +x /usr/local/bin/pyrit-runner
-
-# AI red-teaming: CyberArk FuzzyAI runs as a separate Docker image (ghcr.io/cyberark/fuzzyai),
-# not installed here. See tools/fuzzyai.py for the image definition.
-
-# AI red-teaming: NVIDIA Garak — LLM vulnerability scanner (probe-based)
-# Installed in a venv to avoid conflicts with Debian-managed packages (no RECORD file).
-# --system-site-packages inherits system packages so only the delta is fetched.
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing python3-venv \
-    && rm -rf /var/lib/apt/lists/* \
-    && python3 -m venv /opt/garak-venv --system-site-packages \
-    && /opt/garak-venv/bin/pip install --no-cache-dir garak==0.15.0 \
-    && ln -sf /opt/garak-venv/bin/garak /usr/local/bin/garak
-
-# AI red-teaming: promptfoo — LLM eval + red-team framework (npm)
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing nodejs npm \
-    && rm -rf /var/lib/apt/lists/* \
-    && npm config set strict-ssl false \
-    && npm install -g promptfoo@0.121.2
-
 # Web spider: Playwright + headless Chromium for JavaScript-aware crawling
-# (required for Hotwire/Turbo Frame apps where katana misses lazy-loaded content)
-# Pinned to 1.59.0 — update explicitly when needed
-# 1.50+ uses pyee>=13.0.0 which matches the Kali system python3-pyee package
-RUN pip3 install --no-cache-dir playwright==1.59.0 --break-system-packages \
+# (required for Hotwire/Turbo Frame apps where katana misses lazy-loaded content).
+# Pinned to 1.59.0 — update explicitly when needed.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    pip3 install --no-cache-dir playwright==1.59.0 --break-system-packages \
     && playwright install chromium --with-deps
 
-# Exploitation payload generators
-# phpggc — PHP deserialization gadget-chain generator (Laravel, Symfony,
-# Twig, Monolog, Guzzle, SwiftMailer, Yii, ...). Used for exploiting
-# PHP unserialize / phar:// sinks. Ships `phpggc` binary + a chains/
-# directory with every supported framework/version combination.
-RUN git clone --depth=1 https://github.com/ambionics/phpggc /opt/phpggc \
+# phpggc — PHP deserialization gadget-chain generator (Laravel, Symfony, Twig,
+# Monolog, Guzzle, ...). Used for exploiting PHP unserialize / phar:// sinks.
+RUN [ "$INSTALL_WEB" = "1" ] || { echo "[web] skipped"; exit 0; }; \
+    git clone --depth=1 https://github.com/ambionics/phpggc /opt/phpggc \
     && ln -s /opt/phpggc/phpggc /usr/local/bin/phpggc
 
-# Layer 11: container & K8s security
-# trivy — container image vulnerability scanner
-# kube-bench — CIS Kubernetes Benchmark auditor
-# kubectl — Kubernetes CLI (for K8s assessments from inside Kali)
-# dive — Docker image layer explorer (installed from GitHub release)
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    trivy kubectl \
+COPY playwright_spider.py /usr/local/bin/playwright-spider
+RUN chmod +x /usr/local/bin/playwright-spider
+# COPY can't be ARG-guarded, so drop the wrapper if web (its playwright runtime) isn't installed.
+RUN [ "$INSTALL_WEB" = "1" ] || rm -f /usr/local/bin/playwright-spider
+
+# ============================================================================
+# INFRA (INSTALL_INFRA) — internal network, Active Directory, credentials,
+# service enumeration, cross-compilation, and pivoting.
+# Skills: network-assess, ad-assessment, lateral-movement, post-exploit,
+# credential-audit.
+# ============================================================================
+
+# Internal-network scanning / packet tooling.
+RUN [ "$INSTALL_INFRA" = "1" ] || { echo "[infra] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    masscan hping3 arp-scan nbtscan tcpdump tshark \
     && rm -rf /var/lib/apt/lists/*
 
-# kube-bench from GitHub release (not in Kali repos)
-# Pinned to v0.15.0 — update explicitly when needed
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
-    && KB_VERSION=0.15.0 \
-    && curl -fsSL "https://github.com/aquasecurity/kube-bench/releases/download/v${KB_VERSION}/kube-bench_${KB_VERSION}_linux_${ARCH}.tar.gz" \
-        -o /tmp/kube-bench.tar.gz \
-    && tar -xzf /tmp/kube-bench.tar.gz -C /usr/local/bin/ kube-bench \
-    && chmod +x /usr/local/bin/kube-bench \
-    && rm /tmp/kube-bench.tar.gz
+# Credential testing.
+RUN [ "$INSTALL_INFRA" = "1" ] || { echo "[infra] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    hydra ncrack john cewl crunch medusa \
+    && rm -rf /var/lib/apt/lists/*
 
-# dive from GitHub release (Docker image layer explorer)
-# Pinned to v0.13.1 — update explicitly when needed
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
-    && DIVE_VERSION=0.13.1 \
-    && curl -fsSL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_${ARCH}.tar.gz" \
-        -o /tmp/dive.tar.gz \
-    && tar -xzf /tmp/dive.tar.gz -C /usr/local/bin/ dive \
-    && chmod +x /usr/local/bin/dive \
-    && rm /tmp/dive.tar.gz
+# SMB / Windows / AD. rpcclient is bundled inside smbclient.
+# certipy-ad — ADCS enumeration/exploitation (ESC1-ESC8); bloodhound.py — AD
+# attack-path ingestor. Installed from apt (not pip) to avoid the dnspython
+# uninstall-no-record-file conflict that used to abort the build.
+RUN [ "$INSTALL_INFRA" = "1" ] || { echo "[infra] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    smbmap smbclient samba-common-bin impacket-scripts \
+    enum4linux-ng netexec ldap-utils \
+    certipy-ad bloodhound.py python3-ldapdomaindump \
+    && rm -rf /var/lib/apt/lists/*
 
-# Layer 12: cloud security — AWS CLI, Azure CLI, GCP CLI, Prowler, ScoutSuite
-# AWS CLI (via pip — kali apt awscli is often outdated)
-RUN pip3 install --no-cache-dir awscli==1.44.63 --break-system-packages || true
+# Service enumeration. snmpwalk is bundled in the snmp package.
+# default-mysql-client — MySQL/MariaDB CLI for DB enumeration.
+RUN [ "$INSTALL_INFRA" = "1" ] || { echo "[infra] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    ssh-audit redis-tools snmp onesixtyone swaks \
+    smtp-user-enum ike-scan finger rpcbind \
+    default-mysql-client \
+    && rm -rf /var/lib/apt/lists/*
 
-# Azure CLI
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
-    ca-certificates curl apt-transport-https lsb-release gnupg \
-    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
-    && apt-get update && apt-get install -y --no-install-recommends --fix-missing azure-cli \
-    && rm -rf /var/lib/apt/lists/* || true
+# Cross-compilation for exploit builds. gcc-mingw-w64 — Windows EXE/DLL from Kali.
+RUN [ "$INSTALL_INFRA" = "1" ] || { echo "[infra] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    gcc gcc-mingw-w64 \
+    && rm -rf /var/lib/apt/lists/*
 
-# GCP CLI
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
-    && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
-    && apt-get update && apt-get install -y --no-install-recommends --fix-missing google-cloud-cli \
-    && rm -rf /var/lib/apt/lists/* || true
+# Optional: gcc-multilib (amd64 only) + freerdp (xfreerdp for RDP).
+RUN [ "$INSTALL_INFRA" = "1" ] || { echo "[infra] skipped"; exit 0; }; \
+    apt-get update \
+    && apt-get install -y --no-install-recommends --fix-missing gcc-multilib 2>/dev/null || true \
+    && apt-get install -y --no-install-recommends --fix-missing freerdp2-x11 2>/dev/null \
+    || apt-get install -y --no-install-recommends --fix-missing xfreerdp 2>/dev/null || true \
+    && rm -rf /var/lib/apt/lists/*
 
-# Prowler (AWS/Azure/GCP security auditor) + ScoutSuite (multi-cloud auditor)
-# NOTE: prowler and scoutsuite currently fail to install on kali-rolling arm64.
-# Pinned versions for when the build succeeds on compatible platforms.
-RUN pip3 install --no-cache-dir prowler==5.22.0 scoutsuite==5.14.0 --break-system-packages || true
-
-# Layer 13: pivoting — ligolo-ng (TUN-based, primary) + chisel (HTTP/WS, fallback)
-# ligolo-ng proxy + agent from GitHub release (avoids broken third-party apt repos)
-# Pinned to v0.8.2 — update explicitly when needed
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+# Pivoting — ligolo-ng (TUN-based, primary) + chisel (HTTP/WS, fallback).
+# Pinned to v0.8.2 / v1.10.1 — update explicitly when needed.
+RUN [ "$INSTALL_INFRA" = "1" ] || { echo "[infra] skipped"; exit 0; }; \
+    ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
     && LIGOLO_VERSION=0.8.2 \
     && curl -fsSL "https://github.com/nicocha30/ligolo-ng/releases/download/v${LIGOLO_VERSION}/ligolo-ng_proxy_${LIGOLO_VERSION}_linux_${ARCH}.tar.gz" \
         -o /tmp/ligolo-proxy.tar.gz \
@@ -300,40 +324,132 @@ RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
     && tar xzf /tmp/ligolo-agent.tar.gz -C /tmp/ agent \
     && mv /tmp/agent /usr/local/bin/ligolo-agent \
     && chmod +x /usr/local/bin/ligolo-agent \
-    && rm -f /tmp/ligolo-proxy.tar.gz /tmp/ligolo-agent.tar.gz
-
-# chisel: fallback for HTTP-only egress or when TUN creation fails
-# Pinned to v1.10.1 — update explicitly when needed
-RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
     && CHISEL_VERSION=1.10.1 \
     && curl -fsSL "https://github.com/jpillora/chisel/releases/download/v${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_${ARCH}.gz" \
         -o /tmp/chisel.gz \
     && gunzip /tmp/chisel.gz \
     && mv /tmp/chisel /usr/local/bin/chisel \
-    && chmod +x /usr/local/bin/chisel
+    && chmod +x /usr/local/bin/chisel \
+    && rm -f /tmp/ligolo-proxy.tar.gz /tmp/ligolo-agent.tar.gz
 
-# Decompress rockyou wordlist (needed by hydra, john, etc.)
-RUN gzip -d /usr/share/wordlists/rockyou.txt.gz 2>/dev/null || true
+# ============================================================================
+# MOBILE (INSTALL_MOBILE) — Android/iOS app reversing + dynamic instrumentation.
+# Skills: android-security, ios-security. (MobSF runs as a separate container.)
+# ============================================================================
 
-COPY playwright_spider.py /usr/local/bin/playwright-spider
-RUN chmod +x /usr/local/bin/playwright-spider
-
-# Layer 14: mobile app reversing + dynamic instrumentation (used by
-# /android-security and /ios-security). APK reversing/repackaging (apktool,
-# dex2jar, jadx, apksigner, zipalign) + the adb transport. adb/frida connect OUT
-# to an operator-provided emulator/device over the network (adb connect <ip>:5555)
-# — the `android-dynamic` setup gate confirms the device is live before use.
-RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+# APK reversing/repackaging (apktool, dex2jar, jadx, apksigner, zipalign) + adb.
+# adb/frida connect OUT to an operator-provided emulator/device over the network
+# (adb connect <ip>:5555) — the android-dynamic setup gate confirms it's live.
+RUN [ "$INSTALL_MOBILE" = "1" ] || { echo "[mobile] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     apktool dex2jar jadx apksigner zipalign adb fastboot \
     && rm -rf /var/lib/apt/lists/* || true
 
 # Frida + objection for runtime hooking: SSL-pinning bypass, keystore/keychain
-# dumps, runtime storage/heap inspection. NOTE (client↔server coupling): the
-# operator must push a frida-server whose version MATCHES this frida-tools pin to
-# the device/emulator (see the android-security skill's dynamic ref). Pinned as a
-# compatible pair (frida 16.x) — update explicitly when bumping.
-RUN pip3 install --no-cache-dir --break-system-packages \
+# dumps, runtime storage/heap inspection. The operator must push a frida-server
+# whose version MATCHES this frida-tools pin to the device/emulator.
+# --ignore-installed: objection pulls a newer `tabulate` than the apt-managed
+# one, and pip cannot uninstall the apt copy (no RECORD file). Ignoring
+# already-installed deps installs cleanly on top instead of aborting.
+RUN [ "$INSTALL_MOBILE" = "1" ] || { echo "[mobile] skipped"; exit 0; }; \
+    pip3 install --no-cache-dir --break-system-packages --ignore-installed \
     frida-tools==12.5.1 objection==1.11.0 || true
+
+# ============================================================================
+# CLOUD (INSTALL_CLOUD) — cloud posture + container/K8s security.
+# Skills: cloud-security, container-k8s-security.
+# ============================================================================
+
+# Container & K8s: trivy (image vuln scan) + kubectl.
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    trivy kubectl \
+    && rm -rf /var/lib/apt/lists/*
+
+# kube-bench (CIS K8s benchmark) from GitHub release. Pinned v0.15.0.
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+    && KB_VERSION=0.15.0 \
+    && curl -fsSL "https://github.com/aquasecurity/kube-bench/releases/download/v${KB_VERSION}/kube-bench_${KB_VERSION}_linux_${ARCH}.tar.gz" \
+        -o /tmp/kube-bench.tar.gz \
+    && tar -xzf /tmp/kube-bench.tar.gz -C /usr/local/bin/ kube-bench \
+    && chmod +x /usr/local/bin/kube-bench \
+    && rm /tmp/kube-bench.tar.gz
+
+# dive (Docker image layer explorer) from GitHub release. Pinned v0.13.1.
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+    && DIVE_VERSION=0.13.1 \
+    && curl -fsSL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_${ARCH}.tar.gz" \
+        -o /tmp/dive.tar.gz \
+    && tar -xzf /tmp/dive.tar.gz -C /usr/local/bin/ dive \
+    && chmod +x /usr/local/bin/dive \
+    && rm /tmp/dive.tar.gz
+
+# AWS CLI (via pip — kali apt awscli is often outdated).
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    pip3 install --no-cache-dir awscli==1.44.63 --break-system-packages || true
+
+# Azure CLI.
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing \
+    ca-certificates curl apt-transport-https lsb-release gnupg \
+    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends --fix-missing azure-cli \
+    && rm -rf /var/lib/apt/lists/* || true
+
+# GCP CLI.
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && apt-get update && apt-get install -y --no-install-recommends --fix-missing google-cloud-cli \
+    && rm -rf /var/lib/apt/lists/* || true
+
+# Prowler (AWS/Azure/GCP auditor) + ScoutSuite (multi-cloud auditor), each under
+# `|| true` so one uninstallable pin can't take down the other. prowler 5.31.0 is
+# the first Python-3.13-compatible release; scoutsuite stays fail-soft.
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    pip3 install --no-cache-dir prowler==5.31.0 --break-system-packages || true
+RUN [ "$INSTALL_CLOUD" = "1" ] || { echo "[cloud] skipped"; exit 0; }; \
+    pip3 install --no-cache-dir scoutsuite==5.14.0 --break-system-packages || true
+
+# ============================================================================
+# AI (INSTALL_AI) — LLM/agent red-teaming. Skill: ai-redteam.
+# The heaviest domain (torch/CUDA deps), hence opt-in. FuzzyAI runs as a
+# separate container (ghcr.io/cyberark/fuzzyai); see tools/fuzzyai.py.
+# ============================================================================
+
+# Microsoft PyRIT + thin CLI runner. base2048 (a PyRIT dep) compiles Rust, so
+# rustc/cargo are installed then purged. NOTE: behind a TLS-intercepting proxy,
+# cargo needs the CA — build with --build-arg TRUST_BUILD_PROXY_CA=1.
+RUN [ "$INSTALL_AI" = "1" ] || { echo "[ai] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing rustc cargo \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir --ignore-installed pyrit==0.11.0 --break-system-packages \
+    && apt-get purge -y rustc cargo \
+    && apt-get autoremove -y \
+    && rm -rf /root/.cargo /root/.rustup
+COPY pyrit_runner.py /usr/local/bin/pyrit-runner
+RUN chmod +x /usr/local/bin/pyrit-runner
+# COPY can't be ARG-guarded, so drop the wrapper if the ai module (PyRIT) isn't installed.
+RUN [ "$INSTALL_AI" = "1" ] || rm -f /usr/local/bin/pyrit-runner
+
+# NVIDIA Garak — LLM vulnerability scanner (probe-based). Installed in a venv
+# (--system-site-packages) to avoid conflicts with Debian-managed packages.
+RUN [ "$INSTALL_AI" = "1" ] || { echo "[ai] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/garak-venv --system-site-packages \
+    && /opt/garak-venv/bin/pip install --no-cache-dir garak==0.15.0 \
+    && ln -sf /opt/garak-venv/bin/garak /usr/local/bin/garak
+
+# promptfoo — LLM eval + red-team framework (npm).
+RUN [ "$INSTALL_AI" = "1" ] || { echo "[ai] skipped"; exit 0; }; \
+    apt-get update && apt-get install -y --no-install-recommends --fix-missing nodejs npm \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm config set strict-ssl false \
+    && npm install -g promptfoo@0.121.2
 
 EXPOSE 5000
 


### PR DESCRIPTION
Split the Kali image into composable tool domains so users install only what they need. `core` (MCP server + universal recon) is always built; web/infra (default on) and mobile/cloud/ai (opt-in) are --build-arg toggles, each guarding on its own ARG so toggling one domain only invalidates that domain's layer cache. Default build drops from ~19.8GB to ~9.9GB. All 6 installers now prompt per-module with approximate build-time estimates and assemble the matching --build-arg flags.

Also fixes several silently-masked build bugs surfaced along the way:
- install python3-pip early (was in the SMB layer, below the first pip3 users) so SSTImap/arjun/jwt_tool deps stop failing with "pip3: not found"
- graphql-cop/graphw00f installed from git (not on PyPI) with PATH wrappers
- frida/objection use --ignore-installed to survive the apt-managed tabulate uninstall-no-record-file abort
- prowler bumped 5.22.0 -> 5.31.0 (first Python 3.13-compatible release), split from scoutsuite so one bad pin can't take down the other
- opt-in TRUST_BUILD_PROXY_CA build-arg to capture a local MITM proxy CA (off by default; only needed to compile PyRIT's Rust dep behind a proxy)