### PR TITLE
fix(installers): unbreak the opencode install on Linux — gate launchd, add systemd

### DIFF
--- a/installers/agent-smith-mcp.service
+++ b/installers/agent-smith-mcp.service
@@ -1,0 +1,33 @@
+# systemd USER unit — the Linux counterpart of com.agent-smith.mcp-sse.plist.
+# Installed to ~/.config/systemd/user/agent-smith-mcp.service by the installers,
+# which sed-replace the literal REPO_DIR placeholder with the checkout path.
+#
+# Mapping from the launchd plist:
+#   RunAtLoad=true      -> WantedBy=default.target (+ `systemctl --user enable`)
+#   KeepAlive=true      -> Restart=always
+#   ThrottleInterval=10 -> RestartSec=10
+#   Standard{Out,Error}Path -> StandardOutput/StandardError=append:
+#
+# Like the plist, this runs run-mcp-server.sh in the FOREGROUND (it exec's
+# `python -m mcp_server`), so systemd supervises the real server process rather
+# than a wrapper that backgrounds via nohup and exits.
+[Unit]
+Description=agent-smith pentest MCP server (SSE on 127.0.0.1:7778)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=REPO_DIR
+# systemd user units start from a minimal PATH. Poetry commonly lives in
+# ~/.local/bin (pipx / the official installer), and run-mcp-server.sh resolves
+# the venv through it — keep both that and the standard dirs visible.
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
+ExecStart=/bin/bash REPO_DIR/installers/run-mcp-server.sh --transport sse --host 127.0.0.1 --port 7778
+Restart=always
+RestartSec=10
+StandardOutput=append:REPO_DIR/logs/mcp_sse.log
+StandardError=append:REPO_DIR/logs/mcp_sse.log
+
+[Install]
+WantedBy=default.target

--- a/installers/install_opencode.sh
+++ b/installers/install_opencode.sh
@@ -18,6 +18,20 @@ OPENCODE_SKILLS_DIR="$OPENCODE_CONFIG_DIR/skills"
 # prerequisite checks aligned with the MCP launcher runtime.
 export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin:/snap/bin:/Applications/Docker.app/Contents/Resources/bin"
 
+# ── Platform ─────────────────────────────────────────────────────────────────
+# The MCP server is supervised by launchd on macOS and by a systemd *user* unit
+# on Linux. EVERY launchctl / ~/Library/LaunchAgents touch below is gated on
+# this: on Linux that directory does not exist, so the ungated plist write
+# (`sed ... > "$PLIST_DST"`) failed the redirect and `set -euo pipefail` aborted
+# the whole install with a bare "No such file or directory".
+case "$(uname -s)" in
+    Darwin) OS_KIND="macos" ;;
+    Linux)  OS_KIND="linux" ;;
+    *)      OS_KIND="other" ;;
+esac
+SYSTEMD_UNIT="agent-smith-mcp.service"
+SYSTEMD_UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+
 # ── Colours ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 ok()   { echo -e "${GREEN}✓${NC} $*"; }
@@ -30,7 +44,12 @@ echo "  ===================================="
 echo ""
 
 # ── Prerequisites ─────────────────────────────────────────────────────────────
-command -v docker   >/dev/null 2>&1 || die "docker not found — install Docker Desktop first."
+if ! command -v docker >/dev/null 2>&1; then
+    if [[ "$OS_KIND" == "linux" ]]; then
+        die "docker not found — install Docker Engine: https://docs.docker.com/engine/install/ (then: sudo usermod -aG docker \"$USER\" && newgrp docker)"
+    fi
+    die "docker not found — install Docker Desktop first."
+fi
 command -v poetry   >/dev/null 2>&1 || die "poetry not found — install with: curl -sSL https://install.python-poetry.org | python3 -"
 command -v opencode >/dev/null 2>&1 || command -v opencode-cli >/dev/null 2>&1 || die "opencode not found — install from: https://opencode.ai"
 command -v node    >/dev/null 2>&1 || warn "node not found — Mermaid diagrams will render client-side (install Node.js v18+ for server-side pre-rendering)"
