### PR TITLE
fix(watchdog): resume crashed scans without the 40-agent runaway

### DIFF
--- a/core/api_server/__init__.py
+++ b/core/api_server/__init__.py
@@ -153,7 +153,14 @@ async def _start_background_tasks() -> None:
     _load_dotenv()
     from core.qa_agent import qa_daemon
     _qa_task = asyncio.create_task(qa_daemon.run(interval_s=120))
-    _watchdog_task = asyncio.create_task(_smith_watchdog_loop())
+    # The watchdog auto-respawns a headless Smith whenever a scan is 'running' but Smith
+    # looks dead. SMITH_WATCHDOG_DISABLED=1 turns that off so the dashboard UI can run
+    # WITHOUT unattended agent spawns / surprise API cost — e.g. when a human is driving
+    # the scan interactively. Default (unset) keeps the auto-restart behaviour.
+    if os.environ.get("SMITH_WATCHDOG_DISABLED", "").strip().lower() not in ("1", "true", "yes"):
+        _watchdog_task = asyncio.create_task(_smith_watchdog_loop())
+    else:
+        _watchdog_task = None
     _status_task = asyncio.create_task(_status_update_loop())
 
 
@@ -291,6 +298,7 @@ from .smith import (  # noqa: E402
     _SMITH_STALL_SECONDS,
     _SPAWN_SOURCE_TAGS,
     _WATCHDOG_MAX_NO_PROGRESS,
+    _WATCHDOG_MAX_PER_SCAN,
     _client_installed,
     _client_process_running,
     _cold_recovery_prompt,

--- a/core/api_server/smith/__init__.py
+++ b/core/api_server/smith/__init__.py
@@ -26,6 +26,11 @@ from __future__ import annotations
 # object the submodules mutate via ``_smith.<name>``.
 _watchdog_last_progress: tuple | None = None
 _watchdog_no_progress_count = 0
+# Cumulative per-scan auto-respawn accounting (enforces _WATCHDOG_MAX_PER_SCAN). Keyed
+# on the session id so a new scan resets it; stops the operator-terminated-thorough
+# runaway where the rolling per-hour cap alone let the watchdog respawn forever.
+_watchdog_scan_key: str = ""
+_watchdog_scan_restarts = 0
 # Last respawn-failure reason (the child's own exit line, e.g. an out-of-usage /
 # credit / auth message) so the no-progress HIR can report the REAL cause instead
 # of the generic "agent keeps exiting without testing". Cleared on a live respawn.
@@ -41,6 +46,7 @@ from ._common import (  # noqa: E402,F401
     _SMITH_STALL_SECONDS,
     _WATCHDOG_MAX_NO_PROGRESS,
     _WATCHDOG_COLD_START_AFTER,
+    _WATCHDOG_MAX_PER_SCAN,
     _KNOWN_CLIENTS,
     _SPAWN_SOURCE_TAGS,
     _MCP_SSE_RESTART_MIN_GAP_SECONDS,

--- a/core/api_server/smith/_common.py
+++ b/core/api_server/smith/_common.py
@@ -48,6 +48,15 @@ _WATCHDOG_MAX_NO_PROGRESS = 3
 # context gets a real shot before the run escalates to HIR_NO_PROGRESS.
 _WATCHDOG_COLD_START_AFTER = 2
 
+# Cumulative per-scan auto-respawn cap. _WATCHDOG_MAX_PER_HOUR is a ROLLING window,
+# so a thorough scan — which is operator-terminated and never auto-completes (status
+# stays "running" indefinitely) — lets the watchdog respawn ~20/hour forever: the
+# observed "40 agents overnight" runaway. This is a HARD cap on TOTAL auto-respawns
+# for a single scan (keyed on the session id). Once hit, the watchdog stops respawning
+# and escalates to the operator instead of silently looping. Genuine crash-resume still
+# works up to this many times per scan; a runaway can't exceed it.
+_WATCHDOG_MAX_PER_SCAN = 8
+
 _KNOWN_CLIENTS = ("claude", "opencode", "codex")
 
 # Small lookup table for the audit-log tag that goes into session.json's

--- a/core/api_server/smith/progress.py
+++ b/core/api_server/smith/progress.py
@@ -17,11 +17,16 @@ from ._common import _log, _WATCHDOG_MAX_NO_PROGRESS
 
 
 def _scan_progress_snapshot() -> tuple:
-    """(findings, addressed cells, quick_log mtime) — the watchdog's fingerprint
-    for 'did the last respawn actually accomplish anything?'."""
+    """(findings, addressed cells) — the watchdog's fingerprint for 'did the last
+    respawn actually accomplish anything SUBSTANTIVE?'.
+
+    Deliberately does NOT include quick_log mtime: a respawned agent that merely
+    thrashes (recovery -> list -> exit) still bumps the log, so including mtime made
+    the fingerprint change on pure activity and reset the no-progress counter every
+    time — the breaker then never fired and the watchdog respawned indefinitely. Real
+    progress = a new finding or a newly-closed cell; anything less is a futile respawn."""
     import json
     findings = addressed = 0
-    qmtime = 0.0
     try:
         findings = len(json.loads(_api._FINDINGS_FILE.read_text()).get("findings", []))
     except Exception:
@@ -32,11 +37,7 @@ def _scan_progress_snapshot() -> tuple:
                         if c.get("status") in ("tested_clean", "vulnerable", "not_applicable"))
     except Exception:
         pass
-    try:
-        qmtime = round(_api._QUICK_LOG_FILE.stat().st_mtime, 1)
-    except Exception:
-        pass
-    return (findings, addressed, qmtime)
+    return (findings, addressed)
 
 
 def _watchdog_should_escalate_no_progress() -> bool:

--- a/core/api_server/smith/watchdog.py
+++ b/core/api_server/smith/watchdog.py
@@ -63,6 +63,27 @@ async def _watchdog_respawn_flow(now: float) -> None:
             "WATCHDOG_RESPAWN_CAP",
         )
         return
