### PR TITLE
fix(auth): stop the AI-testing anthropic key from billing the Smith agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,19 @@
 # Leave blank or remove lines you don't need.
 
 OPENAI_API_KEY=
-ANTHROPIC_API_KEY=
+# Anthropic key for the AI red-team tools ONLY. Named AITEST_ (not ANTHROPIC_API_KEY) on purpose so an
+# interactive `claude` can't pick it up and bill your Smith agent's model calls to it — the server
+# re-exposes it as ANTHROPIC_API_KEY internally for FuzzyAI/PyRIT + the QA agent.
+AITEST_ANTHROPIC_API_KEY=
 AZURE_OPENAI_API_KEY=
+
+# ── Smith agent model auth ───────────────────────────────────────────────────
+# Leave unset (default) → the Smith agent runs on your Claude SUBSCRIPTION. Set both of these to bill
+# the agent (interactive + headless) to an API key instead. Only set ANTHROPIC_API_KEY here if you want
+# the agent on the API — it will also make an interactive `claude` bill that key.
+# SMITH_USE_API_KEY=yes
+# SMITH_SPAWN_USE_API_KEY=1
+# ANTHROPIC_API_KEY=
 
 # ── Telegram bridge (optional) ───────────────────────────────────────────────
 # Get HIR / scan-complete alerts on your phone. Leave both blank to disable —

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -233,10 +233,36 @@ echo ""
 
 _ask_key "OPENAI_API_KEY" \
     "Powers FuzzyAI and PyRIT scoring (openai provider)"
-_ask_key "ANTHROPIC_API_KEY" \
-    "Powers FuzzyAI and PyRIT scoring (anthropic provider) — API key (sk-ant-...), NOT your Claude.ai login"
+_ask_key "AITEST_ANTHROPIC_API_KEY" \
+    "Powers FuzzyAI and PyRIT scoring (anthropic provider) — API key (sk-ant-...), NOT your Claude.ai login. Stored SEPARATELY (AITEST_) so it never bills your Smith agent's model calls."
 _ask_key "AZURE_OPENAI_API_KEY" \
     "Powers FuzzyAI with azure provider"
+
+# ── Smith agent model auth: subscription (default) vs API key ─────────────────
+_set_env() {
+    python3 -c "
+import pathlib, sys
+p = pathlib.Path(sys.argv[1])
+lines = [l for l in p.read_text().splitlines() if not l.startswith(sys.argv[2] + '=')]
+lines.append(sys.argv[2] + '=' + sys.argv[3])
+p.write_text('\n'.join(lines) + '\n')
+" "$ENV_FILE" "$1" "$2"
+}
+echo ""
+echo "  Smith agent model auth — bill its model calls to your Claude SUBSCRIPTION (default) or an API key?"
+printf "  Use an API key for the Smith agent (bills credit) instead of your subscription? [y/N]: "
+IFS= read -r _use_api </dev/tty || true
+echo ""
+if [[ "$_use_api" =~ ^[Yy] ]]; then
+    _set_env "SMITH_USE_API_KEY" "yes"
+    _set_env "SMITH_SPAWN_USE_API_KEY" "1"
+    _ask_key "ANTHROPIC_API_KEY" \
+        "The Claude API key the Smith agent (interactive + headless) will bill (sk-ant-...)"
+    ok "Smith agent will use the API key (SMITH_USE_API_KEY=yes)."
+else
+    _set_env "SMITH_USE_API_KEY" "no"
+    ok "Smith agent will use your Claude subscription (no ANTHROPIC_API_KEY written to .env)."
+fi
 
 # ── Telegram bridge (optional) ────────────────────────────────────────────────
 echo ""

--- a/mcp_server/_app.py
+++ b/mcp_server/_app.py
@@ -169,7 +169,16 @@ async def _run(name: str, **kwargs) -> str:
         tool    = REGISTRY[name]
         args    = tool.build_args(**kwargs)
         mount   = os.environ.get("PENTEST_TARGET_PATH", os.getcwd()) if tool.needs_mount else None