@@ -61,7 +80,7 @@ ok "Poetry dependencies installed"
 # SIGKILLing each other. Unload first; we reload the rewritten plist after the
 # MCP is up.
 PLIST_DST="$HOME/Library/LaunchAgents/com.agent-smith.mcp-sse.plist"
-if [[ -f "$PLIST_DST" ]]; then
+if [[ "$OS_KIND" == "macos" && -f "$PLIST_DST" ]]; then
     _OLD_REPO="$(awk '/WorkingDirectory/{getline; gsub(/^[[:space:]]*<string>|<\/string>[[:space:]]*$/, ""); print; exit}' "$PLIST_DST")"
     if [[ -n "$_OLD_REPO" && "$_OLD_REPO" != "$REPO_DIR" ]]; then
         warn "Existing launchd plist points at: $_OLD_REPO"
@@ -271,16 +290,72 @@ ok "MCP server registered in $OPENCODE_CONFIG (transport: remote/SSE)"
 ok "CLAUDE.md added to global instructions"
 ok "Context-window safety set (compaction.reserved > model output; external dirs allowed)"
 
-# ── Install launchd plist for auto-start on login ────────────────────────────
+# ── Install the auto-start supervisor (launchd on macOS, systemd on Linux) ───
 # PLIST_DST was set earlier (pre-disarm step); the unload is a no-op now but
 # keeps this section idempotent if someone runs it standalone.
 echo ""
-echo "Installing launchd plist..."
-PLIST_SRC="$REPO_DIR/installers/com.agent-smith.mcp-sse.plist"
-sed "s|REPO_DIR|$REPO_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
-launchctl unload "$PLIST_DST" 2>/dev/null || true
-launchctl load "$PLIST_DST"
-ok "launchd plist installed — MCP server auto-starts on login and restarts on crash"
+if [[ "$OS_KIND" == "macos" ]]; then
+    echo "Installing launchd plist..."
+    PLIST_SRC="$REPO_DIR/installers/com.agent-smith.mcp-sse.plist"
+    mkdir -p "$(dirname "$PLIST_DST")"
+    sed "s|REPO_DIR|$REPO_DIR|g" "$PLIST_SRC" > "$PLIST_DST"
+    launchctl unload "$PLIST_DST" 2>/dev/null || true
+    launchctl load "$PLIST_DST"
+    ok "launchd plist installed — MCP server auto-starts on login and restarts on crash"
+elif [[ "$OS_KIND" == "linux" ]]; then
+    echo "Installing systemd user unit..."
+    # `systemctl --user` needs a live user D-Bus session. It is absent in some
+    # containers, bare `ssh host cmd` invocations and minimal WSL distros — in
+    # that case fall back to the self-managed nohup instance that
+    # start-mcp-server.sh already launched above, and say so.
+    if command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+        mkdir -p "$SYSTEMD_UNIT_DIR" "$REPO_DIR/logs"
+        sed "s|REPO_DIR|$REPO_DIR|g" \
+            "$REPO_DIR/installers/agent-smith-mcp.service" > "$SYSTEMD_UNIT_DIR/$SYSTEMD_UNIT"
+        systemctl --user daemon-reload
+
+        # start-mcp-server.sh started a self-managed nohup instance a moment ago
+        # (no supervisor was loaded then). It still holds port 7778, so systemd's
+        # instance would lose the bind, exit 1 and be respawned every 10 s — the
+        # dual-supervisor crash-loop. Hand the port over before enabling.
+        _PID_FILE="$REPO_DIR/logs/mcp_sse.pid"
+        if [[ -f "$_PID_FILE" ]] && kill -0 "$(cat "$_PID_FILE")" 2>/dev/null; then
+            kill "$(cat "$_PID_FILE")" 2>/dev/null || true
+            sleep 1
+        fi
+        rm -f "$_PID_FILE"
+
+        systemctl --user enable --now "$SYSTEMD_UNIT"
+        # Survive logout / start at boot on a headless box. Needs polkit or root;
+        # best-effort, and the unit still works for the current session without it.
+        loginctl enable-linger "$USER" >/dev/null 2>&1 || \
+            warn "loginctl enable-linger failed — MCP starts on login, not at boot (fix: sudo loginctl enable-linger $USER)"
+
+        # Readiness poll (curl is not guaranteed on a minimal server image).
+        if command -v curl >/dev/null 2>&1; then
+            for _i in $(seq 1 20); do
+                curl -sf --max-time 1 http://127.0.0.1:7778/sse >/dev/null 2>&1 && break
+                sleep 0.5
+            done
+        else
+            sleep 3
+        fi
+        if systemctl --user is-active --quiet "$SYSTEMD_UNIT"; then
+            ok "systemd user unit installed ($SYSTEMD_UNIT) — auto-starts on login and restarts on crash"
+        else
+            warn "systemd unit installed but not active — check: systemctl --user status $SYSTEMD_UNIT"
+            warn "and the server log: $REPO_DIR/logs/mcp_sse.log"
+        fi
+    else
+        warn "No systemd user session available — skipping auto-start unit."
+        warn "The MCP server is running as a self-managed process; restart it with:"
+        warn "  $REPO_DIR/installers/start-mcp-server.sh restart"
+    fi
+else
+    warn "Unsupported platform '$(uname -s)' for auto-start supervision — skipping."
+    warn "The MCP server is running as a self-managed process; restart it with:"
+    warn "  $REPO_DIR/installers/start-mcp-server.sh restart"
+fi
 
 # ── Ask whether to overwrite existing skill files ────────────────────────────
 echo ""