+    # Cumulative per-scan cap — the per-hour window above resets each hour, so on an
+    # operator-terminated thorough scan (status stays 'running' forever) the watchdog
+    # would respawn ~MAX_PER_HOUR/hour indefinitely (the "40 agents overnight" runaway).
+    # Key a cumulative counter on the session id; once a single scan hits
+    # _WATCHDOG_MAX_PER_SCAN total auto-respawns, STOP and hand off to the operator.
+    sid = str((_api._read_json(_api._SESSION_FILE) or {}).get("id") or "")
+    if sid and sid != _smith._watchdog_scan_key:
+        _smith._watchdog_scan_key = sid      # new scan → reset the cumulative count
+        _smith._watchdog_scan_restarts = 0
+    if _smith._watchdog_scan_restarts >= _api._WATCHDOG_MAX_PER_SCAN:
+        _log.warning("watchdog suppressed: per-scan respawn cap %d reached for scan %s — "
+                     "auto-respawn stopped, awaiting operator",
+                     _api._WATCHDOG_MAX_PER_SCAN, sid[:8])
+        _smith._watchdog_notify(
+            "Smith auto-respawn cap reached for this scan",
+            f"The watchdog has auto-restarted Smith {_smith._watchdog_scan_restarts} times for this "
+            f"scan without it completing (cap {_api._WATCHDOG_MAX_PER_SCAN}). Auto-respawn is now "
+            "STOPPED to prevent a runaway. Resume from the dashboard, or complete the scan.",
+            "WATCHDOG_PER_SCAN_CAP",
+        )
+        return
     # No-progress backoff — escalate to a human instead of respawning into the
     # same dead end (the recovery→list→exit loop that burned the model every 2 min).
     if _api._watchdog_should_escalate_no_progress():
@@ -76,6 +97,7 @@ async def _watchdog_respawn_flow(now: float) -> None:
     if ok:
         _api._watchdog_last_restart_ts = now
         _api._watchdog_restart_count_window.append(now)
+        _smith._watchdog_scan_restarts += 1   # count toward the cumulative per-scan cap
         _smith._last_spawn_failure = ""   # live respawn — clear any prior failure reason
         _log.info("watchdog: spawned pid=%d", int(result) if isinstance(result, int) else 0)
     else:

--- a/tests/test_api_smith_endpoints.py
+++ b/tests/test_api_smith_endpoints.py
@@ -724,40 +724,41 @@ class TestWatchdogNoProgressBackoff:
     def _reset_no_progress_globals(self, monkeypatch):
         monkeypatch.setattr(api.smith, "_watchdog_no_progress_count", 0)
         monkeypatch.setattr(api.smith, "_watchdog_last_progress", None)
+        monkeypatch.setattr(api.smith, "_watchdog_scan_key", "")
+        monkeypatch.setattr(api.smith, "_watchdog_scan_restarts", 0)
 
