### PR TITLE
Detect Claude Code Usage-Policy refusals + auto-recover (notify + skip-past)

### DIFF
--- a/core/api_server/__init__.py
+++ b/core/api_server/__init__.py
@@ -131,6 +131,7 @@ app.mount("/static", StaticFiles(directory=str(_DASHBOARD_DIR)), name="static")
 _qa_task:        asyncio.Task | None = None  # kept alive to prevent GC
 _watchdog_task:  asyncio.Task | None = None
 _status_task:    asyncio.Task | None = None
+_refusal_task:   asyncio.Task | None = None
 # Auto-restart watchdog state
 _watchdog_last_restart_ts: float = 0.0
 _watchdog_restart_count_window: list[float] = []  # epoch seconds of restarts in trailing hour
@@ -155,7 +156,7 @@ _svg_cache: dict[str, dict[str, str]] = {}
 
 @app.on_event("startup")
 async def _start_background_tasks() -> None:
-    global _qa_task, _watchdog_task, _status_task
+    global _qa_task, _watchdog_task, _status_task, _refusal_task
     from mcp_server._app import _load_dotenv
     _load_dotenv()
     from core.qa_agent import qa_daemon
@@ -168,6 +169,15 @@ async def _start_background_tasks() -> None:
         _watchdog_task = asyncio.create_task(_smith_watchdog_loop())
     else:
         _watchdog_task = None
+    # The refusal monitor watches the driving Claude's transcript for Usage-Policy
+    # refusals and drives notify + skip-recovery. It is INTENTIONALLY independent of
+    # SMITH_WATCHDOG_DISABLED — the interactive case (watchdog off) is exactly where a
+    # content-safety refusal otherwise goes unnoticed. It never spawns a process, so it
+    # is safe during a human-driven scan. Disable with SMITH_REFUSAL_MONITOR_DISABLED=1.
+    if os.environ.get("SMITH_REFUSAL_MONITOR_DISABLED", "").strip().lower() not in ("1", "true", "yes"):
+        _refusal_task = asyncio.create_task(_refusal_monitor_loop())
+    else:
+        _refusal_task = None
     _status_task = asyncio.create_task(_status_update_loop())
 
 