--- a/installers/start-mcp-server.sh
+++ b/installers/start-mcp-server.sh
@@ -10,8 +10,12 @@
 # in use" crash-loop). The old `start` even `kill -9`'d the port first, which
 # actively killed launchd's instance and kicked off the fight.
 #
-# Only when launchd is NOT managing the server (a plain dev checkout with no
-# job loaded) does this fall back to a self-managed nohup process.
+# On Linux the same role is played by the systemd USER unit agent-smith-mcp
+# (Restart=always, RestartSec=10) and the same rule applies: delegate to
+# systemctl --user, never start a competing nohup instance.
+#
+# Only when NEITHER supervisor is managing the server (a plain dev checkout with
+# no job/unit loaded) does this fall back to a self-managed nohup process.
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PID_FILE="$REPO_DIR/logs/mcp_sse.pid"
 LOG_FILE="$REPO_DIR/logs/mcp_sse.log"
@@ -19,22 +23,77 @@ PORT=7778
 LAUNCHD_LABEL="com.agent-smith.mcp-sse"
 LAUNCHD_TARGET="gui/$(id -u)/$LAUNCHD_LABEL"
 
-_launchd_loaded() { launchctl list "$LAUNCHD_LABEL" >/dev/null 2>&1; }
+_launchd_loaded() {
+    command -v launchctl >/dev/null 2>&1 && launchctl list "$LAUNCHD_LABEL" >/dev/null 2>&1
+}
 _launchd_pid() { launchctl list "$LAUNCHD_LABEL" 2>/dev/null | sed -n 's/.*"PID" = \([0-9][0-9]*\).*/\1/p'; }