-        env_vars = {k: os.environ[k] for k in tool.forward_env if k in os.environ} or None
+        # forward_env entries are "VAR" or "SRC:DST" — the SRC:DST form forwards SRC's value into the
+        # tool subprocess under the name DST. This lets us keep the anthropic AI-testing key in .env
+        # as AITEST_ANTHROPIC_API_KEY (so Claude Code never picks it up for model billing) while the
+        # red-team tools still receive it as the ANTHROPIC_API_KEY they expect. Server-side only.
+        env_vars = {}
+        for _spec in tool.forward_env:
+            _src, _, _dst = _spec.partition(":")
+            if _src in os.environ:
+                env_vars[_dst or _src] = os.environ[_src]
+        env_vars = env_vars or None
 
         try:
             stdout, stderr, _ = await run_container(
@@ -244,3 +253,12 @@ def _load_dotenv() -> None:
             val = val.strip().strip('"').strip("'")
             if key:
                 os.environ[key] = val
+
+    # Server-only: the AI-testing anthropic key lives in .env as AITEST_ANTHROPIC_API_KEY so an
+    # interactive Claude Code can't pick it up and bill the Smith agent's model calls to it. Inside the
+    # server we re-expose it as ANTHROPIC_API_KEY for the QA agent + red-team tool forwarding; the
+    # spawned Smith strips ANTHROPIC_API_KEY unless SMITH_SPAWN_USE_API_KEY=1, so it never bills the
+    # agent. A real ANTHROPIC_API_KEY (SMITH_USE_API_KEY=yes / legacy) takes precedence if present.
+    _aitest = os.environ.get("AITEST_ANTHROPIC_API_KEY")
+    if _aitest and not os.environ.get("ANTHROPIC_API_KEY"):
+        os.environ["ANTHROPIC_API_KEY"] = _aitest

--- a/tests/test_env_key_separation.py
+++ b/tests/test_env_key_separation.py
@@ -1,0 +1,31 @@
+"""API-key separation (PR #162): the AI-testing anthropic key (AITEST_ANTHROPIC_API_KEY) reaches the
+red-team tools AS ANTHROPIC_API_KEY, while no bare ANTHROPIC_API_KEY is exposed for an interactive
+`claude` to bill to your account."""
+import tools.fuzzyai
+import tools.kali_runner as kali
+
+
+def test_kali_forwards_aitest_as_anthropic():
+    # AITEST_ANTHROPIC_API_KEY is forwarded into the container AS ANTHROPIC_API_KEY (what pyrit reads)
+    assert kali._forward_ai_keys({"AITEST_ANTHROPIC_API_KEY": "sk-ant-test"}) == ["-e", "ANTHROPIC_API_KEY=sk-ant-test"]
+
+
+def test_kali_real_anthropic_overrides_aitest():
+    flags = kali._forward_ai_keys({"AITEST_ANTHROPIC_API_KEY": "aitest", "ANTHROPIC_API_KEY": "real"})
+    assert "ANTHROPIC_API_KEY=real" in flags and "ANTHROPIC_API_KEY=aitest" not in flags
+    assert sum(1 for f in flags if f.startswith("ANTHROPIC_API_KEY=")) == 1   # deduped by destination
+
+
+def test_kali_forwards_openai_and_azure_directly():
+    flags = kali._forward_ai_keys({"OPENAI_API_KEY": "o", "AZURE_OPENAI_API_KEY": "z"})
+    assert "OPENAI_API_KEY=o" in flags and "AZURE_OPENAI_API_KEY=z" in flags
+
+
+def test_kali_no_keys_gives_no_flags():
+    assert kali._forward_ai_keys({}) == []
+
+
+def test_fuzzyai_forwards_the_renamed_key_as_alias():
+    fe = tools.fuzzyai.TOOL.forward_env
+    assert "AITEST_ANTHROPIC_API_KEY:ANTHROPIC_API_KEY" in fe   # renamed key mapped into the tool
+    assert "OPENAI_API_KEY" in fe

--- a/tools/fuzzyai.py
+++ b/tools/fuzzyai.py
@@ -31,7 +31,11 @@ TOOL = Tool(
     default_timeout = 900,
     risk_level      = "intrusive",
     max_output      = 12_000,
-    forward_env     = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "AZURE_OPENAI_API_KEY"],
+    # AITEST_ANTHROPIC_API_KEY is the AI-testing anthropic key (kept out of Claude Code's ANTHROPIC_API_KEY
+    # so it can't bill the Smith agent); it's forwarded INTO the tool as ANTHROPIC_API_KEY. The bare
+    # ANTHROPIC_API_KEY is still forwarded for back-compat / SMITH_USE_API_KEY=yes.
+    forward_env     = ["OPENAI_API_KEY", "AITEST_ANTHROPIC_API_KEY:ANTHROPIC_API_KEY",
+                       "ANTHROPIC_API_KEY", "AZURE_OPENAI_API_KEY"],
     description     = (
         "AI/LLM security fuzzer (CyberArk FuzzyAI). "
         "Args: target (required — URL of the LLM endpoint), "

--- a/tools/kali_runner.py
+++ b/tools/kali_runner.py
@@ -72,13 +72,17 @@ async def ensure_running() -> tuple[bool, str]:
                 f"  docker build -t {KALI_IMAGE} ./tools/kali/"
             )
 
-        # Forward AI API keys from host environment into the container
-        _AI_ENV_KEYS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "AZURE_OPENAI_API_KEY")
-        env_flags: list[str] = []
-        for key in _AI_ENV_KEYS:
-            val = os.environ.get(key)
-            if val:
-                env_flags += ["-e", f"{key}={val}"]
+        # Forward AI API keys into the container. AITEST_ANTHROPIC_API_KEY (kept out of Claude Code's
+        # ANTHROPIC_API_KEY so it can't bill the Smith agent) is forwarded AS ANTHROPIC_API_KEY for
+        # pyrit/tools; a bare ANTHROPIC_API_KEY (SMITH_USE_API_KEY=yes / legacy) overrides it if both set.
+        _fwd: dict[str, str] = {}
+        for src, dst in (("OPENAI_API_KEY", "OPENAI_API_KEY"),
+                         ("AITEST_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
+                         ("ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
+                         ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_API_KEY")):
+            if os.environ.get(src):
+                _fwd[dst] = os.environ[src]
+        env_flags: list[str] = [x for dst, val in _fwd.items() for x in ("-e", f"{dst}={val}")]
 
         proc = await asyncio.create_subprocess_exec(
             docker_executable(), "run", "-d",

--- a/tools/kali_runner.py
+++ b/tools/kali_runner.py
@@ -54,6 +54,21 @@ async def container_running() -> bool:
 # Lifecycle
 # ---------------------------------------------------------------------------
 
+def _forward_ai_keys(environ) -> list[str]:
+    """docker ``-e`` flags for the AI API keys forwarded into the Kali container. AITEST_ANTHROPIC_API_KEY
+    (kept out of Claude Code's ANTHROPIC_API_KEY so it can't bill the Smith agent) is forwarded AS
+    ANTHROPIC_API_KEY for pyrit/tools; a bare ANTHROPIC_API_KEY (SMITH_USE_API_KEY=yes / legacy)
+    overrides it when both are set."""
+    fwd: dict[str, str] = {}
+    for src, dst in (("OPENAI_API_KEY", "OPENAI_API_KEY"),
+                     ("AITEST_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
+                     ("ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
+                     ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_API_KEY")):
+        if environ.get(src):
+            fwd[dst] = environ[src]
+    return [x for dst, val in fwd.items() for x in ("-e", f"{dst}={val}")]
+
+
 async def ensure_running() -> tuple[bool, str]:
     """
     Start the Kali container if it isn't running yet.
@@ -72,17 +87,8 @@ async def ensure_running() -> tuple[bool, str]:
                 f"  docker build -t {KALI_IMAGE} ./tools/kali/"
             )
 
-        # Forward AI API keys into the container. AITEST_ANTHROPIC_API_KEY (kept out of Claude Code's
-        # ANTHROPIC_API_KEY so it can't bill the Smith agent) is forwarded AS ANTHROPIC_API_KEY for
-        # pyrit/tools; a bare ANTHROPIC_API_KEY (SMITH_USE_API_KEY=yes / legacy) overrides it if both set.
-        _fwd: dict[str, str] = {}
-        for src, dst in (("OPENAI_API_KEY", "OPENAI_API_KEY"),
-                         ("AITEST_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
-                         ("ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"),
-                         ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_API_KEY")):
-            if os.environ.get(src):
-                _fwd[dst] = os.environ[src]
-        env_flags: list[str] = [x for dst, val in _fwd.items() for x in ("-e", f"{dst}={val}")]
+        # Forward AI API keys into the container (see _forward_ai_keys).
+        env_flags: list[str] = _forward_ai_keys(os.environ)
 
         proc = await asyncio.create_subprocess_exec(
             docker_executable(), "run", "-d",


### PR DESCRIPTION
## The bug
The installer stores an anthropic key in `.env` **for the red-team tools** (FuzzyAI/PyRIT) — the prompt even says *"NOT your Claude.ai login."* But it stored it under the standard name **`ANTHROPIC_API_KEY`**, which is exactly what an interactive `claude` uses for its *own* model auth. Result: your AI-testing key silently **billed the entire scan to API credit** instead of your Claude subscription. (`~/.claude.json` had the key *approved*, so Claude Code used it whenever it was in the env.)

## The fix — separate the two consumers
- `.env` now holds the AI-testing key as **`AITEST_ANTHROPIC_API_KEY`** (installer + `.env.example`).
- **`_load_dotenv`** re-exposes it as `ANTHROPIC_API_KEY` **inside the server only** (QA agent + tool forwarding). The spawned Smith still strips `ANTHROPIC_API_KEY` unless `SMITH_SPAWN_USE_API_KEY=1`.
- **`forward_env`** gains a `"SRC:DST"` form (`_app.py`); `fuzzyai` + `kali_runner` forward `AITEST_ANTHROPIC_API_KEY` into the tool **as** `ANTHROPIC_API_KEY`.
- **Net:** an interactive `claude` never sees a bare `ANTHROPIC_API_KEY` → **always the subscription**, while FuzzyAI/PyRIT keep working.

## New toggle
Installer asks **`SMITH_USE_API_KEY=yes|no`** (default **no** = subscription). `yes` writes a real `ANTHROPIC_API_KEY` + `SMITH_SPAWN_USE_API_KEY=1` for anyone who *wants* the agent on the API.

## Verified
`SRC:DST` maps `AITEST_`→`ANTHROPIC_API_KEY` for tools; `_load_dotenv` re-exposes it for the server; installer syntax OK; **191 existing tests pass**. Existing `.env` migrated locally (backup at `.env.pre-aitest`) — billing already stops for new terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)