### PR TITLE
feat(kali): bound curl by default + timeout-as-signal + surface the command in the activity feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,12 @@ Scan lifecycle and infrastructure.
   - `action="elect"` — options: `{id, choice: now|defer|skip}`. **Mode-aware:** in interactive runs ASK the operator whether to set it up; headless, default to `defer` (the operator fulfills it on the dashboard). `skip` records the gap explicitly (mark dependent cells `skipped`, reason "operator declined manual setup"). A `requires_host` capability needs an explicit `now` at least once.
   - `action="check"` — options: `{id}` — run the capability's **readiness probe** (an allow-listed command, e.g. `frida-ps -U`) to PROVE the setup is live. A pass writes a proving artifact + a `devices` known-asset and marks the gate satisfied; a fail tells you what to fix. **Probe over trust** — never assume setup is done; verify with `check`. NON-BLOCKING: an unsatisfied gate never blocks `session(complete)` — do all autonomous/static work first, then elect/verify the manual parts.
 
-## Skill Logging (mandatory)
+## Skills: LOAD and FOLLOW them — `set_skill` is bookkeeping, not the work
 
-Before invoking **any** skill via the Skill tool, always call:
+Chaining a skill is **two steps, and the second is the real one**:
+
+1. `session(action="set_skill", options={...})` — **bookkeeping only.** Writes a `SKILL_START` / `SKILL_CHAIN` entry to `pentest.log` and records the decision in `session.json`'s `skill_history`. It does **not** run the skill and, on its own, does **not** satisfy a completion gate.
+2. **Actually invoke the skill and follow its workflow** — Claude Code: `Skill(name="<skill>")`; opencode: `skill({name:"<skill>"})`; Codex: follow the in-prompt workflow. Then **work its phases** (its real tool calls, per-technique probes, coverage closures). This is the step that does the assessment.
 
 ```
 session(action="set_skill", options={
@@ -121,9 +124,13 @@ session(action="set_skill", options={
   "reason": "<1–2 sentences explaining why you chose this skill>",
   "chained_from": "<parent skill name when chaining; omit for the first skill>"
 })
+# ...then immediately:
+Skill(name="<skill-name>")   # load the workflow and EXECUTE its phases
 ```
 
-This writes a `SKILL_START` or `SKILL_CHAIN` entry to `pentest.log` and enriches `session.json`'s `skill_history` with the decision context. It is mandatory — always call it immediately before the Skill tool invocation.
+**Do NOT rubber-stamp a gate.** Calling `set_skill` for a skill and then moving on (or jumping to `session(complete)`) without loading and running that skill is prohibited — you are skipping the assessment the gate exists to guarantee. A gate is now satisfied **only when the declared skill actually does work attributable to it** (a tool fires while that skill is the active skill; see `core/session/gates.py:skill_worked`). "The scan was busy overall" no longer clears a freshly-declared skill's gate. So the only way past a gate is to genuinely run the skill.
+
+You may legitimately **skip phases that don't apply** to the target (e.g. credential-audit's SSH/FTP/Kerberos phases on an HTTP-only app) — but skipping *inapplicable phases within a skill you are running* is different from *not running the skill at all*. Run the skill; execute every phase that applies; note which you skipped and why.
 
 ## Envelope signals to respect
 