+
+SYSTEMD_UNIT="agent-smith-mcp.service"
+
+# `systemctl --user` needs a live user D-Bus session; absent in many containers,
+# `ssh host cmd` invocations and minimal WSL distros. `systemctl --user cat` is
+# the existence check — list-unit-files exits 0 even when it matches nothing.
+_systemd_loaded() {
+    command -v systemctl >/dev/null 2>&1 \
+        && systemctl --user show-environment >/dev/null 2>&1 \
+        && systemctl --user cat "$SYSTEMD_UNIT" >/dev/null 2>&1
+}
+_systemd_pid() {
+    local pid
+    pid="$(systemctl --user show -p MainPID --value "$SYSTEMD_UNIT" 2>/dev/null)"
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] && echo "$pid"
+}
 
 _is_running() {
     [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
 }
 
-# ── launchd-managed path (production default) — thin launchctl wrapper ──────
-if _launchd_loaded; then
-    # A stale self-managed nohup instance (from an older script) would still
-    # hold the port and crash-loop launchd. Clear it so launchd can bind.
+_clear_self_managed() {
+    # A stale self-managed nohup instance would still hold port 7778 and make the
+    # supervised instance crash-loop on "address already in use". Clear it.
     if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
-        echo "Clearing stale self-managed instance (PID $(cat "$PID_FILE")) so launchd owns the port"
+        echo "Clearing stale self-managed instance (PID $(cat "$PID_FILE")) so the supervisor owns the port"
         kill "$(cat "$PID_FILE")" 2>/dev/null || true
         rm -f "$PID_FILE"
     fi
+}
+
+# ── systemd --user path (Linux production default) ──────────────────────────
+if _systemd_loaded; then
+    _clear_self_managed
+    case "${1:-start}" in
+        start)
+            systemctl --user start "$SYSTEMD_UNIT"
+            echo "✓ MCP SSE server started via systemd ($SYSTEMD_UNIT)"
+            ;;
+        restart)
+            systemctl --user restart "$SYSTEMD_UNIT"
+            echo "✓ MCP SSE server restarted via systemd ($SYSTEMD_UNIT)"
+            ;;
+        stop)
+            # Unlike launchd KeepAlive, an explicit systemd stop is honoured —
+            # Restart=always does not fight it. Re-enable with `start`.
+            systemctl --user stop "$SYSTEMD_UNIT"
+            echo "✓ MCP SSE server stopped (systemd will not respawn it until 'start')"
+            ;;
+        status)
+            pid="$(_systemd_pid)"
+            if [[ -n "$pid" ]]; then
+                echo "running under systemd (PID $pid)"
+            else
+                echo "systemd-managed but not currently running — systemctl --user status $SYSTEMD_UNIT; check $LOG_FILE"
+            fi
+            ;;
+        *)
+            echo "Usage: $0 [start|stop|restart|status]"; exit 1
+            ;;
+    esac
+    exit 0
+fi
+
+# ── launchd-managed path (production default) — thin launchctl wrapper ──────
+if _launchd_loaded; then
+    _clear_self_managed
     case "${1:-start}" in
         start)
             launchctl kickstart "$LAUNCHD_TARGET" >/dev/null 2>&1 || true
@@ -66,15 +125,24 @@ if _launchd_loaded; then
     exit 0
 fi
 
-# ── self-managed fallback (no launchd job loaded — dev checkout only) ───────
+# ── self-managed fallback (no launchd job / systemd unit loaded — dev only) ─
 case "${1:-start}" in
     start)
         if _is_running; then
             echo "MCP SSE server already running (PID $(cat "$PID_FILE"))"
             exit 0
         fi
-        # Safe here: with no launchd job loaded there is no supervisor to fight.
-        lsof -ti tcp:"$PORT" | xargs kill -9 2>/dev/null || true
+        # Safe here: with no supervisor loaded there is nothing to fight.
+        # lsof is absent on minimal Linux images — fall back to ss, then fuser.
+        if command -v lsof >/dev/null 2>&1; then
+            lsof -ti tcp:"$PORT" | xargs -r kill -9 2>/dev/null || true
+        elif command -v ss >/dev/null 2>&1; then
+            ss -ltnpH "sport = :$PORT" 2>/dev/null \
+                | grep -oE 'pid=[0-9]+' | cut -d= -f2 | sort -u \
+                | xargs -r kill -9 2>/dev/null || true
+        elif command -v fuser >/dev/null 2>&1; then
+            fuser -k -n tcp "$PORT" >/dev/null 2>&1 || true
+        fi
         mkdir -p "$REPO_DIR/logs"
         RUNNER="$REPO_DIR/installers/run-mcp-server.sh"
         if [[ ! -x "$RUNNER" ]]; then