-    def test_snapshot_reads_findings_cells_and_mtime(self, tmp_path, monkeypatch):
+    def test_snapshot_reads_findings_and_cells_not_mtime(self, tmp_path, monkeypatch):
+        # The fingerprint is (findings, addressed cells) ONLY — quick_log mtime is
+        # deliberately excluded: a respawn that merely thrashes (recovery→list→exit)
+        # still bumps the log, so including mtime reset the no-progress counter on
+        # pure activity and the breaker never fired. Substantive progress = a new
+        # finding or a newly-closed cell, nothing less.
         findings = tmp_path / "findings.json"
         coverage = tmp_path / "coverage.json"
-        quick = tmp_path / "quick_log.json"
         findings.write_text(json.dumps({"findings": [{"id": "a"}, {"id": "b"}]}))
         coverage.write_text(json.dumps({"matrix": [
             {"status": "tested_clean"}, {"status": "vulnerable"},
             {"status": "not_applicable"}, {"status": "pending"},  # pending not counted
         ]}))
-        quick.write_text("{}\n")
         monkeypatch.setattr(api, "_FINDINGS_FILE", findings)
         monkeypatch.setattr(api, "_COVERAGE_FILE", coverage)
-        monkeypatch.setattr(api, "_QUICK_LOG_FILE", quick)
 
-        findings_n, addressed, qmtime = api._scan_progress_snapshot()
-        assert findings_n == 2
-        assert addressed == 3          # tested_clean + vulnerable + not_applicable
-        assert qmtime == round(quick.stat().st_mtime, 1)
+        snap = api._scan_progress_snapshot()
+        assert snap == (2, 3)          # findings=2, addressed = tested_clean+vulnerable+not_applicable
 
     def test_snapshot_is_all_zero_when_files_missing(self, tmp_path, monkeypatch):
         monkeypatch.setattr(api, "_FINDINGS_FILE", tmp_path / "nope.json")
         monkeypatch.setattr(api, "_COVERAGE_FILE", tmp_path / "nope2.json")
-        monkeypatch.setattr(api, "_QUICK_LOG_FILE", tmp_path / "nope3.json")
-        assert api._scan_progress_snapshot() == (0, 0, 0.0)
+        assert api._scan_progress_snapshot() == (0, 0)
 
     def test_first_call_never_escalates(self, monkeypatch):
         """Reset globals → last_progress is None → the very first observation
         can't escalate (we have nothing to compare against yet)."""
-        monkeypatch.setattr(api.smith, "_scan_progress_snapshot", lambda: (1, 5, 123.0))
+        monkeypatch.setattr(api.smith, "_scan_progress_snapshot", lambda: (1, 5))
         assert api._watchdog_should_escalate_no_progress() is False
 
     def test_escalates_after_max_unchanged_snapshots(self, monkeypatch):
