### PR TITLE
training-data: snapshot findings.json into the engagement bundle on scan completion

### DIFF
--- a/core/session/lifecycle.py
+++ b/core/session/lifecycle.py
@@ -200,6 +200,21 @@ def stop_pentest_containers() -> None:
         pass
 
 
+def snapshot_training_bundle() -> None:
+    """When a scan reaches a terminal state, copy the final findings.json into the
+    engagement's durable training bundle (logs/smith-events/<id>/findings.json) so the
+    bundle is self-contained — events + raw artifacts + meta + the adjudicated findings.
+
+    Best-effort and never raises into the completion path. No-op when the event emitter is
+    disabled (no bundle to complete). Lazy import keeps core.session free of a top-level
+    dependency on mcp_server/."""
+    try:
+        from mcp_server.scan_engine.smith_events import snapshot_findings
+        snapshot_findings()
+    except Exception:
+        pass
+
+
 def complete(
     notes: str = "",
     stop_reason: str | None = None,
@@ -221,7 +236,9 @@ def complete(
         if stop_reason is not None:
             _sess._current["stop_reason"] = stop_reason
         _sess._flush()
-        # Scan ended (human complete or force-complete) → tear down the RCE containers.
+        # Scan ended (human complete or force-complete): snapshot the final findings into
+        # the durable training bundle (self-contained), then tear down the RCE containers.
+        snapshot_training_bundle()
         stop_pentest_containers()
     return _sess._current or {}
 

--- a/core/session/limits.py
+++ b/core/session/limits.py
@@ -160,9 +160,11 @@ def _stop(status: str, message: str) -> str:
         _sess._current["stop_reason"] = message
         _sess._current["finished"]    = datetime.now(timezone.utc).isoformat()
         _sess._flush()
-        # A budget/time/call limit ended the scan → tear down the RCE containers too.
+        # A budget/time/call limit ended the scan: snapshot the final findings into the
+        # durable training bundle, then tear down the RCE containers too.
         try:
-            from core.session.lifecycle import stop_pentest_containers
+            from core.session.lifecycle import snapshot_training_bundle, stop_pentest_containers
+            snapshot_training_bundle()
             stop_pentest_containers()
         except Exception:
             pass

--- a/docs/training-data.md
+++ b/docs/training-data.md
@@ -22,9 +22,14 @@ at `logs/smith-events/<engagement_id>.jsonl`:
 | **result** | what came back, plus a reference to the raw artifact the model actually saw |
 | **finding** / **coverage** | confirmed vulnerabilities and coverage-matrix transitions |
 
-Each bundle is **self-contained**: the raw artifacts referenced by the stream are retained
-next to it, so the data still points at real observations even after the scan's scratch files
-are cleared.
+Each bundle is **self-contained**. Everything the stream refers to is retained next to it in
+`logs/smith-events/<engagement_id>/`, so the data still points at real observations even after
+the scan's scratch files are cleared:
+
+- the **raw artifacts** the model actually saw (tool output), and
+- a **`meta.json`** provenance snapshot (target, model profile, timing), and
+- the scan's final **`findings.json`** — the adjudicated vulnerabilities those events led to,
+  copied in when the scan completes (before the next scan overwrites it).
 
 ---
 

--- a/installers/change-mcp-port.sh
+++ b/installers/change-mcp-port.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# change-mcp-port.sh
+# Update the local MCP SSE port when the default port is already in use.
+#
+# What this updates:
+# 1) launchd LaunchAgent plist: ~/Library/LaunchAgents/com.agent-smith.mcp-sse.plist
+# 2) Claude Code MCP registration (if claude CLI is installed)
+# 3) opencode MCP registration in ~/.config/opencode/opencode.json (if present)
+#
+# Usage:
+#   installers/change-mcp-port.sh <new_port>
+# Example:
+#   installers/change-mcp-port.sh 7789
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="com.agent-smith.mcp-sse"
+PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
+NEW_PORT="${1:-}"
+
+if [[ -z "$NEW_PORT" ]]; then
+    echo "Usage: $0 <new_port>"
+    exit 1
+fi
+
+if ! [[ "$NEW_PORT" =~ ^[0-9]+$ ]] || (( NEW_PORT < 1 || NEW_PORT > 65535 )); then
+    echo "Invalid port: $NEW_PORT (must be an integer from 1 to 65535)"
+    exit 1
+fi
+
+if [[ ! -f "$PLIST_PATH" ]]; then
+    echo "LaunchAgent plist not found: $PLIST_PATH"
+    echo "Install first, then run this script."
+    exit 1
+fi
+
+if lsof -n -iTCP:"$NEW_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    listeners="$(lsof -n -tiTCP:"$NEW_PORT" -sTCP:LISTEN | tr '\n' ' ')"
+    keep_going=false
+    for pid in $listeners; do
+        cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+        if [[ "$cmd" == *"mcp_server"* ]] || [[ "$cmd" == *"run-mcp-server.sh"* ]]; then
+            keep_going=true
+            break
+        fi
+    done
+
+    if [[ "$keep_going" != true ]]; then
+        echo "Port $NEW_PORT is already in use. Pick a different port."
+        lsof -n -iTCP:"$NEW_PORT" -sTCP:LISTEN || true
+        exit 1
+    fi
+fi
+
+extract_plist_port() {
+    local plist="$1"
+    awk '
+        /<string>--port<\/string>/ { want = 1; next }
+        want && match($0, /<string>[0-9]+<\/string>/) {
+            s = substr($0, RSTART, RLENGTH)
+            gsub(/<string>|<\/string>/, "", s)
+            print s
+            exit
+        }
+    ' "$plist"
+}
+
+rewrite_plist_port() {
+    local plist="$1"
+    local new_port="$2"
+    local tmp
+    tmp="$(mktemp)"
+
+    awk -v p="$new_port" '
+        {
+            if (want && match($0, /<string>[0-9]+<\/string>/)) {
+                $0 = "        <string>" p "</string>"
+                want = 0
+                changed = 1
+            }
+            if ($0 ~ /<string>--port<\/string>/) {
+                want = 1
+            }
+            print
+        }
+        END {
+            if (!changed) {
+                exit 2
+            }
+        }
+    ' "$plist" > "$tmp"
+
+    mv "$tmp" "$plist"
+}
+
+rewrite_installer_ports() {
+    local new_port="$1"
+    local old_port="$2"
+    local f
+    local files=(
+        "$REPO_DIR/installers/start-mcp-server.sh"
+        "$REPO_DIR/installers/install.sh"
+        "$REPO_DIR/installers/install_opencode.sh"
+        "$REPO_DIR/installers/install-launchd.sh"
+        "$REPO_DIR/installers/com.agent-smith.mcp-sse.plist"
+    )
+
+    for f in "${files[@]}"; do
+        [[ -f "$f" ]] || continue
+
+        NEW_PORT="$new_port" OLD_PORT="$old_port" perl -0pi -e '
+            my $new = $ENV{"NEW_PORT"};
+            my $old = $ENV{"OLD_PORT"};
+            s/\b7778\b/$new/g;
+            if (defined $old && $old ne q{} && $old ne $new) {
+                s/\b\Q$old\E\b/$new/g;
+            }
+        ' "$f"
+    done
+
+    echo "Updated installer scripts/templates to use port ${new_port}"
+}
+
+OLD_PORT="$(extract_plist_port "$PLIST_PATH" || true)"
+if [[ -z "$OLD_PORT" ]]; then
+    echo "Could not detect current MCP port from $PLIST_PATH"
+    exit 1
+fi
+
+reload_needed=true
+if [[ "$OLD_PORT" == "$NEW_PORT" ]]; then
+    echo "MCP port is already set to $NEW_PORT; verifying health and refreshing client configs"
+    reload_needed=false
+fi
+
+if [[ "$reload_needed" == true ]]; then
+    echo "Updating MCP port: $OLD_PORT -> $NEW_PORT"
+    rewrite_plist_port "$PLIST_PATH" "$NEW_PORT"
+
+    # Reload launchd job so the new port takes effect.
+    launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || launchctl unload "$PLIST_PATH" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH" 2>/dev/null || launchctl load "$PLIST_PATH"
+    launchctl enable "gui/$(id -u)/$LABEL" 2>/dev/null || true
+fi
+
+# Keep future installer runs aligned with the selected MCP port.
+rewrite_installer_ports "$NEW_PORT" "$OLD_PORT"
+
+is_mcp_up() {
+    local code
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:${NEW_PORT}/sse" || true)"
+    if [[ "$code" != "000" ]]; then
+        return 0
+    fi
+    lsof -n -iTCP:"$NEW_PORT" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+# Wait for MCP on new port.
+# Startup can take a bit (imports, image preflight), so allow up to 30s.
+for _ in $(seq 1 60); do
+    if is_mcp_up; then
+        break
+    fi
+    sleep 0.5
+done
+
+if is_mcp_up; then
+    echo "MCP SSE is up on http://127.0.0.1:${NEW_PORT}/sse"
+else
+    echo "MCP SSE did not come up on port ${NEW_PORT}."
+    echo "Check logs:"
+    echo "  ${REPO_DIR}/logs/mcp_sse.log"
+    echo "  ${REPO_DIR}/logs/mcp_crash.log"
+    exit 1
+fi
+
+# Update Claude MCP registration if CLI exists.
+if command -v claude >/dev/null 2>&1; then
+    claude mcp remove --scope user pentest-agent >/dev/null 2>&1 || true
+    claude mcp add --scope user --transport sse pentest-agent "http://127.0.0.1:${NEW_PORT}/sse" >/dev/null
+    echo "Updated Claude MCP registration to port ${NEW_PORT}"
+else
+    echo "claude CLI not found; skipped Claude MCP registration update"
+fi
+
+# Update opencode registration if config exists.
+if [[ -f "$OPENCODE_CONFIG" ]]; then
+    if command -v jq >/dev/null 2>&1; then
+        jq --arg url "http://127.0.0.1:${NEW_PORT}/sse" '
+            .mcp["pentest-agent"] = ((.mcp["pentest-agent"] // {}) + {
+                "type": "remote",
+                "url": $url,
+                "enabled": true,
+                "timeout": 9000000
+            })
+        ' "$OPENCODE_CONFIG" > "${OPENCODE_CONFIG}.tmp"
+        mv "${OPENCODE_CONFIG}.tmp" "$OPENCODE_CONFIG"
+        echo "Updated opencode MCP registration to port ${NEW_PORT}"
+    else
+        echo "jq not found; skipped opencode config update at $OPENCODE_CONFIG"
+    fi
+fi
+
+echo "Done. New MCP SSE URL: http://127.0.0.1:${NEW_PORT}/sse"

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -424,6 +424,7 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
     echo "    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest: torch)      ~12 min"
     echo ""
     _kali_build_args=()
+    _kali_install_ai=0
     _ask_kali_module() {  # $1=name  $2=build-arg  $3=default(Y|N)
         local _def="$3" _ans _hint
         [ "$_def" = "Y" ] && _hint="Y/n" || _hint="y/N"
@@ -432,8 +433,10 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
         _ans="${_ans:-$_def}"
         if [[ "$_ans" =~ ^[Yy]$ ]]; then
             _kali_build_args+=(--build-arg "$2=1")
+            [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=1
         else
             _kali_build_args+=(--build-arg "$2=0")
+            [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=0
         fi
     }
     _ask_kali_module web    INSTALL_WEB    Y
@@ -441,6 +444,10 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
     _ask_kali_module mobile INSTALL_MOBILE N
     _ask_kali_module cloud  INSTALL_CLOUD  N
     _ask_kali_module ai     INSTALL_AI     N
+    if [[ "$_kali_install_ai" == "1" ]]; then
+        _kali_build_args+=(--build-arg "REQUIRE_PYRIT=1")
+        echo "  AI module selected: requiring PyRIT in the build"
+    fi
     echo ""
     echo "  Building pentest-agent/kali-mcp (this may take a while)..."
     if docker build "${_kali_build_args[@]}" -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then

--- a/installers/install_codex.sh
+++ b/installers/install_codex.sh
@@ -323,6 +323,7 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
     echo "    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest: torch)      ~12 min"
     echo ""
     _kali_build_args=()
+    _kali_install_ai=0
     _ask_kali_module() {  # args: name  build-arg  default(Y|N)
         local _def="$3" _ans _hint
         [ "$_def" = "Y" ] && _hint="Y/n" || _hint="y/N"
@@ -331,8 +332,10 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
         _ans="${_ans:-$_def}"
         if [[ "$_ans" =~ ^[Yy]$ ]]; then
             _kali_build_args+=(--build-arg "$2=1")
+            [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=1
         else
             _kali_build_args+=(--build-arg "$2=0")
+            [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=0
         fi
     }
     _ask_kali_module web    INSTALL_WEB    Y
@@ -340,6 +343,10 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
     _ask_kali_module mobile INSTALL_MOBILE N
     _ask_kali_module cloud  INSTALL_CLOUD  N
     _ask_kali_module ai     INSTALL_AI     N
+    if [[ "$_kali_install_ai" == "1" ]]; then
+        _kali_build_args+=(--build-arg "REQUIRE_PYRIT=1")
+        echo "  AI module selected: requiring PyRIT in the build"
+    fi
     echo ""
     echo "  Building pentest-agent/kali-mcp (this may take a while)..."
     if docker build "${_kali_build_args[@]}" -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -598,6 +598,7 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
     echo "    ai               LLM red-team: PyRIT, Garak, promptfoo (heaviest: torch)      ~12 min"
     echo ""
     _kali_build_args=()
+    _kali_install_ai=0
     _ask_kali_module() {  # $1=name  $2=build-arg  $3=default(Y|N)
         local _def="$3" _ans _hint
         [ "$_def" = "Y" ] && _hint="Y/n" || _hint="y/N"
@@ -606,8 +607,10 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
         _ans="${_ans:-$_def}"
         if [[ "$_ans" =~ ^[Yy]$ ]]; then
             _kali_build_args+=(--build-arg "$2=1")
+            [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=1
         else
             _kali_build_args+=(--build-arg "$2=0")
+            [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=0
         fi
     }
     _ask_kali_module web    INSTALL_WEB    Y
@@ -615,6 +618,10 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
     _ask_kali_module mobile INSTALL_MOBILE N
     _ask_kali_module cloud  INSTALL_CLOUD  N
     _ask_kali_module ai     INSTALL_AI     N
+    if [[ "$_kali_install_ai" == "1" ]]; then
+        _kali_build_args+=(--build-arg "REQUIRE_PYRIT=1")
+        echo "  AI module selected: requiring PyRIT in the build"
+    fi
     echo ""
     echo "  Building pentest-agent/kali-mcp (this may take a while)..."
     if docker build "${_kali_build_args[@]}" -t pentest-agent/kali-mcp "$REPO_DIR/tools/kali/" 2>&1 | tail -5; then

--- a/mcp_server/scan_engine/smith_events.py
+++ b/mcp_server/scan_engine/smith_events.py
@@ -297,6 +297,32 @@ def _snapshot_meta(engagement: str) -> None:
         pass
 
 
+def snapshot_findings() -> None:
+    """Copy the scan's final findings.json into the engagement's DURABLE bundle
+    (logs/smith-events/<id>/findings.json) at the terminal transition — so the training
+    bundle is self-contained: events + raw artifacts + meta + the adjudicated findings that
+    those events led to. findings.json is wiped/overwritten by the next scan, so capture it
+    now. Derives the engagement id the same way the event stream does (session id), so the
+    findings land in the SAME bundle dir as the events/artifacts. Called from the
+    running→terminal transition (core/session), not per tool call. Fail-soft — never raises."""
+    if not _enabled():
+        return
+    try:
+        engagement = _engagement_id()
+        if not engagement:
+            return
+        from core import findings as _findings
+        src = _findings.FINDINGS_FILE
+        if not src.exists():
+            return
+        dst_dir = _EVENTS_DIR / engagement
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        import shutil
+        shutil.copy2(src, dst_dir / "findings.json")
+    except Exception:
+        pass
+
+
 def emit_tool_call(tool: str, ctx: dict, result: Any, artifact_id: str = "") -> None:
     """Emit one ``action`` event + the ``result`` it caused, linked to the current ``decision`` (if the
     agent recorded one), and COPY the tool's raw artifact into the engagement's durable bundle so the

--- a/tests/test_container_teardown.py
+++ b/tests/test_container_teardown.py
@@ -11,7 +11,12 @@ from core.session import limits as lim
 
 
 def _running(monkeypatch):
-    """Install a running session with the flush/reconcile side-effects stubbed."""
+    """Install a running session with the flush/reconcile side-effects stubbed.
+
+    Disables the smith-event emitter so the terminal transition's training-bundle
+    snapshot doesn't write real files into logs/smith-events/ during these
+    container-teardown tests (the snapshot itself is covered in test_smith_events.py)."""
+    monkeypatch.setenv("SMITH_EVENTS_DISABLED", "1")
     monkeypatch.setattr(cs, "_current", {"id": "s", "status": "running",
                                          "limits": {"max_cost_usd": 1, "max_time_minutes": 1, "max_tool_calls": 1}})
     monkeypatch.setattr(cs, "_flush", lambda: None)
@@ -84,3 +89,25 @@ def test_fail_soft_when_docker_errors(monkeypatch):
                         lambda *a, **k: (_ for _ in ()).throw(OSError("docker missing")))
     lc.complete(notes="done")                          # must NOT raise
     assert cs._current["status"] == "complete"         # completion still succeeded
+
+
+def test_complete_fail_soft_when_bundle_snapshot_errors(monkeypatch):
+    # The training-bundle snapshot must never break completion — a raising
+    # snapshot_findings is swallowed and the scan still reaches 'complete'.
+    _running(monkeypatch)
+    monkeypatch.setenv("SMITH_KEEP_CONTAINERS", "1")   # isolate: no docker in this test
+    import mcp_server.scan_engine.smith_events as se
+    monkeypatch.setattr(se, "snapshot_findings",
+                        lambda: (_ for _ in ()).throw(RuntimeError("bundle boom")))
+    lc.complete(notes="done")                          # must NOT raise
+    assert cs._current["status"] == "complete"
+
+
+def test_limit_reached_fail_soft_when_bundle_snapshot_errors(monkeypatch):
+    # Same fail-soft guarantee on the budget/time/call-limit terminal path.
+    _running(monkeypatch)
+    monkeypatch.setenv("SMITH_KEEP_CONTAINERS", "1")
+    monkeypatch.setattr(lc, "snapshot_training_bundle",
+                        lambda: (_ for _ in ()).throw(RuntimeError("bundle boom")))
+    lim._stop("limit_reached", "TIME LIMIT hit")       # must NOT raise
+    assert cs._current["status"] == "limit_reached"

--- a/tests/test_smith_events.py
+++ b/tests/test_smith_events.py
@@ -219,3 +219,41 @@ def test_emit_tool_call_fail_soft_when_artifact_missing(emit_env, monkeypatch, t
 def test_emit_tool_call_no_artifact_id_omits_field(emit_env):
     se.emit_tool_call("nmap", {"target": "h"}, FakeResult())        # no artifact_id
     assert "artifact_id" not in _events(emit_env)[1]["result"]
+
+
+def test_snapshot_findings_copies_into_bundle(emit_env, monkeypatch, tmp_path):
+    import core.findings as cf
+    src = tmp_path / "findings.json"
+    src.write_text('{"findings": [{"id": "F-1", "title": "SQLi", "severity": "critical"}]}')
+    monkeypatch.setattr(cf, "FINDINGS_FILE", src)
+    se.snapshot_findings()
+    dst = emit_env / "eng-test" / "findings.json"                    # same bundle dir as events/artifacts
+    assert dst.exists()
+    assert json.loads(dst.read_text())["findings"][0]["id"] == "F-1"
+
+
+def test_snapshot_findings_disabled_via_env_noop(emit_env, monkeypatch, tmp_path):
+    import core.findings as cf
+    src = tmp_path / "findings.json"; src.write_text("{}")
+    monkeypatch.setattr(cf, "FINDINGS_FILE", src)
+    monkeypatch.setenv("SMITH_EVENTS_DISABLED", "1")                 # no bundle to complete
+    se.snapshot_findings()
+    assert not (emit_env / "eng-test" / "findings.json").exists()
+
+
+def test_snapshot_findings_no_source_is_fail_soft(emit_env, monkeypatch, tmp_path):
+    import core.findings as cf
+    monkeypatch.setattr(cf, "FINDINGS_FILE", tmp_path / "nope" / "findings.json")
+    se.snapshot_findings()                                           # findings.json absent -> must not raise
+    assert not (emit_env / "eng-test" / "findings.json").exists()
+
+
+def test_snapshot_findings_no_session_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(se, "_EVENTS_DIR", tmp_path)
+    import core.session as cs
+    monkeypatch.setattr(cs, "get", lambda: None)                    # no engagement id
+    import core.findings as cf
+    src = tmp_path / "findings.json"; src.write_text("{}")
+    monkeypatch.setattr(cf, "FINDINGS_FILE", src)
+    se.snapshot_findings()
+    assert not list(tmp_path.glob("*/findings.json"))               # nothing written into a bundle

--- a/tests/test_smith_events.py
+++ b/tests/test_smith_events.py
@@ -257,3 +257,14 @@ def test_snapshot_findings_no_session_noop(tmp_path, monkeypatch):
     monkeypatch.setattr(cf, "FINDINGS_FILE", src)
     se.snapshot_findings()
     assert not list(tmp_path.glob("*/findings.json"))               # nothing written into a bundle
+
+
+def test_snapshot_findings_fail_soft_on_copy_error(emit_env, monkeypatch, tmp_path):
+    import core.findings as cf
+    src = tmp_path / "findings.json"; src.write_text('{"findings": []}')
+    monkeypatch.setattr(cf, "FINDINGS_FILE", src)
+    import shutil
+    monkeypatch.setattr(shutil, "copy2",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")))
+    se.snapshot_findings()                                          # copy error swallowed, must not raise
+    assert not (emit_env / "eng-test" / "findings.json").exists()   # nothing left behind on failure


### PR DESCRIPTION
The per-engagement training bundle at `logs/smith-events/<id>/` already collects the event stream, the raw artifacts the model saw, and a `meta.json` provenance snapshot — but **not** the scan's final `findings.json`, which is wiped/overwritten by the next scan. This copies it in at the running→terminal transition so each bundle is fully self-contained (events → the outcomes they led to).

## Training-data bundle (primary)
- **`smith_events.snapshot_findings()`** — copies `findings.json` → `logs/smith-events/<id>/findings.json`. Derives the engagement id the same way the event stream does (session id), so it lands in the **same** bundle dir. Gated on the emitter being enabled (`SMITH_EVENTS_DISABLED` opts out). Fail-soft.
- **`lifecycle.snapshot_training_bundle()`** — terminal-transition hook mirroring `stop_pentest_containers` (lazy import; never raises into completion). Wired into `complete()` (human / force-complete) and `limits._stop()` (budget / time / call limit).
- **Tests** — copy-into-bundle, disabled-env no-op, missing-source fail-soft, no-session no-op. Emitter suite 23 passed; session/lifecycle/limits 360 passed. Verified end-to-end (real `complete()` copies `findings.json` byte-identical).
- **docs/training-data.md** — bundle contents now enumerate artifacts + `meta.json` + `findings.json`.

## Installers (folded in at maintainer's request)
- `install.sh` / `install_codex.sh` / `install_opencode.sh`: when the AI kali module is selected, pass `--build-arg REQUIRE_PYRIT=1` so the build fails loudly if PyRIT doesn't land (no silently-incomplete AI image). Exec bit (755) restored.
- `change-mcp-port.sh` (new): repoint the MCP SSE port across the launchd plist, the Claude Code MCP registration, and `opencode.json` in one command, for when the default **7778** is in use. Canonical default stays 7778 — no port bumped in the installers.

> Stacked on #167 (dashboard disclaimer) so the live dashboard keeps its banner — that commit rides along until #167 merges, then this diff reduces to the bundle + installer changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)