### PR TITLE
Add AI-generated-content warning after the dashboard URL

### DIFF
--- a/mcp_server/report_tools/diagrams.py
+++ b/mcp_server/report_tools/diagrams.py
@@ -266,7 +266,8 @@ async def _do_dashboard(data):
         except Exception:
             pass
         log.tool_result("dashboard", url)
-        return f"Dashboard running — open {url}"
+        return (f"Dashboard running — open {url}\n"
+                "⚠ AI-generated content may be incorrect. It should always be validated by a person.")
     except Exception as exc:
         # Defense against S5145: don't echo the raw exception message into
         # the audit log or the return string — its content could come from

--- a/mcp_server/session_tools/start.py
+++ b/mcp_server/session_tools/start.py
@@ -53,6 +53,7 @@ def _start_response(cfg: dict, classification: dict, target: str, scan_mode: str
         "  │  dashboard key — it is REQUIRED to load data, and a new scan mints a",
         "  │  new one. Show this link to the operator before you go silent.",
         "  └─────────────────────────────────────────────────────────────────────",
+        "  ⚠ AI-generated content may be incorrect. It should always be validated by a person.",
         "",
     ]
     if scan_mode == "benchmark":
@@ -214,7 +215,8 @@ def _do_start(opts):
         print(
             f"\n[agent-smith] Dashboard → http://localhost:7777/#k={_tok}\n"
             "[agent-smith]   open in a browser; the #k=… token is required to load "
-            "scan data (a new scan mints a new token).\n",
+            "scan data (a new scan mints a new token).\n"
+            "[agent-smith]   ⚠ AI-generated content may be incorrect. It should always be validated by a person.\n",
             file=_sys.stderr, flush=True,
         )
     except Exception:

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -515,9 +515,11 @@ async def test_dashboard_serves_canonical_on_malformed_port_input():
     with patch("core.api_server.serve", side_effect=_capture_serve):
         result = await _do_dashboard({"port": "5000\nINJECTED"})
     assert captured_args == [_DASHBOARD_CANONICAL_PORT]
-    # The injected payload must NOT appear anywhere in what we return
+    # The malformed port value must NOT be echoed anywhere in what we return. (The result now
+    # carries a trailing AI-content warning on its own line, so we assert the injected payload
+    # and the bad port fragment aren't reflected, rather than blanket-forbidding newlines.)
     assert "INJECTED" not in result
-    assert "\n" not in result
+    assert "5000" not in result
 
 
 # ── chain mermaid label escaping ─────────────────────────────────────────────


### PR DESCRIPTION
Small addition: print **"AI-generated content may be incorrect. It should always be validated by a person."** after the dashboard link, so an operator opening the dashboard is reminded to validate.

Added in all three places the dashboard URL surfaces (`mcp_server/session_tools/start.py` + `mcp_server/report_tools/diagrams.py`):
- the scan-start banner box,
- the stderr operator line, and
- the `report(action='dashboard')` result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)