-        monkeypatch.setattr(api.smith, "_scan_progress_snapshot", lambda: (1, 5, 123.0))
+        monkeypatch.setattr(api.smith, "_scan_progress_snapshot", lambda: (1, 5))
         # First call seeds last_progress (False); each subsequent identical call
         # increments; escalation fires once the counter hits the cap.
         results = [api._watchdog_should_escalate_no_progress()
@@ -767,7 +768,7 @@ class TestWatchdogNoProgressBackoff:
         assert any(results)  # cap reached within the window
 
     def test_progress_resets_the_counter(self, monkeypatch):
-        snaps = [(1, 5, 1.0), (1, 5, 1.0), (2, 6, 2.0), (2, 6, 2.0)]
+        snaps = [(1, 5), (1, 5), (2, 6), (2, 6)]
         it = iter(snaps)
         monkeypatch.setattr(api.smith, "_scan_progress_snapshot", lambda: next(it))
         api._watchdog_should_escalate_no_progress()      # seed (1,5,1.0)
@@ -778,7 +779,7 @@ class TestWatchdogNoProgressBackoff:
 
     def test_escalate_triggers_hir_and_notifies_and_resets(self, monkeypatch):
         monkeypatch.setattr(api.smith, "_watchdog_no_progress_count", 3)
-        monkeypatch.setattr(api.smith, "_watchdog_last_progress", (1, 5, 1.0))
+        monkeypatch.setattr(api.smith, "_watchdog_last_progress", (1, 5))
         with patch("core.session.trigger_intervention") as mock_hir, \
              patch("core.notifiers.notify") as mock_notify:
             api._escalate_no_progress_hir()
@@ -815,6 +816,50 @@ class TestWatchdogNoProgressBackoff:
             await api.smith._watchdog_respawn_flow(time.time())
         mock_escalate.assert_not_called()
         mock_spawn.assert_awaited_once()
+        # A successful respawn counts toward the cumulative per-scan cap.
+        assert api.smith._watchdog_scan_restarts == 1
+
+    @pytest.mark.asyncio
+    async def test_respawn_flow_stops_at_per_scan_cap(self, monkeypatch):
+        """The rolling per-HOUR window resets each hour, so on an operator-terminated
+        thorough scan (status stays 'running' forever) it alone lets the watchdog
+        respawn ~20/hour indefinitely — the '40 agents overnight' runaway. Once a single
+        scan hits the cumulative per-scan cap, auto-respawn STOPS and hands off to the
+        operator instead of spawning again."""
+        monkeypatch.setattr(api, "_watchdog_last_restart_ts", 0.0)
+        monkeypatch.setattr(api, "_watchdog_restart_count_window", [])
+        # This scan has already been auto-respawned up to the cap.
+        monkeypatch.setattr(api.smith, "_watchdog_scan_key", "scan-abc")
+        monkeypatch.setattr(api.smith, "_watchdog_scan_restarts", api._WATCHDOG_MAX_PER_SCAN)
+        with patch.object(api, "_mcp_sse_alive", return_value=True), \
+             patch.object(api, "_read_json", return_value={"id": "scan-abc"}), \
+             patch.object(api, "_watchdog_should_escalate_no_progress", return_value=False), \
+             patch.object(api, "_spawn_smith", new_callable=AsyncMock) as mock_spawn, \
+             patch.object(api.smith, "_watchdog_notify") as mock_notify:
+            await api.smith._watchdog_respawn_flow(time.time())
+        mock_spawn.assert_not_called()
+        codes = [c.args[2] for c in mock_notify.call_args_list]
+        assert "WATCHDOG_PER_SCAN_CAP" in codes
+
+    @pytest.mark.asyncio
+    async def test_respawn_flow_resets_per_scan_count_on_new_scan(self, monkeypatch):
+        """A new scan (different session id) resets the cumulative counter so a fresh
+        scan gets its full crash-resume budget even if a prior scan exhausted the cap."""
+        monkeypatch.setattr(api, "_watchdog_last_restart_ts", 0.0)
+        monkeypatch.setattr(api, "_watchdog_restart_count_window", [])
+        monkeypatch.setattr(api.smith, "_watchdog_scan_key", "old-scan")
+        monkeypatch.setattr(api.smith, "_watchdog_scan_restarts", api._WATCHDOG_MAX_PER_SCAN)
+        with patch.object(api, "_mcp_sse_alive", return_value=True), \
+             patch.object(api, "_read_json", return_value={"id": "new-scan"}), \
+             patch.object(api, "_watchdog_should_escalate_no_progress", return_value=False), \
+             patch.object(api, "_detect_active_client", return_value="opencode"), \
+             patch.object(api, "_spawn_smith", new_callable=AsyncMock,
+                          return_value=(True, 4242)) as mock_spawn, \
+             patch("core.notifiers.notify"):
+            await api.smith._watchdog_respawn_flow(time.time())
+        mock_spawn.assert_awaited_once()          # reset → spawn allowed
+        assert api.smith._watchdog_scan_key == "new-scan"
+        assert api.smith._watchdog_scan_restarts == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The dashboard watchdog respawns a headless Smith when a scan is 'running' but Smith looks dead. Two gaps let that resume-on-crash turn into an overnight runaway (~40 agents):

1. The no-progress fingerprint (_scan_progress_snapshot) included the quick_log mtime, so a respawn that merely thrashed (recovery->list->exit) still bumped the log -> fingerprint changed -> the no-progress breaker reset every cycle and never fired. Fingerprint is now (findings, addressed cells) ONLY: real progress, not mere activity.

2. _WATCHDOG_MAX_PER_HOUR is a ROLLING window that resets each hour, so an operator-terminated thorough scan (status stays 'running' forever) let the watchdog respawn ~20/hour indefinitely. Added a cumulative per-scan cap (_WATCHDOG_MAX_PER_SCAN=8) keyed on the session id: a new scan resets it; once a single scan exhausts it, auto-respawn STOPS and escalates to the operator (WATCHDOG_PER_SCAN_CAP) instead of looping.

Genuine crash-resume still works (up to the cap per scan); the runaway can't exceed it. SMITH_WATCHDOG_DISABLED=1 remains an opt-in escape hatch for interactive/solo driving; default keeps auto-restart on.


Claude-Session: https://claude.ai/code/session_01TKBxKVztFvX58BibWN3TZK