### PR TITLE
update install.sh

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -438,6 +438,9 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
             _kali_build_args+=(--build-arg "$2=0")
             [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=0
         fi
+        # The trailing [[ ]] tests above return 1 for every non-AI module. Without
+        # this, `set -e` kills the installer on the first module prompt.
+        return 0
     }
     _ask_kali_module web    INSTALL_WEB    Y
     _ask_kali_module infra  INSTALL_INFRA  Y

--- a/installers/install_codex.sh
+++ b/installers/install_codex.sh
@@ -337,6 +337,9 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
             _kali_build_args+=(--build-arg "$2=0")
             [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=0
         fi
+        # The trailing [[ ]] tests above return 1 for every non-AI module. Without
+        # this, `set -e` kills the installer on the first module prompt.
+        return 0
     }
     _ask_kali_module web    INSTALL_WEB    Y
     _ask_kali_module infra  INSTALL_INFRA  Y

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -612,6 +612,9 @@ if [[ "${_kali_answer:-Y}" =~ ^[Yy]$ ]]; then
             _kali_build_args+=(--build-arg "$2=0")
             [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=0
         fi
+        # The trailing [[ ]] tests above return 1 for every non-AI module. Without
+        # this, `set -e` kills the installer on the first module prompt.
+        return 0
     }
     _ask_kali_module web    INSTALL_WEB    Y
     _ask_kali_module infra  INSTALL_INFRA  Y


### PR DESCRIPTION
fix(installers): stop set -e from aborting install.sh at the first Kali module prompt

Answering the "Include web module?" prompt terminated the installer with exit 1 — no error message, just back to the shell — leaving the Kali image unbuilt and every step after it (Metasploit build, MobSF pull, final summary) unexecuted.

Both branches of _ask_kali_module end with a bare conditional:

    [[ "$2" == "INSTALL_AI" ]] && _kali_install_ai=1

For web, infra, mobile and cloud that test is false, so it is the function's last command and the function returns 1. install.sh runs under `set -euo pipefail` and each `_ask_kali_module <name> ...` call is a plain simple command, so the non-zero return aborted the script. Only the `ai` prompt — the one case where the test is true — would have survived, and it is never reached.

Add an explicit `return 0` so the function's status reflects "the prompt was answered" rather than "the module happens not to be AI".