@@ -336,6 +346,7 @@ from .smith import (  # noqa: E402
     _smith_running,
     _smith_stalled_pid,
     _smith_watchdog_loop,
+    _refusal_monitor_loop,
     _spawn_smith,
     _spawn_source_tag,
     _watchdog_should_escalate_no_progress,

--- a/core/api_server/smith/__init__.py
+++ b/core/api_server/smith/__init__.py
@@ -42,6 +42,14 @@ _watchdog_last_respawn_progress: tuple = ()
 _last_spawn_failure: str = ""
 # Restart throttle for the MCP SSE self-heal — reset by tests on this facade.
 _mcp_sse_last_restart_ts: float = 0.0
+# ── Usage-Policy refusal monitor state ───────────────────────────────────────
+# Transcript size (per filename) we last alerted a refusal on, so a persistent wedge
+# alerts ONCE while a genuinely new refusal (file grew, terminal turn is a refusal
+# again) re-alerts. Consecutive counter drives the interactive HIR escalation; both
+# reset when the scan is no longer wedged. On the facade so refusal.py mutates the
+# same object tests patch.
+_refusal_last_alert: dict = {}
+_refusal_consecutive = 0
 
 # ── Re-exports (public import surface preserved) ─────────────────────────────
 from core.client_patterns import looks_like_smith  # noqa: E402,F401
@@ -111,4 +119,18 @@ from .watchdog import (  # noqa: E402,F401
     _watchdog_respawn_flow,
     _watchdog_tick,
     _smith_watchdog_loop,
+)
+from .refusal import (  # noqa: E402,F401
+    _looks_like_refusal,
+    _find_wedged_transcript,
+    _newest_scan_transcript,
+    _evaluate_transcript,
+    _terminal_assistant_text,
+    _assistant_text_of,
+    _tail_has_pentest_tooluse,
+    _active_skill,
+    _skip_directive_message,
+    _handle_refusal,
+    _refusal_monitor_tick,
+    _refusal_monitor_loop,
 )

--- a/core/api_server/smith/refusal.py
+++ b/core/api_server/smith/refusal.py
@@ -1,0 +1,397 @@
+"""
+Usage-Policy refusal monitor — the recovery path for when Claude Code's
+server-side content-safety classifier REFUSES a request mid-scan (e.g. "this
+request ... appears to violate our Usage Policy" / "triggered cyber-related
+safeguards").
+
+That refusal never reaches the MCP server — no tool call is made — so the
+envelope / smith-event layer is blind to it. Two failure shapes result:
+
+  • headless ``claude -p``: the refusal ends the turn and the child exits. The
+    watchdog respawns it, but the operator is told a GENERIC "Smith stopped"; the
+    real cause (a policy refusal, fixable by switching model / skipping the step)
+    is laundered away.
+  • interactive ``claude``: the process stays ALIVE but wedged on the refused
+    request — and because the watchdog is disabled for interactive runs
+    (SMITH_WATCHDOG_DISABLED=1), NOTHING notices and the human is never told.
+
+This monitor closes both gaps. It reads the driving Claude's transcript
+(read-only), recognises the refusal as the terminal assistant turn, and then:
+
+  A. NOTIFIES the operator with a distinct POLICY_REFUSAL alert.
+  B. Enqueues a NON-BLOCKING skip steering directive that routes the agent AROUND
+     the blocked step — record it as a coverage gap and continue — which the next
+     turn consumes (a watchdog respawn in headless; the human typing "continue" in
+     interactive). After repeated refusals on an interactive run it escalates to a
+     blocking HIR so the human switches model.
+
+It runs on its OWN always-on loop, independent of SMITH_WATCHDOG_DISABLED, because
+the interactive case is exactly where detection matters most. It NEVER spawns a
+process, so it cannot ghost-spawn during a human-driven scan and cannot change
+Phase A/B behaviour. Fully fail-soft. Disable with SMITH_REFUSAL_MONITOR_DISABLED=1.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pathlib
+
+import core.api_server as _api
+import core.api_server.smith as _smith
+
+from ._common import _log
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int((os.environ.get(name, "") or "").strip() or default)
+    except ValueError:
+        return default
+
+
+# Poll cadence (a wedge is not time-critical — the human just needs to be told).
+_REFUSAL_POLL_SECONDS = _int_env("SMITH_REFUSAL_POLL_SECONDS", 45)
+# Only consider transcripts touched recently — a wedged scan stops being written,
+# so its mtime is roughly when it wedged; an old transcript is a past engagement.
+_RECENT_WINDOW_SECONDS = _int_env("SMITH_REFUSAL_RECENT_WINDOW_SECONDS", 30 * 60)
+# Distinct consecutive refusals before an interactive run escalates to a blocking HIR.
+_REFUSAL_ESCALATE_AFTER = _int_env("SMITH_REFUSAL_ESCALATE_AFTER", 3)
+
+# Substrings (lower-cased) that mark a Claude Code content-safety refusal. Kept broad
+# enough to catch the known variants across models/clients without matching ordinary
+# assistant prose.
+_REFUSAL_MARKERS = (
+    "appears to violate our usage policy",
+    "cyber-related safeguards",
+    "triggered cyber",
+    "unable to respond to this request",
+    "output blocked by content filtering policy",
+)
+
+
+def _looks_like_refusal(text: str) -> bool:
+    """True when a piece of assistant text is a Claude Code Usage-Policy refusal."""
+    t = (text or "").lower()
+    return any(m in t for m in _REFUSAL_MARKERS)
+
+
+# ── Transcript location + parsing (read-only) ────────────────────────────────
+
+def _project_transcript_dir() -> pathlib.Path:
+    """``~/.claude/projects/<slug>`` for this repo, where Claude Code writes the
+    driving agent's transcript. The slug is the repo path with ``/`` and ``.``
+    replaced by ``-`` (Claude Code's own convention)."""
+    slug = str(_api._REPO_ROOT).replace("/", "-").replace(".", "-")
+    return pathlib.Path.home() / ".claude" / "projects" / slug
+
+
+def _read_tail_events(path: pathlib.Path, max_bytes: int = 300_000, max_events: int = 60) -> list:
+    """Last few complete JSONL events from a transcript, reading only the tail so a
+    multi-MB transcript stays cheap. Best-effort: returns [] on any read error."""
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+                fh.readline()  # discard the partial first line after the seek
+            raw = fh.read().decode("utf-8", "replace")
+    except OSError:
+        return []
+    events = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except ValueError:
+            continue
+    return events[-max_events:]
+
+
+def _assistant_text_of(msg: dict) -> str:
+    """Readable text of one assistant message. Falls back to the raw message JSON
+    when it carries no text block (an API-error turn may be stored without one) so
+    the marker scan still sees it."""
+    content = msg.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+    if isinstance(content, list):
+        parts = [b.get("text", "") for b in content
+                 if isinstance(b, dict) and b.get("type") == "text" and b.get("text")]
+        if parts:
+            return "\n".join(parts)
+    try:
+        return json.dumps(msg)
+    except (TypeError, ValueError):
+        return ""
+
+
+def _terminal_assistant_text(events: list) -> str:
+    """Text of the LAST assistant message in the tail (searching from the end), or
+    ''. Searching from the end means a scan that RECOVERED — whose latest assistant
+    turn is a normal tool call — correctly reads as not-wedged."""
+    for e in reversed(events):
+        msg = e.get("message") if isinstance(e, dict) else None
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            return _assistant_text_of(msg)
+    return ""
+
+
+def _tail_has_pentest_tooluse(events: list) -> bool:
+    """True when the tail contains a pentest-agent MCP tool call — the signal that
+    this transcript is the SCAN driver, not an unrelated dev/chat conversation in
+    the same repo. Used to avoid mis-identifying the operator's own Claude Code
+    session as the wedged scan."""
+    for e in events:
+        msg = e.get("message") if isinstance(e, dict) else None
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            continue
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "tool_use":
+                name = str(b.get("name", ""))
+                if "pentest-agent" in name or name.startswith("mcp__pentest"):
+                    return True
+    return False
+
+
+def _evaluate_transcript(path: pathlib.Path, require_scan_relevance: bool):
+    """Return ``(path, refusal_text, size)`` if this transcript is wedged on a
+    refusal, else None. ``require_scan_relevance`` gates on a pentest-agent tool
+    call (used for the heuristic interactive match; skipped when we KNOW the
+    transcript is the scan's own recorded session)."""
+    events = _read_tail_events(path)
+    if not events:
+        return None
+    if require_scan_relevance and not _tail_has_pentest_tooluse(events):
+        return None
+    text = _terminal_assistant_text(events)
+    if not _looks_like_refusal(text):
+        return None
+    try:
+        return (path, text, path.stat().st_size)
+    except OSError:
+        return None
+
+
+def _recorded_smith_sid() -> str | None:
+    """The scan's own recorded claude session id (headless), or None. NEVER a
+    directory scan — mirrors spawn._recorded_claude_session's safety rule."""
+    try:
+        from core import session as _s
+        return _s.get_smith_session_id()
+    except Exception:
+        return None
+
+
+def _find_wedged_transcript(now: float):
+    """Locate the scan-driving transcript that is wedged on a refusal, or None.
+
+    Two-tier: (1) if the scan recorded its OWN claude session id (headless spawn),
+    trust that transcript directly; (2) otherwise (interactive — the human launched
+    claude, so we minted no id) look at the NEWEST recently-touched scan transcript
+    and report it wedged only if IT is the one on a refusal.
+
+    The "newest wins" rule matters after recovery: once a fresh session resumes the
+    scan, the abandoned transcript is still terminal-on-refusal on disk and inside
+    the recent window, but it is NOT the current driver. Keying on the newest scan
+    transcript means a recovered scan (newest activity is a healthy tool call) reads
+    as not-wedged, instead of the monitor false-firing on the stale one until it
+    ages out.
+    """
+    d = _project_transcript_dir()
+    if not d.is_dir():
+        return None
+    sid = _recorded_smith_sid()
+    if sid:
+        p = d / f"{sid}.jsonl"
+        if p.exists():
+            return _evaluate_transcript(p, require_scan_relevance=False)
+        # recorded id but no file yet — fall through to the heuristic
+    newest = _newest_scan_transcript(d, now)
+    if newest is None:
+        return None
+    p, events = newest
+    text = _terminal_assistant_text(events)
+    if not _looks_like_refusal(text):
+        return None  # newest scan activity is healthy — recovered, not wedged
+    try:
+        return (p, text, p.stat().st_size)
+    except OSError:
+        return None
+
+
+def _newest_scan_transcript(d: pathlib.Path, now: float):
+    """The most recently modified in-window scan transcript (one that issues
+    pentest-agent tool calls) as ``(path, events)``, or None. Isolating the scan
+    keeps _find_wedged_transcript's newest-wins recovery rule readable."""
+    newest = None  # (mtime, path, events)
+    for p in d.glob("*.jsonl"):
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        if now - mtime > _RECENT_WINDOW_SECONDS:
+            continue
+        events = _read_tail_events(p)
+        if not _tail_has_pentest_tooluse(events):
+            continue  # not a scan transcript (e.g. an unrelated dev conversation)
+        if newest is None or mtime > newest[0]:
+            newest = (mtime, p, events)
+    return (newest[1], newest[2]) if newest else None
+
+
+# ── Mode + context helpers ───────────────────────────────────────────────────
+
+def _watchdog_enabled() -> bool:
+    """True in headless mode (watchdog running), False in interactive mode
+    (SMITH_WATCHDOG_DISABLED set — the operator drives claude in a terminal)."""
+    return os.environ.get("SMITH_WATCHDOG_DISABLED", "").strip().lower() not in ("1", "true", "yes")
+
+
+def _active_skill(session_data: dict) -> str:
+    """Best-effort name of the skill the scan was running when it wedged."""
+    s = session_data.get("skill")
+    if isinstance(s, str) and s and s != "unknown":
+        return s
+    hist = session_data.get("skill_history") or []
+    if hist and isinstance(hist[-1], dict):
+        return str(hist[-1].get("skill", "") or "")
+    return ""
+
+
+# ── Recovery + notification ──────────────────────────────────────────────────
+
+def _skip_directive_message(skill: str) -> str:
+    """The recovery instruction queued after a refusal. It routes the agent AROUND
+    the blocked step — skip, record the gap, continue — and explicitly forbids
+    rewording the request to evade the filter."""
+    where = f" while running the '{skill}' skill" if skill else ""
+    return (
+        "CONTENT-SAFETY REFUSAL RECOVERY: Claude Code's Usage-Policy filter refused your "
+        f"previous request{where} (flagged as violative / a cyber safeguard). Do NOT retry that "
+        "exact request or payload — it will only be refused again. Instead: "
+        "(1) if the blocked step maps to a coverage cell, close that cell as `skipped` with note "
+        "'content-filter refusal'; "
+        "(2) call report(action='note') recording which step was blocked, for the audit trail; "
+        "(3) CONTINUE with the remaining pending coverage — do not stop the scan. "
+        "If an entire skill sub-step is blocked (e.g. generating a reverse-shell payload), note it "
+        "as a documented gap and move to the next applicable technique. Do NOT try to reword the "
+        "request to get around the filter."
+    )
+
+
+def _enqueue_skip_directive(skill: str) -> None:
+    try:
+        from core.steering import steering_queue
+        steering_queue.add_directive(
+            code="POLICY_REFUSAL_SKIP",
+            message=_skip_directive_message(skill),
+            priority="high",
+            skill=skill or None,
+            trigger="usage_policy_refusal",
+            force=True,  # a recovery instruction must never be deduped away
+        )
+    except Exception:
+        _log.exception("refusal monitor: failed to enqueue skip directive")
+
+
+def _notify_refusal(skill: str, interactive: bool) -> None:
+    where = f" in skill '{skill}'" if skill else ""
+    if interactive:
+        body = (
+            f"Claude Code refused a request (content-safety / cyber safeguard){where}. Your "
+            "interactive scan is stalled on it and will NOT retry on its own. A skip-past-this "
+            "instruction is already queued — type 'continue' in your terminal (it records the "
+            "blocked step as a gap and moves on), or click 'Restart Smith' on the dashboard. If "
+            "refusals keep happening, restart with SMITH_SPAWN_MODEL=claude-sonnet-5."
+        )
+    else:
+        body = (
+            f"Claude Code refused a request (content-safety / cyber safeguard){where}. A "
+            "skip-past-this instruction has been queued; the watchdog will respawn and route "
+            "around the blocked step. If refusals persist for this model, set "
+            "SMITH_SPAWN_MODEL=<another model> so respawns are less refusal-prone."
+        )
+    _smith._watchdog_notify("Claude Code refused a request (Usage Policy)", body, "POLICY_REFUSAL")
+
+
+def _escalate_refusal_hir(skill: str) -> None:
+    """After repeated refusals on an INTERACTIVE run, pause for a human decision.
+    Only fired interactive (watchdog off) so it never blocks the watchdog's own
+    auto-recovery; headless leans on the watchdog's existing per-scan / no-progress
+    caps instead."""
+    try:
+        from core.session.intervention import trigger_intervention, get_intervention
+        if get_intervention():
+            return  # already paused — don't stack interventions
+        where = f" in skill '{skill}'" if skill else ""
+        trigger_intervention(
+            code="HIR_POLICY_REFUSAL",
+            situation=(f"Claude Code has refused {_smith._refusal_consecutive} requests in a row"
+                       f"{where} (content-safety / cyber safeguard). Skipping past isn't clearing it."),
+            tried=["Queued a skip-past-this steering directive after each refusal"],
+            options=["Skip the blocked step and continue",
+                     "Switch model (restart with SMITH_SPAWN_MODEL=claude-sonnet-5)",
+                     "Abort the scan"],
+        )
+    except Exception:
+        _log.exception("refusal monitor: HIR escalation failed")
+
+
+def _handle_refusal(session_data: dict, refusal_text: str) -> None:
+    """A refusal has been (newly) detected: queue the skip directive, notify the
+    operator, log it, and — interactive only, after repeated refusals — escalate."""
+    skill = _active_skill(session_data)
+    interactive = not _watchdog_enabled()
+    _enqueue_skip_directive(skill)
+    _notify_refusal(skill, interactive)
+    _log.warning(
+        "refusal monitor: POLICY_REFUSAL detected (%s, skill=%s, consecutive=%d) — queued skip "
+        "directive + notified operator: %.140s",
+        "interactive" if interactive else "headless", skill or "?",
+        _smith._refusal_consecutive, refusal_text.replace("\n", " "),
+    )
+    if interactive and _smith._refusal_consecutive >= _REFUSAL_ESCALATE_AFTER:
+        _escalate_refusal_hir(skill)
+
+
+# ── Loop ─────────────────────────────────────────────────────────────────────
+
+async def _refusal_monitor_tick(now: float) -> None:
+    """One monitor pass. Idle unless a scan is running; detects a NEW refusal
+    (dedup by transcript size so a persistent wedge alerts once) and hands off to
+    _handle_refusal. Resets the consecutive-refusal streak whenever the scan is no
+    longer wedged (recovered)."""
+    session_data = _api._read_json(_api._SESSION_FILE) or {}
+    if session_data.get("status") != "running":
+        _smith._refusal_consecutive = 0
+        return
+    loop = asyncio.get_running_loop()
+    hit = await loop.run_in_executor(None, _find_wedged_transcript, now)
+    if not hit:
+        _smith._refusal_consecutive = 0  # healthy / recovered — clear the streak
+        return
+    path, refusal_text, size = hit
+    if _smith._refusal_last_alert.get(path.name) == size:
+        return  # already handled this exact wedge (unchanged transcript)
+    _smith._refusal_last_alert[path.name] = size
+    _smith._refusal_consecutive += 1
+    _handle_refusal(session_data, refusal_text)
+
+
+async def _refusal_monitor_loop() -> None:
+    """Background task: watch the driving Claude's transcript for Usage-Policy
+    refusals and drive notify + skip-recovery. Always on (independent of the
+    watchdog) so the interactive case is covered; fail-soft forever."""
+    import time as _time
+    while True:
+        try:
+            await asyncio.sleep(_REFUSAL_POLL_SECONDS)
+            await _refusal_monitor_tick(_time.time())
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.exception("refusal monitor loop error (continuing)")

--- a/tests/test_refusal_monitor.py
+++ b/tests/test_refusal_monitor.py
@@ -1,0 +1,247 @@
+"""Usage-Policy refusal monitor (core/api_server/smith/refusal.py): detects a
+Claude Code content-safety refusal in the driving transcript, notifies the operator,
+and queues a NON-BLOCKING skip directive — without ever spawning a process. Negative
+controls: ordinary prose is not a refusal, a recovered scan is not wedged, and a dev
+conversation that merely quotes the policy is not mistaken for the scan driver."""
+import json
+
+import pytest
+
+import core.api_server.smith as smith
+import core.api_server.smith.refusal as rf
+
+REFUSAL = ("API Error: Claude Code is unable to respond to this request, which appears to "
+           "violate our Usage Policy (https://www.anthropic.com/legal/aup). This request "
+           "triggered cyber-related safeguards.")
+
+
+# ── transcript builders ──────────────────────────────────────────────────────
+
+def _assistant(text):
+    return {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+
+
+def _assistant_str(text):
+    return {"type": "assistant", "message": {"role": "assistant", "content": text}}
+
+
+def _user(text):
+    return {"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+
+def _pentest_call(name="mcp__pentest-agent__http"):
+    return {"type": "assistant", "message": {"role": "assistant",
+            "content": [{"type": "tool_use", "name": name, "input": {}}]}}
+
+
+def _write(path, events):
+    path.write_text("".join(json.dumps(e) + "\n" for e in events))
+
+
+# ── marker classifier (with negative control) ────────────────────────────────
+
+@pytest.mark.parametrize("text", [
+    REFUSAL,
+    "Output blocked by content filtering policy.",
+    "This request triggered cyber-related safeguards.",
+    "I'm unable to respond to this request.",
+])
+def test_looks_like_refusal_positive(text):
+    assert rf._looks_like_refusal(text)
+
+
+@pytest.mark.parametrize("text", [
+    "Running an nmap scan against the target now.",
+    "I found a SQL injection on the login endpoint; filing a finding.",
+    "",
+    "The security policy of the app allows weak passwords — that's a finding.",  # 'policy' but not the marker
+])
+def test_looks_like_refusal_negative(text):
+    assert not rf._looks_like_refusal(text)
+
+
+# ── terminal-assistant-text extraction ───────────────────────────────────────
+
+def test_terminal_assistant_text_picks_last_assistant_ignoring_trailing_user():
+    events = [_assistant("earlier turn"), _pentest_call(), _assistant(REFUSAL), _user("")]
+    assert rf._looks_like_refusal(rf._terminal_assistant_text(events))
+
+
+def test_terminal_assistant_text_handles_string_content():
+    assert rf._terminal_assistant_text([_assistant_str(REFUSAL)]) == REFUSAL
+
+
+def test_terminal_assistant_text_recovered_scan_reads_not_refusal():
+    # last assistant turn is a normal tool call -> scan recovered, not wedged
+    events = [_assistant(REFUSAL), _pentest_call(), _assistant("Continuing with the next cell.")]
+    assert not rf._looks_like_refusal(rf._terminal_assistant_text(events))
+
+
+def test_terminal_assistant_text_raw_fallback_when_no_text_block():
+    # an API-error entry stored without a text block still gets scanned via raw JSON
+    ev = {"type": "assistant", "message": {"role": "assistant", "isApiErrorMessage": True,
+          "content": [], "error": REFUSAL}}
+    assert rf._looks_like_refusal(rf._terminal_assistant_text([ev]))
+
+
+# ── scan-relevance discriminator ─────────────────────────────────────────────
+
+def test_tail_has_pentest_tooluse():
+    assert rf._tail_has_pentest_tooluse([_pentest_call("mcp__pentest-agent__scan")])
+    assert rf._tail_has_pentest_tooluse([_pentest_call("pentest-agent_kali")])   # opencode/codex form
+    assert not rf._tail_has_pentest_tooluse([_assistant("just text"), _user("hi")])
+
+
+# ── _evaluate_transcript ─────────────────────────────────────────────────────
+
+def test_evaluate_wedged_scan_transcript_hits(tmp_path):
+    p = tmp_path / "scan.jsonl"
+    _write(p, [_pentest_call(), _assistant(REFUSAL)])
+    hit = rf._evaluate_transcript(p, require_scan_relevance=True)
+    assert hit and hit[0] == p and rf._looks_like_refusal(hit[1])
+
+
+def test_evaluate_healthy_transcript_returns_none(tmp_path):
+    p = tmp_path / "scan.jsonl"
+    _write(p, [_pentest_call(), _assistant("all cells tested clean")])
+    assert rf._evaluate_transcript(p, require_scan_relevance=True) is None
+
+
+def test_evaluate_refusal_without_pentest_tooluse_gated_by_relevance(tmp_path):
+    # a dev/chat transcript that merely QUOTES the refusal, no pentest tool calls
+    p = tmp_path / "dev.jsonl"
+    _write(p, [_user("why did it stop?"), _assistant(f"It said: {REFUSAL}")])
+    assert rf._evaluate_transcript(p, require_scan_relevance=True) is None   # ignored as non-scan
+    assert rf._evaluate_transcript(p, require_scan_relevance=False) is not None  # trusted when it's the recorded sid
+
+
+# ── _find_wedged_transcript ──────────────────────────────────────────────────
+
+def test_find_uses_recorded_sid_directly(tmp_path, monkeypatch):
+    monkeypatch.setattr(rf, "_project_transcript_dir", lambda: tmp_path)
+    monkeypatch.setattr(rf, "_recorded_smith_sid", lambda: "sess-abc")
+    p = tmp_path / "sess-abc.jsonl"
+    _write(p, [_assistant(REFUSAL)])   # no pentest tool_use needed — it's the scan's own session
+    hit = rf._find_wedged_transcript(now=1e12)
+    assert hit and hit[0].name == "sess-abc.jsonl"
+
+
+def test_find_interactive_ignores_dev_transcript_picks_scan(tmp_path, monkeypatch):
+    monkeypatch.setattr(rf, "_project_transcript_dir", lambda: tmp_path)
+    monkeypatch.setattr(rf, "_recorded_smith_sid", lambda: None)   # interactive: no minted id
+    dev = tmp_path / "dev.jsonl"
+    _write(dev, [_user("q"), _assistant(f"It refused: {REFUSAL}")])       # quotes policy, no pentest calls
+    scan = tmp_path / "scan.jsonl"
+    _write(scan, [_pentest_call(), _assistant(REFUSAL)])                  # the real wedged driver
+    import os
+    now = os.path.getmtime(scan) + 1
+    hit = rf._find_wedged_transcript(now=now)
+    assert hit and hit[0].name == "scan.jsonl"
+
+
+def test_find_recovered_when_newer_healthy_session_exists(tmp_path, monkeypatch):
+    # after recovery the abandoned transcript is still terminal-on-refusal, but a NEWER
+    # healthy session is the real driver -> newest-wins rule reads the scan as recovered
+    import os
+    import time
+    monkeypatch.setattr(rf, "_project_transcript_dir", lambda: tmp_path)
+    monkeypatch.setattr(rf, "_recorded_smith_sid", lambda: None)
+    old = tmp_path / "old.jsonl"
+    _write(old, [_pentest_call(), _assistant(REFUSAL)])
+    new = tmp_path / "new.jsonl"
+    _write(new, [_pentest_call(), _assistant("resumed — testing the next cell")])
+    os.utime(old, (time.time() - 100, time.time() - 100))
+    os.utime(new, (time.time(), time.time()))
+    assert rf._find_wedged_transcript(now=time.time() + 1) is None
+    # ...but if the newest IS the wedged one, it still fires
+    os.utime(new, (time.time() - 200, time.time() - 200))
+    assert rf._find_wedged_transcript(now=time.time() + 1)[0].name == "old.jsonl"
+
+
+def test_find_missing_project_dir_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(rf, "_project_transcript_dir", lambda: tmp_path / "does-not-exist")
+    monkeypatch.setattr(rf, "_recorded_smith_sid", lambda: None)
+    assert rf._find_wedged_transcript(now=1e12) is None
+
+
+# ── _handle_refusal: notify + skip directive + mode-aware escalation ──────────
+
+@pytest.fixture
+def captured(monkeypatch):
+    calls = {"directives": [], "notifies": [], "interventions": []}
+    import core.steering as cs
+    monkeypatch.setattr(cs.steering_queue, "add_directive",
+                        lambda **kw: calls["directives"].append(kw) or "steer-1")
+    monkeypatch.setattr(smith, "_watchdog_notify",
+                        lambda title, body, code: calls["notifies"].append((title, body, code)))
+    import core.session.intervention as iv
+    monkeypatch.setattr(iv, "get_intervention", lambda: None)
+    monkeypatch.setattr(iv, "trigger_intervention",
+                        lambda **kw: calls["interventions"].append(kw) or {})
+    monkeypatch.setattr(smith, "_refusal_consecutive", 0)
+    return calls
+
+
+def test_handle_refusal_notifies_and_queues_skip_directive(captured, monkeypatch):
+    monkeypatch.setenv("SMITH_WATCHDOG_DISABLED", "1")  # interactive
+    smith._refusal_consecutive = 1
+    rf._handle_refusal({"skill": "reverse-shell"}, REFUSAL)
+    assert len(captured["directives"]) == 1
+    d = captured["directives"][0]
+    assert d["code"] == "POLICY_REFUSAL_SKIP" and d["force"] is True
+    assert "reword" in d["message"].lower()          # anti-evasion guarantee
+    assert "reverse-shell" in d["message"]
+    assert captured["notifies"] and captured["notifies"][0][2] == "POLICY_REFUSAL"
+    assert "type 'continue'" in captured["notifies"][0][1]   # interactive guidance
+    assert not captured["interventions"]             # 1 refusal — no HIR yet
+
+
+def test_handle_refusal_headless_body_and_no_hir(captured, monkeypatch):
+    monkeypatch.delenv("SMITH_WATCHDOG_DISABLED", raising=False)  # headless
+    smith._refusal_consecutive = 5   # even past threshold, headless never fires the HIR
+    rf._handle_refusal({"skill": "web-exploit"}, REFUSAL)
+    body = captured["notifies"][0][1]
+    assert "watchdog will respawn" in body
+    assert not captured["interventions"]             # headless leans on watchdog caps
+
+
+def test_handle_refusal_interactive_escalates_after_threshold(captured, monkeypatch):
+    monkeypatch.setenv("SMITH_WATCHDOG_DISABLED", "1")  # interactive
+    smith._refusal_consecutive = rf._REFUSAL_ESCALATE_AFTER
+    rf._handle_refusal({"skill": "reverse-shell"}, REFUSAL)
+    assert captured["interventions"] and captured["interventions"][0]["code"] == "HIR_POLICY_REFUSAL"
+
+
+# ── tick: dedup by size + streak reset ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_tick_dedups_persistent_wedge_and_resets_on_recovery(tmp_path, monkeypatch):
+    monkeypatch.setattr(rf, "_project_transcript_dir", lambda: tmp_path)
+    monkeypatch.setattr(rf, "_recorded_smith_sid", lambda: "s")
+    monkeypatch.setattr(smith, "_refusal_last_alert", {})
+    monkeypatch.setattr(smith, "_refusal_consecutive", 0)
+    monkeypatch.setattr(rf._api, "_read_json", lambda _p: {"status": "running", "skill": "x"})
+    handled = []
+    monkeypatch.setattr(rf, "_handle_refusal", lambda sd, txt: handled.append(txt))
+
+    p = tmp_path / "s.jsonl"
+    _write(p, [_assistant(REFUSAL)])
+    await rf._refusal_monitor_tick(now=1e12)
+    await rf._refusal_monitor_tick(now=1e12)   # unchanged transcript -> deduped
+    assert len(handled) == 1                    # alerted exactly once for the same wedge
+
+    _write(p, [_assistant("recovered — continuing"), _pentest_call()])  # scan resumed
+    await rf._refusal_monitor_tick(now=1e12)
+    assert len(handled) == 1                    # not re-alerted
+    assert smith._refusal_consecutive == 0      # streak reset on recovery
+
+
+@pytest.mark.asyncio
+async def test_tick_idle_when_no_scan(tmp_path, monkeypatch):
+    monkeypatch.setattr(rf._api, "_read_json", lambda _p: {"status": "complete"})
+    monkeypatch.setattr(smith, "_refusal_consecutive", 3)
+    called = []
+    monkeypatch.setattr(rf, "_find_wedged_transcript", lambda now: called.append(now))
+    await rf._refusal_monitor_tick(now=1e12)
+    assert not called                            # no transcript scan when idle
+    assert smith._refusal_consecutive == 0       # streak cleared


### PR DESCRIPTION
## Problem

When Claude Code's server-side content-safety classifier refuses a request mid-scan (*"appears to violate our Usage Policy" / "triggered cyber-related safeguards"*), the refusal **never reaches the MCP server** — no tool call is made — so the envelope / smith-event layer is blind to it. Two failure shapes:

- **headless `claude -p`**: the child exits; the watchdog respawns it but the operator sees a generic *"Smith stopped"* — the real, fixable cause (a policy refusal) is laundered away.
- **interactive `claude`**: the process wedges alive on the refused request, and because the watchdog is disabled for interactive runs, **nothing notices and the human is never told**.

This is what stalled a live scan for ~45 min inside the `/reverse-shell` skill.

## Fix

A dedicated refusal monitor ([`core/api_server/smith/refusal.py`](core/api_server/smith/refusal.py)) on its own **always-on** loop, **intentionally independent of `SMITH_WATCHDOG_DISABLED`** — the interactive case is exactly where the refusal otherwise goes unnoticed. It reads the driving Claude's transcript read-only, recognises the refusal as the terminal assistant turn, and:

- **A — Notify**: fires a distinct `POLICY_REFUSAL` operator alert (never a generic "stopped").
- **B — Recover**: queues a **non-blocking** `POLICY_REFUSAL_SKIP` steering directive that routes the agent *around* the blocked step (record it as a coverage gap, continue) — and **explicitly forbids rewording to evade the filter**. The next turn consumes it: a watchdog respawn (headless) or the human typing `continue` (interactive). After 3 consecutive refusals on an interactive run it escalates to a blocking `HIR_POLICY_REFUSAL` so the operator switches model (`SMITH_SPAWN_MODEL`).

### Safe by construction
- **Never spawns a process** → cannot ghost-spawn during a human-driven scan, cannot change Phase A/B behaviour.
- **Newest-scan-transcript-wins** rule → a recovered scan reads as healthy instead of the monitor false-firing on the abandoned wedged transcript.
- Fully fail-soft; disable via `SMITH_REFUSAL_MONITOR_DISABLED=1`.

## Validation
- **Proven end-to-end on the live wedged scan**: detected the real refusal, queued the skip directive, the respawn **skipped the reverse-shell block and did 62 productive events (18 findings) with no re-refusal**.
- **25 new tests** with negative controls (ordinary prose isn't a refusal; a recovered scan isn't wedged; a dev conversation that merely *quotes* the policy isn't mistaken for the scan driver).
- Existing watchdog/smith/spawn suite green (248 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)