### PR DESCRIPTION
## Problem

`installers/install_opencode.sh` writes the launchd plist to `~/Library/LaunchAgents/` unconditionally. That directory does not exist on Linux, so the redirect fails:

```
installers/install_opencode.sh: line 279: /home/user/Library/LaunchAgents/com.agent-smith.mcp-sse.plist: No such file or directory
```

With `set -euo pipefail` at the top of the file, that aborts the entire install. (`launchctl load`, two lines later, would have exited 127 anyway.) The pre-disarm block near the top of the script has the same problem.

The block sits **after** MCP registration but **before** skills, the compaction-recovery plugin, `.env` setup and the Docker image builds — so a Linux install dies half-finished, with no message explaining why.

Reproduced on Linux (aarch64 and x86_64). `install_codex.sh` is unaffected — it uses stdio and never touches launchd.

## Fix

Gate every `launchctl` / `~/Library/LaunchAgents` touch on the platform, and give Linux the real equivalent of the launchd supervisor rather than nothing at all:

- **New `installers/agent-smith-mcp.service`** — systemd *user* unit mirroring the plist semantics: `KeepAlive` → `Restart=always`, `ThrottleInterval=10` → `RestartSec=10`, same log file, and the same foreground `run-mcp-server.sh` invocation so systemd supervises the actual server rather than a wrapper that backgrounds and exits. Passes `systemd-analyze --user verify`.
- Installed and `enable --now` on Linux, with best-effort `loginctl enable-linger` so a headless box starts it at boot. Falls back to the self-managed nohup instance — with an explicit message — when there is no user D-Bus session (`ssh host cmd`, containers, minimal WSL).
- **Port handover before enabling.** `start-mcp-server.sh restart` runs earlier in the installer and leaves a nohup instance holding 7778. Without killing it first, systemd's instance loses the bind, exits 1, and is respawned every 10s — the same dual-supervisor crash-loop `start-mcp-server.sh` already documents for launchd.

`start-mcp-server.sh` gets the matching systemd branch, so `start|stop|restart|status` delegate to `systemctl --user` instead of spawning a competitor. Two portability fixes alongside it: `lsof` is absent on minimal server images (falls back to `ss`, then `fuser`), and `launchctl` is probed with `command -v` first.

Also included:

- `mkdir -p` before the plist write — fixes the same abort on a fresh macOS account with no `~/Library/LaunchAgents`.
- The docker prerequisite now points Linux users at Docker Engine and the `docker` group instead of Docker Desktop.

## Verification

All three supervisor paths exercised under `set -euo pipefail` with stubbed `systemctl`/`launchctl`:

| case | result |
|---|---|
| Linux + systemd user session | exit 0, unit written to `~/.config/systemd/user/`, enabled |
| Linux, no user D-Bus session | exit 0, falls back to nohup with a clear warning |
| macOS | exit 0, plist written and loaded (unchanged behaviour) |

The unpatched script still exits 1 on Linux under the same harness.

Also checked the arm64 angle, since this was hit on an NVIDIA Spark: both pinned base digests (`kalilinux/kali-rolling`, `metasploitframework/metasploit-framework`) are multi-arch manifest lists including `linux/arm64`, and `tools/kali/Dockerfile` already branches on `uname -m` — so the image builds were never the blocker.

## Notes for review

- **The `skills` submodule is intentionally not part of this PR.** The working tree it was authored from had `skills` checked out 17 merges behind `main`; including it would have been a silent rewind.
- **`installers/install.sh` still has the identical bug** at lines 95–99 (Claude Code installer). Left out to keep this PR scoped to opencode as requested — happy to fold the same gate in here, or land it separately. `install.ps1` likely warrants its own pass too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
