### PR TITLE
Dashboard: AI-generated-content disclaimer under Clear All

### DIFF
--- a/dashboard/css/dashboard.css
+++ b/dashboard/css/dashboard.css
@@ -81,6 +81,12 @@
     }
     .clear-btn:hover  { color: #ff4d4f; border-color: #ff4d4f; }
     .tunnel-btn:hover { color: var(--green); border-color: var(--green); }
+    .ai-disclaimer {
+      margin: 0.55rem 0 0; padding-top: 0.5rem;
+      border-top: 1px solid var(--border-subtle, var(--border));
+      color: var(--text-dim); font-size: 0.62rem; line-height: 1.4;
+      text-align: center; letter-spacing: 0.01em;
+    }
 
     #status {
       font-size: 0.76rem; color: var(--text-dim); margin-bottom: 0.75rem;
@@ -1129,6 +1135,7 @@
       .rail-footer .clear-btn { font-size: 0; padding: 0.45rem 0; }
       .rail-footer .tunnel-btn::before { content: "\26A1"; font-size: 0.95rem; }  /* ⚡ */
       .rail-footer .clear-btn::before  { content: "\2326"; font-size: 0.95rem; }  /* ⌦ */
+      .rail-footer .ai-disclaimer { display: none; }  /* too much text for the collapsed icon rail */
     }
     @media (max-width: 720px) {
       .app-shell { grid-template-columns: 1fr; }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -18,7 +18,7 @@
   <script src="/static/js/vendor/mermaid.min.js"></script>
   <script src="/static/js/vendor/marked.min.js"></script>
   <script src="/static/js/vendor/cytoscape.min.js"></script>
-  <link rel="stylesheet" href="/static/css/dashboard.css?v=11">
+  <link rel="stylesheet" href="/static/css/dashboard.css?v=12">
 </head>
 <body>
 <div class="app-shell">
@@ -54,6 +54,7 @@
   <div class="rail-footer">
     <button class="tunnel-btn" onclick="cleanupTunnels()" title="Kill chisel tunnels and Meterpreter sessions">Cleanup Tunnels</button>
     <button class="clear-btn" onclick="clearFindings()" title="Wipe all scan data — findings, session, coverage, logs, QA state">Clear All</button>
+    <p class="ai-disclaimer">⚠ AI-generated content may be incorrect. It should always be validated by a person.</p>
   </div>
 </aside>
 


### PR DESCRIPTION
Adds a persistent **"⚠ AI-generated content may be incorrect. It should always be validated by a person."** notice on the dashboard, under the Clear All button in the left rail footer.

Why on the dashboard rather than the printed tool output: the driving agent paraphrases the tool result when it relays the dashboard link in chat, so a printed warning gets dropped. A banner on the dashboard is seen by everyone reviewing the (AI-generated) findings, independent of how the agent phrases things — the correct home for the disclaimer.

- `dashboard/index.html` — disclaimer under Clear All; CSS cache-buster v=11→v=12.
- `dashboard/css/dashboard.css` — `.ai-disclaimer` style; hidden in the collapsed icon-rail.

Served live from disk, so it's already visible on refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)