--- a/core/graph/build.py
+++ b/core/graph/build.py
@@ -7,6 +7,7 @@ the source of truth while the matrix remains authoritative.
 """
 from __future__ import annotations
 
+import re
 from urllib.parse import urlparse
 
 from . import model as m
@@ -20,6 +21,37 @@ def _host_of(url_or_target: str) -> str:
         return url_or_target
 
 
+def _clean_host(raw: str, root_host: str) -> str:
+    """Best-effort host from a freeform finding ``target`` string, falling back to
+    the scan's root host. Finding targets are human-written (e.g.
+    "http://localhost:5000 (JWT auth, /sup3r_s3cr3t_admin)"), so a naive
+    ``_host_of`` yields junk like ``localhost:5000 (JWT auth,`` — reject anything
+    that isn't a clean ``host[:port]`` and use the root host instead. This keeps
+    every finding anchored to the ONE target node rather than spawning duplicate,
+    disconnected host nodes (a cause of the 'loose nodes' the graph used to show)."""
+    if not raw:
+        return root_host
+    h = _host_of(raw)
+    if not h or any(c in h for c in " /()[]"):
+        return root_host
+    return h or root_host
+
+
+def _endpoint_host(path: str, root_host: str) -> str:
+    """The host an endpoint belongs to. Endpoint paths from the coverage matrix are
+    RELATIVE ("/login", "/api/v1/payments"), so they must anchor to the scan's root
+    host. Only override when the path is a genuine absolute URL to another host
+    (real netloc). The old code ran ``_host_of("/login")`` -> "/login" (a truthy
+    non-host), built an edge to a ``host:/login`` node that was never created, and
+    the dangling edge got dropped client-side — leaving every endpoint (and its
+    params) floating disconnected from the target."""
+    if "//" in path:
+        h = _host_of(path)
+        if h and "/" not in h and " " not in h:
+            return h
+    return root_host
+
+
 def _add_tech_nodes(g, ka, root_host) -> None:
     """Technologies / fingerprints → TECH nodes RUN by the host."""
     for tech in ka.get("technologies", []) or []:
@@ -28,27 +60,38 @@ def _add_tech_nodes(g, ka, root_host) -> None:
             g.add_edge(f"host:{root_host}", tid, m.RUNS)
 
 
-def _add_endpoint_nodes(g, matrix, root_host) -> dict:
-    """Endpoints + their params. Returns {endpoint_id: node_id} for cell wiring."""
+def _add_endpoint_nodes(g, matrix, root_host) -> tuple[dict, dict]:
+    """Endpoints + their params, anchored to the target host so the graph reads
+    target -> component -> param. Returns ({endpoint_id: node_id}, {path: node_id})
+    — the first wires coverage cells, the second lets findings attach to the
+    component they were found on."""
     ep_by_id: dict = {}
+    ep_by_path: dict = {}
     for ep in matrix.get("endpoints", []):
         eid = f"ep:{ep['id']}"
         ep_by_id[ep["id"]] = eid
-        g.add_node(eid, m.ENDPOINT, f"{ep.get('method','GET')} {ep.get('path','')}",
-                   path=ep.get("path", ""), method=ep.get("method", "GET"),
+        path = ep.get("path", "")
+        g.add_node(eid, m.ENDPOINT, f"{ep.get('method','GET')} {path}",
+                   path=path, method=ep.get("method", "GET"),
                    auth_context=ep.get("auth_context", "none"))
-        host = _host_of(ep.get("path", "")) or root_host
+        if path:
+            ep_by_path.setdefault(path, eid)
+        host = _endpoint_host(path, root_host)
         if host:
+            g.add_node(f"host:{host}", m.HOST, host)  # materialize so the edge isn't dangling
             g.add_edge(f"host:{host}", eid, m.HOSTS)
         for p in ep.get("params", []) or []:
             pid = f"param:{ep['id']}:{p.get('name','')}"
             g.add_node(pid, m.PARAM, p.get("name", ""), type=p.get("type", "query"))
             g.add_edge(eid, pid, m.HAS_PARAM)
-    return ep_by_id
+    return ep_by_id, ep_by_path
 
 
-def _add_cell_edges(g, matrix, ep_by_id) -> None:
-    """The coverage matrix cells, as endpoint→injection TESTED_FOR edges."""
+def _add_cell_edges(g, matrix, ep_by_id) -> dict:
+    """The coverage matrix cells, as endpoint→injection TESTED_FOR edges. Also
+    returns {finding_id: endpoint_node_id} so confirmed findings anchor to the
+    exact component whose cell they closed."""
+    fid_to_ep: dict = {}
     for cell in matrix.get("matrix", []):
         eid = ep_by_id.get(cell.get("endpoint_id"))
         if not eid:
@@ -56,6 +99,42 @@ def _add_cell_edges(g, matrix, ep_by_id) -> None:
         g.add_edge(eid, f"inj:{cell.get('injection_type')}", m.TESTED_FOR,
                    status=cell.get("status"), param=cell.get("param"),
                    finding_id=cell.get("finding_id"))
+        if cell.get("finding_id"):
+            fid_to_ep[cell["finding_id"]] = eid
+    return fid_to_ep
+
+
+# Endpoint paths whose handler MINTS auth material (a session/JWT) — the source
+# of the auth dataflow. Matched against the endpoint path.
+_AUTH_ISSUER_RE = re.compile(r"/(login|signin|sign-in|authenticate|auth|token|oauth|session)(/|$)", re.I)
+# auth_context values that mean "this component is gated by a token/session" — the
+# sinks of the auth dataflow.
+_PROTECTED_AUTH = {"jwt", "bearer", "token", "session", "cookie", "apikey", "api_key",
+                   "merchant", "merchantapikey", "oauth", "basic"}
+
+
+def _add_auth_flow(g, ep_by_id, root_host) -> None:
+    """Overlay the auth/token DATAFLOW: issuer endpoints (login/token) --issues-->
+    a session/token hub --grants--> every auth-gated endpoint. This is the 'how are
+    the components linked together' the flat node soup lacked — it shows the
+    credential a login mints flowing into each protected component."""
+    endpoints = g.of_kind(m.ENDPOINT)
+    issuers = [n for n in endpoints if _AUTH_ISSUER_RE.search(n.attrs.get("path", ""))]
+    protected = [n for n in endpoints
+                 if str(n.attrs.get("auth_context", "none")).lower() in _PROTECTED_AUTH]
+    if not issuers and not protected:
+        return
+    # Prefer a real captured token node as the hub; else a synthetic session node.
+    toks = g.of_kind(m.TOKEN)
+    hub = toks[0].id if toks else g.add_node(f"token:session:{root_host}", m.TOKEN, "session/JWT")
+    if root_host:
+        g.add_edge(hub, f"host:{root_host}", m.AUTHENTICATES)  # anchor the hub to the target
+    issuer_ids = {n.id for n in issuers}
+    for iss in issuers:
+        g.add_edge(iss.id, hub, m.ISSUES)
+    for pep in protected:
+        if pep.id not in issuer_ids:
+            g.add_edge(hub, pep.id, m.GRANTS)
 
 
 def _add_credential_nodes(g, ka, root_host) -> None:
@@ -81,22 +160,39 @@ def _add_credential_nodes(g, ka, root_host) -> None:
 _CRED_LEAK_MARKERS = ("credential", "password", "token leak", "secret", "api key", "api_key")
 
 
-def _add_finding_nodes(g, root_host) -> None:
-    """Findings → FOUND_ON host, LEAKS (credential material), ESCALATES_TO, and
-    PROVIDES/REQUIRES primitive edges (the substrate for compositional chaining)."""
+def _match_endpoint(text: str, ep_by_path: dict) -> str | None:
+    """Anchor a finding to the component it names. Longest path first so
+    "/admin/create_admin" wins over "/admin"."""
+    for path in sorted((p for p in ep_by_path if len(p) > 1), key=len, reverse=True):
+        if path in text:
+            return ep_by_path[path]
+    return None
+
+
+def _add_finding_nodes(g, root_host, ep_by_path, fid_to_ep) -> None:
+    """Findings → FOUND_ON their endpoint (falling back to the target host), LEAKS
+    (credential material), ESCALATES_TO, and PROVIDES/REQUIRES primitive edges (the
+    substrate for compositional chaining). Anchoring to the endpoint (not just the
+    host) is what makes a finding read as belonging to a component in the tree."""
     from core import findings as findings_store
     for f in findings_store._load().get("findings", []):
         fid = f"finding:{f.get('id','')}"
         g.add_node(fid, m.FINDING, f.get("title", ""),
                    severity=(f.get("severity") or "").lower(), target=f.get("target", ""),
                    status=(f.get("status") or "").lower())
-        fhost = _host_of(f.get("target", "")) or root_host
-        if fhost:
+        fhost = _clean_host(f.get("target", ""), root_host)
+        title, desc = f.get("title", ""), f.get("description", "")
+        text = f"{title} {desc} {f.get('target','')}"
+        # Prefer the exact endpoint (via the cell it closed, else a path match in
+        # its text); anchor to the host only when no component is identifiable.
+        anchor = fid_to_ep.get(f.get("id", "")) or _match_endpoint(text, ep_by_path)
+        if anchor:
+            g.add_edge(fid, anchor, m.FOUND_ON)
+        elif fhost:
             g.add_node(f"host:{fhost}", m.HOST, fhost)  # materialize so the edge isn't dangling
             g.add_edge(fid, f"host:{fhost}", m.FOUND_ON)
-        title, desc = f.get("title", ""), f.get("description", "")
-        text = f"{title} {desc}".lower()
-        if fhost and any(k in text for k in _CRED_LEAK_MARKERS):
+        if fhost and any(k in text.lower() for k in _CRED_LEAK_MARKERS):
+            g.add_node(f"host:{fhost}", m.HOST, fhost)
             g.add_edge(fid, f"host:{fhost}", m.LEAKS, what="credential-material")
         for lead in f.get("escalation_leads", []) or []:
             if isinstance(lead, dict) and lead.get("status") == "pending":
@@ -185,8 +281,9 @@ def _assemble() -> m.Graph:
         g.add_node(f"host:{root_host}", m.HOST, root_host)
 
     _add_tech_nodes(g, ka, root_host)
-    ep_by_id = _add_endpoint_nodes(g, matrix, root_host)
-    _add_cell_edges(g, matrix, ep_by_id)
+    ep_by_id, ep_by_path = _add_endpoint_nodes(g, matrix, root_host)
+    fid_to_ep = _add_cell_edges(g, matrix, ep_by_id)
     _add_credential_nodes(g, ka, root_host)
-    _add_finding_nodes(g, root_host)
+    _add_auth_flow(g, ep_by_id, root_host)
+    _add_finding_nodes(g, root_host, ep_by_path, fid_to_ep)
     return g

--- a/core/graph/build.py
+++ b/core/graph/build.py
@@ -122,8 +122,53 @@ def _add_primitive_edges(g, fid: str, f: dict) -> None:
         pass
 
 
+# Memoized (mtime, size) signature → built Graph. build_graph() was re-run on
+# every QA-daemon tick and every report(action='note') bridge, each time
+# re-reading and re-projecting all three stores. The projection is read-only and
+# consumers never mutate the returned graph, so a shared instance is reused until
+# an input changes.
+_GRAPH_CACHE: "tuple[tuple, m.Graph] | None" = None
+
+
+def _cache_key() -> tuple:
+    """Cheap version signature of the three stores build_graph reads. All three
+    flush to disk on every mutation (findings._save / coverage._save /
+    session._flush), so (mtime_ns, size) is an accurate change signal both
+    in-process and across the QA-daemon / dashboard processes — and no file is
+    read to compute it."""
+    from core import paths as _paths
+    sig = []
+    for p in (_paths.SESSION_FILE, _paths.FINDINGS_FILE, _paths.COVERAGE_FILE):
+        try:
+            st = p.stat()
+            sig.append((st.st_mtime_ns, st.st_size))
+        except OSError:
+            sig.append((0, 0))
+    return tuple(sig)
+
+
+def invalidate_graph_cache() -> None:
+    """Drop the memoized graph. The test harness calls this between tests (the
+    stores are monkeypatched in-memory there, so the mtime key can't observe the
+    change); also available to any caller that mutates a store out-of-band."""
+    global _GRAPH_CACHE
+    _GRAPH_CACHE = None
+
+
 def build_graph() -> m.Graph:
-    """Assemble the world-model graph from everything learned so far."""
+    """Assemble the world-model graph, memoized on the (mtime, size) of
+    session.json / findings.json / coverage_matrix.json (see _cache_key)."""
+    global _GRAPH_CACHE
+    key = _cache_key()
+    if _GRAPH_CACHE is not None and _GRAPH_CACHE[0] == key:
+        return _GRAPH_CACHE[1]
+    g = _assemble()
+    _GRAPH_CACHE = (key, g)
+    return g
+
+
+def _assemble() -> m.Graph:
+    """Project the world-model graph from everything learned so far."""
     from core import session as scan_session
     try:
         from core import coverage as cov

--- a/core/graph/model.py
+++ b/core/graph/model.py
@@ -36,6 +36,8 @@ LEAKS = "leaks"                # finding --leaks--> credential/token
 ESCALATES_TO = "escalates_to"  # finding --escalates_to--> (terminal, via edge attr)
 PROVIDES = "provides"          # finding --provides--> primitive (this bug HANDS YOU the capability)
 REQUIRES = "requires"          # finding --requires--> primitive (this bug is BLOCKED needing it)
+ISSUES = "issues"              # endpoint --issues--> token/session (auth DATAFLOW: login mints a token)
+GRANTS = "grants"              # token/session --grants--> endpoint (auth DATAFLOW: token unlocks a protected component)
 
 
 @dataclass

--- a/core/session/gates.py
+++ b/core/session/gates.py
@@ -144,43 +144,27 @@ def set_skill(
     return _sess._current
 
 
-_SUBSTANTIVE_WORK_MIN_TOOLS = 3
-
-
-def _scan_has_substantive_work() -> bool:
-    """True when THIS session has done real work — measured session-locally (so it is
-    correctly sandboxed and never reads another scan's disk files). The agent typically
-    EXPLOITS FIRST and only declares skills afterward, so 'a tool fired while this skill
-    was active' under-counts real work; a scan that ran several distinct tools and then
-    acknowledged the skill has genuinely done the work. A fresh/empty session (no tool
-    activity) still fails, so a bare declaration on an empty scan is NOT satisfied."""
-    cur = _sess._current or {}
-    ti = cur.get("tool_invocations", 0)
-    inv_count = len(ti) if isinstance(ti, (list, dict)) else (ti or 0)
-    return inv_count >= _SUBSTANTIVE_WORK_MIN_TOOLS or \
-        len(cur.get("tools_called", [])) >= _SUBSTANTIVE_WORK_MIN_TOOLS
-
-
 def skill_worked(skill_name: str) -> bool:
-    """True when ``skill_name`` was DECLARED (set_skill) AND real work was done.
+    """True ONLY when ``skill_name`` was DECLARED (set_skill) AND a tool fired WHILE
+    IT WAS THE ACTIVE SKILL — the per-skill ``worked`` flag set by add_tool_called.
 
-    Real work = a tool fired while the skill was active (the strong signal), OR the
-    scan produced substantive results (findings / addressed cells). The fallback
-    matters because the agent routinely exploits a target before formally declaring
-    the covering skills — requiring 'work while active' alone left the gates
-    permanently unsatisfiable and stalled productive scans. A bare declaration on an
-    EMPTY scan (no findings, no coverage) still does NOT satisfy — the rubber-stamp
-    is rejected."""
+    A gate must not clear on bookkeeping. Declaring a skill's name is *not* running
+    its workflow: to satisfy the gate the skill has to actually execute (invoke the
+    Skill, work its phases, fire tools). Work must be attributable to THIS skill —
+    a tool fired while it was active — not "the scan did some work overall".
+
+    Previously this fell back to ``_scan_has_substantive_work()`` — true whenever the
+    WHOLE scan had fired >=3 tools total, regardless of whether this skill did
+    anything. That let a freshly-declared skill's gate clear instantly as long as
+    EARLIER skills had already run tools (recon almost always has), i.e. a pure
+    set_skill rubber-stamp cleared the gate. That fallback is removed: each skill now
+    earns its own gate by doing its own work. (add_tool_called marks the active
+    skill's history entry worked=True, so the proper flow — set_skill then run the
+    skill — satisfies it naturally; declare-then-complete does not.)"""
     if _sess._current is None:
         return False
-    declared = any(e.get("skill") == skill_name
-                   for e in _sess._current.get("skill_history", []))
-    if not declared:
-        return False
-    if any(e.get("skill") == skill_name and e.get("worked")
-           for e in _sess._current.get("skill_history", [])):
-        return True
-    return _scan_has_substantive_work()
+    return any(e.get("skill") == skill_name and e.get("worked")
+               for e in _sess._current.get("skill_history", []))
 
 
 def reconcile_worked_gates() -> None:

--- a/dashboard/css/dashboard.css
+++ b/dashboard/css/dashboard.css
@@ -923,6 +923,14 @@
     .ql-type.SPIDER   { color: var(--green); }
     .ql-type.FINDING  { color: #ff4d6d; }
     .ql-type.COVERAGE { color: #ffd166; }
+    /* kali command preview + timeout signal in the activity feed */
+    .ql-cmd { font-family: var(--font-mono); font-size: 0.66rem; color: var(--text-muted);
+              background: var(--bg-deep); border: 1px solid var(--border-subtle); border-radius: 4px;
+              padding: 0.03rem 0.35rem; max-width: 60ch; overflow: hidden; text-overflow: ellipsis;
+              white-space: nowrap; display: inline-block; vertical-align: middle; }
+    .ql-timeout { font-family: var(--font-mono); font-size: 0.6rem; font-weight: 700; color: var(--sev-high);
+                  background: rgba(250,140,22,.14); border: 1px solid rgba(250,140,22,.32); border-radius: 4px;
+                  padding: 0.03rem 0.35rem; margin-left: 0.3rem; }
 
     /* ── QA cycle history (embedded in QA tab) ── */
     #cycle-history-wrap {

--- a/dashboard/js/skills.js
+++ b/dashboard/js/skills.js
@@ -120,7 +120,15 @@
 
   function _qlDesc(e) {
     if (e.type === 'SKILL')    return `<span class="ql-type SKILL">${esc(e.name)}</span>${e.reason ? ' — ' + esc(e.reason) : ''}`;
-    if (e.type === 'TOOL')     return `<span class="ql-type TOOL">${esc(e.name)}</span>${e.target ? ' → ' + esc(e.target) : ''}${e.duration_s != null ? ' (' + e.duration_s + 's)' : ''}`;
+    if (e.type === 'TOOL') {
+      // kali entries now carry the actual command + outcome; others keep the target.
+      const detail = e.command
+        ? ` <code class="ql-cmd" title="${esc(e.command)}">${esc(e.command)}</code>`
+        : (e.target ? ' → ' + esc(e.target) : '');
+      const to  = e.timed_out ? ' <span class="ql-timeout" title="a request hit its time bound — possible time-based-blind / SSRF / slow endpoint">⏱ timed out</span>' : '';
+      const dur = e.duration_s != null ? ' (' + e.duration_s + 's)' : '';
+      return `<span class="ql-type TOOL">${esc(e.name)}</span>${detail}${to}${dur}`;
+    }
     if (e.type === 'SPIDER')   return `<span class="ql-type SPIDER">SPIDER</span> ${e.endpoints_found ?? '?'} endpoints found${e.target ? ' — ' + esc(e.target) : ''}`;
     if (e.type === 'FINDING')  return `<span class="ql-type FINDING">${esc(e.severity?.toUpperCase() || 'FINDING')}</span> ${esc(e.title || '')}`;
     if (e.type === 'COVERAGE') return `<span class="ql-type COVERAGE">COVERAGE</span> ${e.registered ?? '?'} endpoints · ${e.tested ?? 0} tested · ${e.pending ?? 0} pending`;

--- a/dashboard/js/world-model.js
+++ b/dashboard/js/world-model.js
@@ -89,6 +89,15 @@ const WM_SEV_COLOR = {
   critical: '#f85149', high: '#fa8c16', medium: '#d29922', low: '#5bf29b', info: '#7b78ff',
 };
 const WM_EDGE = {
+  // Structural skeleton (faint) — target -> component -> param.
+  hosts:        { color: '#30363d', style: 'solid',  width: 1 },
+  has_param:    { color: '#30363d', style: 'solid',  width: 1 },
+  runs:         { color: '#30363d', style: 'solid',  width: 1 },
+  // Auth/token DATAFLOW (blue) — how a session/JWT moves between components.
+  issues:       { color: '#4f8cff', style: 'solid',  width: 3 },
+  grants:       { color: '#4f8cff', style: 'dashed', width: 2 },
+  authenticates:{ color: '#4f8cff', style: 'dashed', width: 2 },
+  // Exploit / escalation overlay (red/amber/green).
   provides:     { color: '#3fb950', style: 'solid',  width: 3 },
   requires:     { color: '#ff7b3d', style: 'dashed', width: 3 },
   leaks:        { color: '#e3b341', style: 'solid',  width: 2 },
@@ -156,9 +165,19 @@ function wmStyle() {
 }
 
 function wmLayoutOpts(animate) {
-  return { name: 'cose', animate: !!animate, animationDuration: 500, randomize: false,
-           nodeRepulsion: 9000, idealEdgeLength: 78, edgeElasticity: 120, gravity: 0.6,
-           padding: 24, nodeDimensionsIncludeLabels: true };
+  // Hierarchical (breadthfirst) rooted at the target host so the graph reads
+  // top-down: target -> components (endpoints) -> params, with findings/tokens
+  // tiered by their distance from the target. Undirected BFS so semantic arrow
+  // direction (e.g. finding --found_on--> endpoint) doesn't invert the tiers.
+  // Falls back to a plain BFS from arbitrary roots if no host node exists.
+  const roots = _wmCy ? _wmCy.nodes('[kind="host"]') : null;
+  const opts = {
+    name: 'breadthfirst', directed: false, animate: !!animate, animationDuration: 450,
+    spacingFactor: 1.15, padding: 26, avoidOverlap: true, circle: false, grid: false,
+    nodeDimensionsIncludeLabels: true,
+  };
+  if (roots && roots.length) opts.roots = roots;
+  return opts;
 }
 
 function wmRenderGraph() {

--- a/mcp_server/kali_tools.py
+++ b/mcp_server/kali_tools.py
@@ -7,6 +7,19 @@ from core import session as scan_session
 from mcp_server._app import mcp, _clip, _record, _inject_qa_alerts
 
 
+# A request/command that hit its time bound is a LEAD, not just wasted wall-clock —
+# time-based-blind SQLi/cmdi, an SSRF connecting outbound, or a genuinely slow endpoint.
+_KALI_TIMEOUT_MARKERS = (
+    "[partial — command timed out]", "operation timed out",
+    "connection timed out", "timed out after", "curl: (28)",
+)
+
+
+def _kali_timed_out(output: str) -> bool:
+    low = (output or "").lower()
+    return any(mk in low for mk in _KALI_TIMEOUT_MARKERS)
+
+
 @mcp.tool()
 async def kali(command: str, timeout: int = 600) -> str:
     """Run any command in the Kali container (auto-starts if needed).
@@ -28,10 +41,24 @@ async def kali(command: str, timeout: int = 600) -> str:
     call_id = cost_tracker.start("kali")
     raw_output = await kali_runner.exec_command(command, timeout=timeout)
     log.tool_result_verbose("kali", raw_output, "")
+
+    # Layer 3 — timeout-as-signal: surface a hung request as a LEAD instead of letting
+    # the agent silently burn minutes waiting (and re-waiting) on it.
+    timed_out = _kali_timed_out(raw_output)
+    if timed_out:
+        raw_output = (
+            "⏱ TIMEOUT SIGNAL — a request/command here hit its time bound. This is a LEAD, not just a "
+            "slow call: it can indicate time-based-blind SQLi/cmdi, an SSRF connecting outbound, or a "
+            "genuinely slow endpoint. Do NOT just re-run and wait — confirm with a CONTROLLED time-based "
+            "probe (a known sleep delta) or bound the request with --max-time (curl is already capped at "
+            "30s by default in the container).\n\n" + raw_output
+        )
+
     result = _clip(raw_output, 8_000)
     cost_tracker.finish(call_id, result)
     log.tool_result("kali", result)
 
     from mcp_server.scan_engine import wrap
     tool_key = "kali_sqlmap" if command.strip().startswith("sqlmap") else "kali"
-    return _inject_qa_alerts(wrap(tool_key, raw_output, {"command": command, "_tool": tool_key}))
+    return _inject_qa_alerts(wrap(
+        tool_key, raw_output, {"command": command, "_tool": tool_key, "timed_out": timed_out}))

--- a/mcp_server/scan_engine/envelope/quick_log.py
+++ b/mcp_server/scan_engine/envelope/quick_log.py
@@ -27,8 +27,38 @@ def _build_quick_log_entry(
 
     entry: dict = {"type": "TOOL", "name": tool, "target": target}
     _enrich_http_request_entry(entry, tool, result, ctx)
+    _enrich_kali_entry(entry, tool, result, ctx)
     _mark_tool_error(entry, tool, result)
     return entry
+
+
+_KALI_TOOLS = ("kali", "kali_sqlmap")
+
+
+def _redact_cmd(cmd: str, limit: int = 220) -> str:
+    """One-line, secret-redacted preview of a kali command for the activity feed."""
+    import re
+    c = re.sub(r"\s+", " ", cmd).strip()
+    c = re.sub(r"(Bearer\s+)[A-Za-z0-9._-]{16,}", r"\1<redacted>", c)
+    c = re.sub(r"eyJ[A-Za-z0-9._-]{16,}", "<jwt>", c)          # bare JWTs
+    return (c[: limit - 1] + "…") if len(c) > limit else c
+
+
+def _enrich_kali_entry(entry: dict, tool: str, result: Any, ctx: dict | None) -> None:
+    """Surface WHAT a kali call ran + its outcome, so the dashboard shows
+    'kali · curl …/x → …' instead of a bare 'kali'. All fields optional — the display
+    degrades gracefully for older bare entries."""
+    if tool not in _KALI_TOOLS or not ctx:
+        return
+    cmd = (ctx.get("command") or "").strip()
+    if cmd:
+        entry["command"] = _redact_cmd(cmd)
+    if ctx.get("timed_out"):
+        entry["timed_out"] = True
+    ev = (result.evidence or {}) if result is not None else {}
+    aid = ev.get("artifact_id")
+    if aid:
+        entry["artifact_id"] = aid
 
 
 def _enrich_http_request_entry(

--- a/mcp_server/scan_engine/summarizers/__init__.py
+++ b/mcp_server/scan_engine/summarizers/__init__.py
@@ -33,6 +33,8 @@ from .web import (
     _summarize_kali_sqlmap,
     _parse_ffuf_json,
     _parse_ffuf_text,
+    _parse_ffuf_bare_words,
+    parse_ffuf_paths,
     _summarize_ffuf,
     _STATIC_EXTENSIONS,
     _extract_url_params,

--- a/mcp_server/scan_engine/summarizers/web.py
+++ b/mcp_server/scan_engine/summarizers/web.py
@@ -131,12 +131,46 @@ def _parse_ffuf_text(raw: str) -> list[dict]:
     return paths
 
 
+def _parse_ffuf_bare_words(raw: str, base_url: str) -> list[dict]:
+    """Parse ffuf silent-mode (-s) output: one matched FUZZ payload per line, no
+    status/URL. scan(tool='ffuf') runs ``-of json -s``; ``-of json`` is inert
+    without ``-o`` so stdout is bare words, which neither the JSON nor the text
+    parser matches — this was the CH-6 auto-register no-op. Each word is joined
+    onto base_url to reconstruct the discovered endpoint."""
+    base = base_url.rstrip("/")
+    if not base:
+        return []
+    paths: list[dict] = []
+    for line in raw.strip().splitlines():
+        w = line.strip()
+        # A discovered payload is a single token; skip empties, ffuf chatter
+        # (banner/progress lines carry whitespace), comments, and http-prefixed
+        # lines (already handled by the text parser).
+        if not w or w.startswith(("#", "[", ":", "http")) or any(c.isspace() for c in w):
+            continue
+        paths.append({"url": f"{base}/{w.lstrip('/')}", "status": 0, "length": 0})
+    return paths
+
+
+def parse_ffuf_paths(raw: str, base_url: str = "") -> list[dict]:
+    """Single source of truth for ffuf output parsing across all three shapes it
+    emits — JSON (``-of json`` with ``-o``), the text result table, and bare
+    silent-mode words — returning ``[{url, status, length}, ...]``. Used by both
+    the summarizer and the handlers_net auto-register path so they can never
+    disagree about what ffuf found."""
+    js = _parse_ffuf_json(raw)
+    if js is not None:
+        return js
+    text = _parse_ffuf_text(raw)
+    if text:
+        return text
+    return _parse_ffuf_bare_words(raw, base_url)
+
+
 def _summarize_ffuf(raw: str, _ctx: dict) -> SummaryResult:
     """Parse ffuf output for discovered paths."""
     result = SummaryResult()
-    paths = _parse_ffuf_json(raw)
-    if paths is None:
-        paths = _parse_ffuf_text(raw)
+    paths = parse_ffuf_paths(raw, (_ctx or {}).get("url", ""))
 
     if paths:
         result.summary = f"ffuf found {len(paths)} path(s)"

--- a/mcp_server/scan_tools/handlers_net.py
+++ b/mcp_server/scan_tools/handlers_net.py
@@ -94,8 +94,13 @@ async def _handle_ffuf(target, flags, options):
     # model to hand-register each. Fail-soft — never break the ffuf result.
     try:
         from mcp_server.scan_engine.discovery import discover_and_register
+        from mcp_server.scan_engine.summarizers.web import parse_ffuf_paths
         from mcp_server.scan_tools.spider import _spider_discovery_auth
-        paths = [ln.strip() for ln in raw.splitlines() if ln.strip().startswith("http")]
+        # Reuse the summarizer's parser (json / text-table / bare silent-mode words)
+        # instead of a startswith('http') filter — ffuf runs with -s, so raw stdout
+        # is bare FUZZ words that never start with 'http'; the old filter yielded []
+        # and this auto-register was a silent no-op on every scan.
+        paths = [p["url"] for p in parse_ffuf_paths(raw, target) if p["url"].startswith("http")]
         if paths:
             enrich = await discover_and_register(target, paths, auth=_spider_discovery_auth(None))
             if enrich.get("registered"):

--- a/mcp_server/session_tools/__init__.py
+++ b/mcp_server/session_tools/__init__.py
@@ -102,7 +102,7 @@ from .blocker_response import (
 )
 from .complete import (
     _persist_completion_counters,
-    _apply_thorough_depth_gate,
+    _thorough_gate,
     _autoclose_crosscutting_best_effort,
     _do_complete,
     _record_metrics,

--- a/mcp_server/session_tools/complete.py
+++ b/mcp_server/session_tools/complete.py
@@ -20,28 +20,6 @@ def _persist_completion_counters() -> dict:
     return current
 
 
-def _apply_thorough_depth_gate(blockers: list, current: dict) -> list:
-    """Increment analysis pass counter when quality-clean and append iteration blocker if needed.
-
-    Returns the (possibly appended) blockers list.
-    """
-    depth = (scan_session.get() or {}).get("depth", "")
-    if blockers or depth != "thorough":
-        return blockers
-    _st._analysis_passes += 1
-    if current:
-        current["analysis_passes"] = _st._analysis_passes
-        scan_session._flush()
-    if _st._analysis_passes < _st._min_iterations():
-        brief = (
-            _st._deepen_brief_whitebox(_st._analysis_passes)
-            if _st._is_whitebox_scan()
-            else _st._deepen_brief(_st._analysis_passes)
-        )
-        blockers.append(brief)
-    return blockers
-
-
 async def _autoclose_crosscutting_best_effort() -> None:
     """Propagate app-wide cross-cutting verdicts to their cells before completion.
 
@@ -93,14 +71,54 @@ def _thorough_keep_working_response(current: dict) -> str:
     return "\n".join(lines)
 
 
+def _thorough_gate(current: dict) -> str:
+    """Thorough completion = 3 enforced re-run passes, THEN unlimited/operator-terminated.
+
+    Each complete() call in thorough mode advances ONE analysis pass. While fewer
+    than _min_iterations() passes are done (full=3), it hands back THAT pass's
+    escalating deepen brief and requires another complete() after the re-run work —
+    so the 3 phases are actually driven, not skipped. Only once the 3-pass floor is
+    met does thorough become purely operator-terminated: no auto-complete, no
+    cost/time/call caps — the operator ends it via the dashboard.
+
+    Root cause this fixes: _do_complete() used to short-circuit thorough BEFORE
+    _apply_thorough_depth_gate, making _THOROUGH_MIN_ITERATIONS dead code — thorough
+    enforced neither the 3 passes nor a coverage floor, and even told the agent not
+    to call complete() again, so a single call (or none) let the scan be treated as
+    finished. This restores the '3 phases + unlimited' contract."""
+    _st._analysis_passes += 1
+    current["analysis_passes"] = _st._analysis_passes
+    _st.scan_session._flush()
+    # Evaluate skill-chain gates honestly so unrun mandatory skills surface in the brief.
+    _st.scan_session.restore_gates()
+    _st.scan_session.reconcile_worked_gates()
+    min_passes = _st._min_iterations()
+    if _st._analysis_passes < min_passes:
+        brief = (
+            _st._deepen_brief_whitebox(_st._analysis_passes)
+            if _st._is_whitebox_scan()
+            else _st._deepen_brief(_st._analysis_passes)
+        )
+        return (
+            f"THOROUGH PASS {_st._analysis_passes}/{min_passes} — the scan is NOT done "
+            f"({min_passes - _st._analysis_passes} more mandatory pass(es) after this). "
+            "Execute EVERY step below (re-run tools + skills at escalating aggression, "
+            "burn down pending coverage, chain confirmed findings), THEN call "
+            "session(action='complete') again to advance to the next pass:\n\n" + brief
+        )
+    # 3-pass floor met — thorough is now unlimited + operator-terminated.
+    return _thorough_keep_working_response(current)
+
+
 def _do_complete():
     current0 = _st.scan_session.get() or {}
-    # THOROUGH = OPERATOR-TERMINATED. In thorough depth the AGENT can never end the
-    # scan — it keeps working until the operator clicks Complete Scan (POST /api/complete
-    # → scan_session.complete() directly, unaffected by this gate). We short-circuit
-    # BEFORE counting an attempt, so this never trips HIR_FORCE_COMPLETE either.
+    # THOROUGH = 3 mandatory re-run passes, THEN unlimited/operator-terminated. The
+    # AGENT can never end a thorough scan (only the operator's dashboard Complete Scan
+    # → scan_session.complete() does), but it MUST be driven through the 3 escalating
+    # passes first (_thorough_gate). We handle thorough separately and do NOT touch
+    # _complete_attempts, so this never trips HIR_FORCE_COMPLETE.
     if str(current0.get("depth", "")).lower() == "thorough":
-        return _thorough_keep_working_response(current0)
+        return _thorough_gate(current0)
     _st._complete_attempts += 1
 
     data = findings_store._load()
@@ -119,7 +137,6 @@ def _do_complete():
 
     effective = _st._effective_tools()
     blockers = _st._collect_completion_blockers(data, effective)
-    blockers = _apply_thorough_depth_gate(blockers, current)
 
     # Progress-aware HIR (condensed profiles): blockers are surfaced one at a
     # time, so a model clearing them across several complete() calls is making

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,18 @@ _mcp_tool_shim.start()
 
 
 @pytest.fixture(autouse=True)
+def _reset_graph_cache():
+    """build_graph() memoizes on the (mtime,size) of the three store files. Tests
+    monkeypatch those stores in-memory without touching disk, so the mtime key
+    can't see the change — invalidate before and after each test so a graph built
+    from one test's monkeypatched stores never leaks into the next."""
+    from core.graph import build as _gb
+    _gb.invalidate_graph_cache()
+    yield
+    _gb.invalidate_graph_cache()
+
+
+@pytest.fixture(autouse=True)
 def disable_dashboard_auth(monkeypatch, tmp_path):
     """Disable the per-session dashboard bearer-token gate for the suite.
 

--- a/tests/test_ffuf_discovery.py
+++ b/tests/test_ffuf_discovery.py
@@ -1,0 +1,131 @@
+"""FG9 — ffuf path parsing + CH-6 auto-register.
+
+scan(tool='ffuf') runs ``ffuf -u URL/FUZZ -w WL -of json -s``. ``-s`` (silent)
+prints one bare matched FUZZ word per line and ``-of json`` is inert without
+``-o``, so stdout is bare words. The old parser only understood JSON / a text
+table / http-prefixed lines, so it returned [] on real output — the summarizer
+reported "no paths" and the auto-register block registered zero endpoints on
+every scan. These tests pin the bare-word shape and prove the reconstructed URLs
+reach discover_and_register.
+"""
+import json
+
+import pytest
+
+from mcp_server.scan_engine.summarizers.web import (
+    _parse_ffuf_bare_words,
+    _summarize_ffuf,
+    parse_ffuf_paths,
+)
+
+BARE_SILENT_OUTPUT = "admin\nlogin\n.git\nconfig.php\n"
+
+
+# ── bare-word parser (the shape that was silently dropped) ────────────────────
+
+def test_bare_words_reconstruct_urls_against_base():
+    paths = _parse_ffuf_bare_words(BARE_SILENT_OUTPUT, "http://t.test")
+    urls = [p["url"] for p in paths]
+    assert urls == [
+        "http://t.test/admin",
+        "http://t.test/login",
+        "http://t.test/.git",
+        "http://t.test/config.php",
+    ]
+    assert all(p["status"] == 0 and p["length"] == 0 for p in paths)
+
+
+def test_bare_words_need_a_base_url():
+    # No base to join onto → nothing can be reconstructed (auth for the handler's
+    # startswith('http') filter to keep working).
+    assert _parse_ffuf_bare_words(BARE_SILENT_OUTPUT, "") == []
+
+
+def test_bare_words_skip_chatter_and_dupe_slashes():
+    raw = "# comment\n[INFO] progress line\n:: banner ::\n\nadmin\n/api\nhttp://x/y\n"
+    urls = [p["url"] for p in _parse_ffuf_bare_words(raw, "http://t.test/")]
+    # only the two real payload tokens survive; the leading-slash one is normalized
+    assert urls == ["http://t.test/admin", "http://t.test/api"]
+
+
+# ── parse_ffuf_paths dispatch across all three shapes ─────────────────────────
+
+def test_dispatch_prefers_json():
+    raw = json.dumps({"results": [
+        {"url": "http://t.test/admin", "status": 200, "length": 12},
+    ]})
+    paths = parse_ffuf_paths(raw, "http://ignored")
+    assert paths == [{"url": "http://t.test/admin", "status": 200, "length": 12}]
+
+
+def test_dispatch_falls_back_to_text_table():
+    raw = "200      GET      512      http://t.test/robots.txt\n"
+    paths = parse_ffuf_paths(raw, "http://t.test")
+    assert paths and paths[0]["url"] == "http://t.test/robots.txt"
+    assert paths[0]["status"] == 200
+
+
+def test_dispatch_falls_back_to_bare_words():
+    paths = parse_ffuf_paths(BARE_SILENT_OUTPUT, "http://t.test")
+    assert [p["url"] for p in paths] == [
+        "http://t.test/admin", "http://t.test/login",
+        "http://t.test/.git", "http://t.test/config.php",
+    ]
+
+
+# ── summarizer no longer reports "no paths" on real -s output ─────────────────
+
+def test_summarizer_finds_bare_word_paths():
+    result = _summarize_ffuf(BARE_SILENT_OUTPUT, {"url": "http://t.test"})
+    assert result.evidence["total"] == 4
+    assert "http://t.test/admin" in [p["url"] for p in result.evidence["paths"]]
+    assert result.summary == "ffuf found 4 path(s)"
+
+
+def test_summarizer_json_regression_still_parses():
+    raw = json.dumps({"results": [
+        {"url": "http://t.test/a", "status": 200, "length": 1},
+        {"url": "http://t.test/b", "status": 301, "length": 2},
+    ]})
+    result = _summarize_ffuf(raw, {"url": "http://t.test"})
+    assert result.evidence["total"] == 2
+
+
+def test_summarizer_empty_stays_empty():
+    result = _summarize_ffuf("", {"url": "http://t.test"})
+    assert result.evidence == {"paths": [], "total": 0}
+    assert result.summary == "ffuf: no paths discovered"
+
+
+# ── auto-register wiring: reconstructed URLs reach discover_and_register ───────
+
+@pytest.mark.asyncio
+async def test_handle_ffuf_auto_registers_bare_word_paths(monkeypatch):
+    import mcp_server.scan_engine as scan_engine
+    import mcp_server.scan_engine.discovery as discovery
+    import mcp_server.scan_tools.handlers_net as hn
+    from tools import kali_runner
+
+    async def fake_exec(cmd, timeout=None):
+        return BARE_SILENT_OUTPUT
+
+    captured = {}
+
+    async def fake_register(target, spider_urls, auth_context="none", auth=None):
+        captured["target"] = target
+        captured["urls"] = list(spider_urls)
+        return {"registered": len(spider_urls), "cells": len(spider_urls) * 12}
+
+    monkeypatch.setattr(kali_runner, "exec_command", fake_exec)
+    monkeypatch.setattr(hn, "_record", lambda *a, **k: None)
+    monkeypatch.setattr(scan_engine, "wrap", lambda tool, raw, ctx: f"[wrapped {tool}]")
+    monkeypatch.setattr(discovery, "discover_and_register", fake_register)
+
+    result = await hn._handle_ffuf("http://t.test", "", {})
+
+    assert captured["urls"] == [
+        "http://t.test/admin", "http://t.test/login",
+        "http://t.test/.git", "http://t.test/config.php",
+    ]
+    # the operator-facing note reports the auto-registered endpoints/cells
+    assert "AUTO-DISCOVERY" in result and "registered 4" in result

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -164,3 +164,52 @@ class TestBuildProjection:
         assert any(n.kind == gm.ENDPOINT for n in g.nodes.values())
         assert any(e.kind == gm.TESTED_FOR for e in g.edges)
         scan_session._current = None
+
+
+class TestGraphCache:
+    """build_graph() is memoized on the (mtime,size) of its three store files —
+    it was re-projecting all three on every QA-daemon tick and report(note)."""
+
+    def test_memoizes_until_input_signature_changes(self, monkeypatch):
+        import core.graph.build as gb
+        calls = {"n": 0}
+        base = gb._assemble
+
+        def counting():
+            calls["n"] += 1
+            return base()
+
+        monkeypatch.setattr(gb, "_assemble", counting)
+        monkeypatch.setattr(gb, "_cache_key", lambda: ("sig-v1",))
+        gb.invalidate_graph_cache()
+
+        first = gb.build_graph()
+        second = gb.build_graph()
+        assert calls["n"] == 1              # second call served from cache
+        assert first is second             # same instance, not a rebuild
+
+        monkeypatch.setattr(gb, "_cache_key", lambda: ("sig-v2",))
+        third = gb.build_graph()
+        assert calls["n"] == 2              # input signature changed → rebuild
+        assert third is not first
+
+        gb.invalidate_graph_cache()
+        gb.build_graph()
+        assert calls["n"] == 3              # explicit invalidation forces a rebuild
+        gb.invalidate_graph_cache()
+
+    def test_cache_key_is_stable_and_read_free(self, monkeypatch, tmp_path):
+        """The key stats the three store files (mtime,size) — never reads them —
+        and a missing file degrades to (0,0) rather than raising."""
+        import core.graph.build as gb
+        import core.paths as paths
+        sess = tmp_path / "session.json"
+        sess.write_text("{}")
+        monkeypatch.setattr(paths, "SESSION_FILE", sess)
+        monkeypatch.setattr(paths, "FINDINGS_FILE", tmp_path / "missing_findings.json")
+        monkeypatch.setattr(paths, "COVERAGE_FILE", tmp_path / "missing_cov.json")
+        k1 = gb._cache_key()
+        assert k1[1] == (0, 0) and k1[2] == (0, 0)   # missing files → (0,0)
+        assert gb._cache_key() == k1                 # stable when nothing changes
+        sess.write_text('{"status": "running"}')     # bigger content → new size
+        assert gb._cache_key() != k1

--- a/tests/test_kali_observability.py
+++ b/tests/test_kali_observability.py
@@ -1,0 +1,79 @@
+"""
+Kali timeout-as-signal (Layer 3) + activity-feed observability (command/outcome
+surfaced in the quick_log entry instead of a bare 'kali').
+"""
+import mcp_server.kali_tools as kt
+from mcp_server.scan_engine.envelope.quick_log import (
+    _build_quick_log_entry, _enrich_kali_entry, _redact_cmd,
+)
+
+
+class _R:
+    def __init__(self, evidence=None):
+        self.evidence = evidence or {}
+
+
+# ── Layer 3: timeout-as-signal ───────────────────────────────────────────────
+
+class TestKaliTimeoutDetect:
+    def test_curl_operation_timeout(self):
+        assert kt._kali_timed_out("curl: (28) Operation timed out after 30001 ms")
+
+    def test_partial_timeout_marker(self):
+        assert kt._kali_timed_out("[partial — command timed out]\n<some output>")
+
+    def test_connection_timed_out(self):
+        assert kt._kali_timed_out("Connection timed out")
+
+    def test_normal_output_is_not_a_timeout(self):
+        assert not kt._kali_timed_out("HTTP/1.1 200 OK\n412 bytes")
+
+    def test_empty_output(self):
+        assert not kt._kali_timed_out("")
+
+
+# ── Observability: command preview + redaction ───────────────────────────────
+
+class TestRedactCmd:
+    def test_redacts_bearer_token(self):
+        out = _redact_cmd("curl -H 'Authorization: Bearer eyJ0eXAiOiJKV1Qiabcdefghijklmnop' http://t/x")
+        assert "eyJ0eXAiOiJKV1Q" not in out and ("<redacted>" in out or "<jwt>" in out)
+
+    def test_collapses_whitespace_and_truncates(self):
+        out = _redact_cmd("curl   \n  http://t/x " + "A" * 400, limit=120)
+        assert "\n" not in out and len(out) <= 120 and out.endswith("…")
+
+    def test_short_command_untouched(self):
+        assert _redact_cmd("curl http://t/x") == "curl http://t/x"
+
+
+class TestEnrichKaliEntry:
+    def test_kali_entry_gets_command_timeout_artifact(self):
+        e = {"type": "TOOL", "name": "kali", "target": ""}
+        _enrich_kali_entry(e, "kali", _R({"artifact_id": "kali_123"}),
+                           {"command": "curl http://t/x", "timed_out": True})
+        assert e["command"] == "curl http://t/x"
+        assert e["timed_out"] is True
+        assert e["artifact_id"] == "kali_123"
+
+    def test_sqlmap_variant_also_enriched(self):
+        e = {"type": "TOOL", "name": "kali_sqlmap"}
+        _enrich_kali_entry(e, "kali_sqlmap", None, {"command": "sqlmap -u http://t/x?id=1"})
+        assert e["command"].startswith("sqlmap")
+
+    def test_non_kali_tool_untouched(self):
+        e = {"type": "TOOL", "name": "http_request"}
+        _enrich_kali_entry(e, "http_request", None, {"command": "should be ignored"})
+        assert "command" not in e
+
+    def test_no_ctx_is_noop(self):
+        e = {"type": "TOOL", "name": "kali"}
+        _enrich_kali_entry(e, "kali", None, None)
+        assert "command" not in e
+
+    def test_build_entry_end_to_end(self):
+        entry = _build_quick_log_entry(
+            "kali", "", "ran a probe", None, {"command": "curl -s http://t/x", "timed_out": False})
+        assert entry["type"] == "TOOL" and entry["name"] == "kali"
+        assert entry["command"] == "curl -s http://t/x"
+        assert "timed_out" not in entry  # falsy → omitted

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -527,6 +527,25 @@ def test_skill_worked_true_after_a_tool_call():
     assert core.session.skill_worked("api-security") is True
 
 
+def test_skill_worked_false_for_freshly_declared_skill_even_after_prior_scan_work():
+    """The bookkeeping loophole: recon (and earlier skills) have already fired several
+    tools, then a NEW skill is declared with no work of its own. It must NOT be
+    considered worked just because the scan-as-a-whole was busy — otherwise a bare
+    set_skill on a live scan rubber-stamps the gate. Work must be attributable to the
+    declared skill."""
+    core.session.start("example.com")
+    core.session.set_skill("pentester")
+    for t in ("httpx", "naabu", "spider", "nuclei"):   # recon ran >=3 tools under pentester
+        core.session.add_tool_called(t)
+    core.session.set_skill("business-logic")            # declared, but does no work of its own
+    assert core.session.skill_worked("business-logic") is False
+    # pentester genuinely worked, so it stays satisfied.
+    assert core.session.skill_worked("pentester") is True
+    # Now business-logic actually runs a tool -> it earns its gate.
+    core.session.add_tool_called("http")
+    assert core.session.skill_worked("business-logic") is True
+
+
 def test_reconcile_worked_gates_only_satisfies_worked_skills():
     core.session.start("example.com")
     core.session.trigger_gate("api_coverage", "api discovered", ["api-security"])

--- a/tests/test_session_tools_helpers.py
+++ b/tests/test_session_tools_helpers.py
@@ -954,19 +954,35 @@ class TestDoComplete:
             or "complete" in result.lower()
         )
 
-    def test_thorough_is_operator_terminated_agent_never_completes(self, tmp_path, monkeypatch):
-        # THOROUGH is OPERATOR-TERMINATED: the agent's complete() never ends the scan —
-        # it is told to keep working until the operator clicks Complete Scan, and it must
-        # NOT count as a complete() attempt (so it can't trip HIR_FORCE_COMPLETE).
+    def test_thorough_enforces_3_passes_then_operator_terminated(self, tmp_path, monkeypatch):
+        # THOROUGH = MY LAYOUT: 3 mandatory escalating re-run passes, THEN
+        # unlimited/operator-terminated. The first (_min_iterations()-1) complete()
+        # calls each hand back that pass's deepen brief and require another complete();
+        # only once the 3-pass floor is met does it flip to operator-terminated. The
+        # agent's complete() NEVER ends the scan and NEVER counts as a complete()
+        # attempt (so it can't trip HIR_FORCE_COMPLETE). Regression for the bug where
+        # thorough short-circuited BEFORE the pass gate, making the 3 passes dead code.
         import mcp_server.session_tools as st
         monkeypatch.setattr(st, "_complete_attempts", 0)
+        monkeypatch.setattr(st, "_analysis_passes", 0)
+        monkeypatch.setattr(st, "_min_iterations", lambda: 3)
+        monkeypatch.setattr(st, "_is_whitebox_scan", lambda: False)
+        monkeypatch.setattr(st, "_deepen_brief", lambda n: f"DEEPEN-BRIEF-PASS-{n}")
         self._setup_session(tmp_path, monkeypatch, depth="thorough")
-        with patch("mcp_server.session_tools._effective_tools", return_value=set()), \
-             patch("mcp_server.session_tools._collect_completion_blockers", return_value=[]):
-            result = _do_complete()
-        assert "does NOT auto-complete" in result
-        assert "operator" in result.lower() and "keep" in result.lower()
-        assert st._complete_attempts == 0  # not counted as an attempt
+
+        # Pass 1 and 2 → escalating pass brief, NOT done, still zero attempts.
+        r1 = _do_complete()
+        assert "THOROUGH PASS 1/3" in r1 and "DEEPEN-BRIEF-PASS-1" in r1
+        assert "does NOT auto-complete" not in r1
+        r2 = _do_complete()
+        assert "THOROUGH PASS 2/3" in r2 and "DEEPEN-BRIEF-PASS-2" in r2
+
+        # Pass 3 → 3-phase floor met → unlimited/operator-terminated message.
+        r3 = _do_complete()
+        assert "does NOT auto-complete" in r3
+        assert "operator" in r3.lower() and "keep" in r3.lower()
+
+        assert st._complete_attempts == 0  # thorough never counts a complete() attempt
 
     def test_multiple_blockers_full_profile_shows_all(self, tmp_path, monkeypatch):
         """Full profile (large context, ``condensed_directives=False``) gets the

--- a/tools/kali/Dockerfile
+++ b/tools/kali/Dockerfile
@@ -451,6 +451,13 @@ RUN [ "$INSTALL_AI" = "1" ] || { echo "[ai] skipped"; exit 0; }; \
     && npm config set strict-ssl false \
     && npm install -g promptfoo@0.121.2
 
+# Bound curl by DEFAULT so a hung request can never silently block a tool call for
+# minutes — a working injection payload (time-based-blind, SSRF-connect) routinely stalls
+# the response, and without a cap curl waits ~300s. The agent can still override --max-time
+# for deliberate time-based tests. (kali_runner also seeds this at container start, so it
+# applies even before a rebuild.)
+RUN printf 'connect-timeout = 5\nmax-time = 30\n' > /root/.curlrc
+
 EXPOSE 5000
 
 # kali-server-mcp is the Flask API component of mcp-kali-server.

--- a/tools/kali_runner.py
+++ b/tools/kali_runner.py
@@ -111,12 +111,29 @@ async def ensure_running() -> tuple[bool, str]:
                     timeout=aiohttp.ClientTimeout(total=1),
                 ) as r:
                     if r.status == 200:
+                        await _seed_curl_defaults()
                         return True, "started"
         except Exception:
             pass
         await asyncio.sleep(1)
 
     return False, "container started but /health never responded — check: docker logs pentest-kali"
+
+
+async def _seed_curl_defaults() -> None:
+    """Write /root/.curlrc into the running container so EVERY curl is bounded by default
+    (connect-timeout 5s, max-time 30s). A hung request then can't silently block a tool
+    call for minutes. Runtime seed → applies without an image rebuild; the Dockerfile
+    bakes the same file for clean rebuilds. Best-effort — never fail container startup."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            docker_executable(), "exec", KALI_CONTAINER, "sh", "-c",
+            "printf 'connect-timeout = 5\\nmax-time = 30\\n' > /root/.curlrc",
+            stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL,
+        )
+        await proc.wait()
+    except Exception:
+        pass
 
 
 async def stop() -> str:


### PR DESCRIPTION
## Why
Parameter testing was wall-clock slow **not because the model is slow** (http/coverage turns are seconds) but because kali verification curls carry **no time bound** — a working injection payload routinely stalls the response, and without `--max-time` curl waits ~300s, so each `kali` call blocked **5–6 min**. And the dashboard showed a bare `kali` with no command/outcome.

## Layer 1 — bound curl at the *environment* (no agent discipline)
- **Dockerfile**: `/root/.curlrc` with `connect-timeout=5`, `max-time=30` (permanent).
- **kali_runner**: `_seed_curl_defaults()` writes the same at container start via `docker exec` — applies **without an image rebuild**. Agent can still override `--max-time` for deliberate time-based tests.

## Layer 3 — timeout-as-signal
A request that hit its time bound is a **LEAD** (time-based-blind SQLi/cmdi, an SSRF connecting outbound, a slow endpoint), not wasted wall-clock. `kali_tools.py` detects it and prepends a **TIMEOUT SIGNAL** note steering a *controlled* follow-up instead of a blind re-wait — so we don't silently discard the signal a blanket `--max-time` would throw away.

## Observability — show what kali actually did
- **quick_log writer**: enriches the TOOL entry for kali with the **secret-redacted, truncated command**, a `timed_out` flag, and the output `artifact_id`.
- **dashboard**: the activity feed now shows `kali · curl …/x  ⏱ timed out` instead of a bare `kali`. Degrades gracefully for old bare entries.

## Testing & activation
`tests/test_kali_observability.py` (13, green). Built **git-only while a scan runs — no restarts, no live-state touched**. Activation: dashboard display is **live on a browser refresh**; the `.curlrc` seed + Layer 3 + enriched writer take effect on the **next MCP restart / kali container start**; the Dockerfile line on the next **image rebuild**. Layer 2 (idle-output kill in the in-container kali-server) is the planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)